### PR TITLE
Allow apps to return multiple botIDs when authorizing

### DIFF
--- a/src/App.ts
+++ b/src/App.ts
@@ -81,7 +81,7 @@ export interface AuthorizeResult {
   // one of either botToken or userToken are required
   botToken?: string; // used by `say` (preferred over userToken)
   userToken?: string; // used by `say` (overridden by botToken)
-  botId?: string; // required for `ignoreSelf` global middleware
+  botId?: string | string[] | undefined; // required for `ignoreSelf` global middleware
   botUserId?: string; // optional but allows `ignoreSelf` global middleware be more filter more than just message events
   [key: string]: any;
 }
@@ -612,7 +612,7 @@ function singleTeamAuthorization(
   authorization: Partial<AuthorizeResult> & { botToken: Required<AuthorizeResult>['botToken'] },
 ): Authorize {
   // TODO: warn when something needed isn't found
-  const identifiers: Promise<{ botUserId: string, botId: string }> = authorization.botUserId !== undefined &&
+  const identifiers: Promise<{ botUserId: string, botId: string | string[] }> = authorization.botUserId !== undefined &&
     authorization.botId !== undefined ?
     Promise.resolve({ botUserId: authorization.botUserId, botId: authorization.botId }) :
     client.auth.test({ token: authorization.botToken })

--- a/src/middleware/builtin.spec.ts
+++ b/src/middleware/builtin.spec.ts
@@ -302,6 +302,33 @@ describe('ignoreSelf()', () => {
     assert.equal(contextMissingError.missingProperty, expectedError.missingProperty);
   });
 
+  it('should handle context missing error, botId array cannot be empty', async () => {
+    // Arrange
+    const fakeNext = sinon.fake();
+    const fakeBotUserId = undefined;
+    const fakeArgs = {
+      next: fakeNext,
+      context: { botUserId: fakeBotUserId, botId: [] },
+    } as unknown as MemberJoinedOrLeftChannelMiddlewareArgs;
+
+    const { ignoreSelf: getIgnoreSelfMiddleware, contextMissingPropertyError } = await importBuiltin();
+
+    // Act
+    const middleware = getIgnoreSelfMiddleware();
+    middleware(fakeArgs);
+    await delay();
+
+    // Assert
+    const expectedError = contextMissingPropertyError(
+      'botId',
+      'Cannot ignore events from the app without a bot ID. Ensure authorize callback returns a botId.',
+    );
+
+    const contextMissingError: ContextMissingPropertyError = fakeNext.getCall(0).lastArg;
+    assert.equal(contextMissingError.code, expectedError.code);
+    assert.equal(contextMissingError.missingProperty, expectedError.missingProperty);
+  });
+
   it('should immediately call next(), because incoming middleware args don\'t contain event', async () => {
     // Arrange
     const fakeNext = sinon.fake();
@@ -431,6 +458,30 @@ describe('ignoreSelf()', () => {
 
     // Assert
     assert.equal(fakeNext.callCount, listOfFakeArgs.length);
+  });
+
+  it('filters an event out botIds is an array, matches our own app and shouldn\'t be retained', async () => {
+    // Arrange
+    const fakeNext = sinon.fake();
+    const fakeBotUserId = 'BUSER1';
+    const fakeArgs = {
+      next: fakeNext,
+      context: { botUserId: fakeBotUserId, botId: [fakeBotUserId] },
+      event: {
+        type: 'tokens_revoked',
+        user: fakeBotUserId,
+      },
+    } as unknown as TokensRevokedMiddlewareArgs;
+
+    const { ignoreSelf: getIgnoreSelfMiddleware } = await importBuiltin();
+
+    // Act
+    const middleware = getIgnoreSelfMiddleware();
+    middleware(fakeArgs);
+    await delay();
+
+    // Assert
+    assert(fakeNext.notCalled);
   });
 });
 


### PR DESCRIPTION
###  Summary
This PR allows apps to return multiple botIDs when authorizing as mentioned here: https://github.com/slackapi/bolt/issues/391

Describe the goal of this PR. Mention any related Issue numbers.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).