### PR TITLE
Suggestion: Make middleware pipeline async with promises

### DIFF
--- a/src/App.spec.ts
+++ b/src/App.spec.ts
@@ -394,7 +394,7 @@ describe('App', () => {
 
           // Act
           const app = new App({ receiver: fakeReceiver, authorize: sinon.fake.resolves(dummyAuthorizationResult) });
-          app.use((args) => {
+          app.use(async (args) => {
             // By definition, these events should all produce a say function, so we cast args.say into a SayFn
             const say = (args as any).say as SayFn;
             say(dummyMessage);
@@ -425,7 +425,7 @@ describe('App', () => {
 
           // Act
           const app = new App({ receiver: fakeReceiver, authorize: sinon.fake.resolves(dummyAuthorizationResult) });
-          app.use((args) => {
+          app.use(async (args) => {
             // By definition, these events should all produce a say function, so we cast args.say into a SayFn
             const say = (args as any).say as SayFn;
             say(dummyMessage);
@@ -506,7 +506,7 @@ describe('App', () => {
 
           // Act
           const app = new App({ receiver: fakeReceiver, authorize: sinon.fake.resolves(dummyAuthorizationResult) });
-          app.use((args) => {
+          app.use(async (args) => {
             assert.isUndefined((args as any).say);
             // If the above assertion fails, then it would throw an AssertionError and the following line will not be
             // called
@@ -530,7 +530,7 @@ describe('App', () => {
 
           // Act
           const app = new App({ receiver: fakeReceiver, authorize: sinon.fake.resolves(dummyAuthorizationResult) });
-          app.use((args) => {
+          app.use(async (args) => {
             // By definition, these events should all produce a say function, so we cast args.say into a SayFn
             const say = (args as any).say as SayFn;
             say(dummyMessage);
@@ -653,7 +653,7 @@ function createDummyReceiverEvent(): ReceiverEvent {
 }
 
 // Utility functions
-const noop = () => { }; // tslint:disable-line:no-empty
+const noop = async () => { }; // tslint:disable-line:no-empty
 const noopMiddleware = ({ next }: { next: NextMiddleware; }) => { next(); };
 const noopAuthorize = (() => Promise.resolve({}));
 

--- a/src/ExpressReceiver.ts
+++ b/src/ExpressReceiver.ts
@@ -86,7 +86,7 @@ export default class ExpressReceiver extends EventEmitter implements Receiver {
     };
 
     if (req.body && req.body.response_url) {
-      event.respond = (response): void => {
+      event.respond = async (response): Promise<void> => {
         axios.post(req.body.response_url, response)
           .catch((e) => {
             this.emit('error', e);

--- a/src/conversation-store.ts
+++ b/src/conversation-store.ts
@@ -55,13 +55,13 @@ export function conversationContext<ConversationState = any>(
   store: ConversationStore<ConversationState>,
   logger: Logger,
 ): Middleware<AnyMiddlewareArgs> {
-  return (args) => {
+  return async (args) => {
     const { body, context, next } = args;
     const { conversationId } = getTypeAndConversation(body as any);
     if (conversationId !== undefined) {
       // TODO: expiresAt is not passed through to store.set
       context.updateConversation = (conversation: ConversationState) => store.set(conversationId, conversation);
-      store.get(conversationId)
+      await store.get(conversationId)
         .then((conversationState) => {
           context.conversation = conversationState;
           logger.debug(`Conversation context loaded for ID ${conversationId}`);
@@ -72,7 +72,7 @@ export function conversationContext<ConversationState = any>(
         .then(next);
     } else {
       logger.debug('No conversation ID for incoming event');
-      next();
+      await next();
     }
   };
 }

--- a/src/middleware/builtin.ts
+++ b/src/middleware/builtin.ts
@@ -21,53 +21,53 @@ import { ErrorCode, errorWithCode } from '../errors';
 /**
  * Middleware that filters out any event that isn't an action
  */
-export const onlyActions: Middleware<AnyMiddlewareArgs & { action?: SlackAction }> = ({ action, next }) => {
+export const onlyActions: Middleware<AnyMiddlewareArgs & { action?: SlackAction }> = async ({ action, next }) => {
   // Filter out any non-actions
   if (action === undefined) {
     return;
   }
 
   // It matches so we should continue down this middleware listener chain
-  next();
+  await next();
 };
 
 /**
  * Middleware that filters out any event that isn't a command
  */
-export const onlyCommands: Middleware<AnyMiddlewareArgs & { command?: SlashCommand }> = ({ command, next }) => {
+export const onlyCommands: Middleware<AnyMiddlewareArgs & { command?: SlashCommand }> = async ({ command, next }) => {
   // Filter out any non-commands
   if (command === undefined) {
     return;
   }
 
   // It matches so we should continue down this middleware listener chain
-  next();
+  await next();
 };
 
 /**
  * Middleware that filters out any event that isn't an options
  */
-export const onlyOptions: Middleware<AnyMiddlewareArgs & { options?: OptionsRequest }> = ({ options, next }) => {
+export const onlyOptions: Middleware<AnyMiddlewareArgs & { options?: OptionsRequest }> = async ({ options, next }) => {
   // Filter out any non-options requests
   if (options === undefined) {
     return;
   }
 
   // It matches so we should continue down this middleware listener chain
-  next();
+  await next();
 };
 
 /**
  * Middleware that filters out any event that isn't an event
  */
-export const onlyEvents: Middleware<AnyMiddlewareArgs & { event?: SlackEvent }> = ({ event, next }) => {
+export const onlyEvents: Middleware<AnyMiddlewareArgs & { event?: SlackEvent }> = async ({ event, next }) => {
   // Filter out any non-events
   if (event === undefined) {
     return;
   }
 
   // It matches so we should continue down this middleware listener chain
-  next();
+  await next();
 };
 
 /**
@@ -76,7 +76,7 @@ export const onlyEvents: Middleware<AnyMiddlewareArgs & { event?: SlackEvent }> 
 export function matchConstraints(
     constraints: ActionConstraints,
   ): Middleware<SlackActionMiddlewareArgs | SlackOptionsMiddlewareArgs> {
-  return ({ payload, body, next, context }) => {
+  return async ({ payload, body, next, context }) => {
     // TODO: is putting matches in an array actually helpful? there's no way to know which of the regexps contributed
     // which matches (and in which order)
     let tempMatches: RegExpMatchArray | null;
@@ -140,7 +140,7 @@ export function matchConstraints(
       }
     }
 
-    next();
+    await next();
   };
 }
 
@@ -148,7 +148,7 @@ export function matchConstraints(
  * Middleware that filters out messages that don't match pattern
  */
 export function matchMessage(pattern: string | RegExp): Middleware<SlackEventMiddlewareArgs<'message'>> {
-  return ({ message, context, next }) => {
+  return async ({ message, context, next }) => {
     let tempMatches: RegExpMatchArray | null;
 
     if (message.text === undefined) {
@@ -170,7 +170,7 @@ export function matchMessage(pattern: string | RegExp): Middleware<SlackEventMid
       }
     }
 
-    next();
+    await next();
   };
 }
 
@@ -178,13 +178,13 @@ export function matchMessage(pattern: string | RegExp): Middleware<SlackEventMid
  * Middleware that filters out any command that doesn't match name
  */
 export function matchCommandName(name: string): Middleware<SlackCommandMiddlewareArgs> {
-  return ({ command, next }) => {
+  return async ({ command, next }) => {
     // Filter out any commands that are not the correct command name
     if (name !== command.command) {
       return;
     }
 
-    next();
+    await next();
   };
 }
 
@@ -192,18 +192,18 @@ export function matchCommandName(name: string): Middleware<SlackCommandMiddlewar
  * Middleware that filters out any event that isn't of given type
  */
 export function matchEventType(type: string): Middleware<SlackEventMiddlewareArgs> {
-  return ({ event, next }) => {
+  return async ({ event, next }) => {
     // Filter out any events that are not the correct type
     if (type !== event.type) {
       return;
     }
 
-    next();
+    await next();
   };
 }
 
 export function ignoreSelf(): Middleware<AnyMiddlewareArgs> {
-  return (args) => {
+  return async (args) => {
     // When context does not have a botId in it, then this middleware cannot perform its job. Bail immediately.
     if (args.context.botId === undefined) {
       args.next(contextMissingPropertyError(
@@ -237,14 +237,14 @@ export function ignoreSelf(): Middleware<AnyMiddlewareArgs> {
     }
 
     // If all the previous checks didn't skip this message, then its okay to resume to next
-    args.next();
+    await args.next();
   };
 }
 
 export function subtype(subtype: string): Middleware<SlackEventMiddlewareArgs<'message'>> {
-  return ({ message, next }) => {
+  return async ({ message, next }) => {
     if (message.subtype === subtype) {
-      next();
+      await next();
     }
   };
 }
@@ -252,7 +252,7 @@ export function subtype(subtype: string): Middleware<SlackEventMiddlewareArgs<'m
 const slackLink = /<(?<type>[@#!])?(?<link>[^>|]+)(?:\|(?<label>[^>]+))?>/;
 
 export function directMention(): Middleware<SlackEventMiddlewareArgs<'message'>> {
-  return ({ message, context, next }) => {
+  return async ({ message, context, next }) => {
     // When context does not have a botUserId in it, then this middleware cannot perform its job. Bail immediately.
     if (context.botUserId === undefined) {
       next(contextMissingPropertyError(
@@ -279,7 +279,7 @@ export function directMention(): Middleware<SlackEventMiddlewareArgs<'message'>>
       return;
     }
 
-    next();
+    await next();
   };
 }
 

--- a/src/types/middleware.ts
+++ b/src/types/middleware.ts
@@ -9,7 +9,7 @@ export type AnyMiddlewareArgs =
   SlackEventMiddlewareArgs | SlackActionMiddlewareArgs | SlackCommandMiddlewareArgs | SlackOptionsMiddlewareArgs;
 
 export interface PostProcessFn {
-  (error: Error | undefined, done: (error?: Error) => void): unknown;
+  (error: Error | undefined, done: (error?: Error) => Promise<void>): Promise<void>;
 }
 
 export interface Context extends StringIndexed {
@@ -19,13 +19,13 @@ export interface Context extends StringIndexed {
 // constraint would mess up the interface of App#event(), App#message(), etc.
 export interface Middleware<Args> {
   // TODO: is there something nice we can do to get context's property types to flow from one middleware to the next?
-  (args: Args & { next: NextMiddleware, context: Context }): unknown;
+  (args: Args & { next: NextMiddleware, context: Context }): Promise<void>;
 }
 
 export interface NextMiddleware {
-  (error: Error): void;
-  (postProcess: PostProcessFn): void;
-  (): void;
+  (error: Error): Promise<void>;
+  (postProcess: PostProcessFn): Promise<void>;
+  (): Promise<void>;
 }
 
 export interface ContextMissingPropertyError extends CodedError {

--- a/src/types/receiver.ts
+++ b/src/types/receiver.ts
@@ -11,10 +11,10 @@ export interface ReceiverEvent {
 }
 
 export interface Receiver {
-  on(event: 'message', listener: (event: ReceiverEvent) => void): unknown;
+  on(event: 'message', listener: (event: ReceiverEvent) => Promise<void>): unknown;
   // strictly speaking, Error | ReceiverAckTimeoutError is just Error since the latter is a subtype of the former, but
   // being explicit here is good for documentation purposes
-  on(event: 'error', listener: (error: Error | ReceiverAckTimeoutError) => void): unknown;
+  on(event: 'error', listener: (error: Error | ReceiverAckTimeoutError) => Promise<void>): unknown;
   start(...args: any[]): Promise<unknown>;
   stop(...args: any[]): Promise<unknown>;
 }

--- a/src/types/utilities.ts
+++ b/src/types/utilities.ts
@@ -8,7 +8,7 @@ export type SayArguments = Pick<ChatPostMessageArguments, Exclude<KnownKeys<Chat
 };
 
 export interface SayFn {
-  (message: string | SayArguments): void;
+  (message: string | SayArguments): Promise<void>;
 }
 
 export type RespondArguments = SayArguments & {
@@ -19,7 +19,7 @@ export type RespondArguments = SayArguments & {
 };
 
 export interface RespondFn {
-  (message: string | RespondArguments): void;
+  (message: string | RespondArguments): Promise<void>;
 }
 
 export interface AckFn<Response> {


### PR DESCRIPTION
###  Summary

To address some of the problems with hosting bolt as a serverless function (#220)

For example, in AWS Lambda, we must not call res.end() until the very end of our flow. This is due to https calls forcefully terminating after we ack with a response. The middleware pipeline needs to be async in order for us to know when bolt is finished with the event.

Another issue I haven't addressed in this PR is the fact that the receiver is using Node's EventEmitter class. The `emit` method does not return a promise or take a callback, so we won't be able to know when the serverless function can ack. My personal solution was to write a custom receiver using [emittery](https://www.npmjs.com/package/emittery), which provides an emitter that returns a promise. I feel like this is a bad practice however, and there is probably a better way to process an event in a way that's safe to run inside a serverless handler.

Using the changes in my forked repo, I was able to get a bolt-powered endpoint working in Zeit Now, which is powered by AWS Lambda.

### Requirements (place an `x` in each `[ ]`)

* [X] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [X] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).