### PR TITLE
Add middleware matching app_mention events' text

### DIFF
--- a/src/middleware/builtin.ts
+++ b/src/middleware/builtin.ts
@@ -205,21 +205,23 @@ export function matchConstraints(
 /*
  * Middleware that filters out messages that don't match pattern
  */
-export function matchMessage(pattern: string | RegExp): Middleware<SlackEventMiddlewareArgs<'message'>> {
-  return async ({ message, context, next }) => {
+export function matchMessage(
+    pattern: string | RegExp,
+  ): Middleware<SlackEventMiddlewareArgs<'message' | 'app_mention'>> {
+  return async ({ event, context, next }) => {
     let tempMatches: RegExpMatchArray | null;
 
-    if (message.text === undefined) {
+    if (event.text === undefined) {
       return;
     }
 
-    // Filter out messages that don't contain the pattern
+    // Filter out messages or app mentions that don't contain the pattern
     if (typeof pattern === 'string') {
-      if (!message.text.includes(pattern)) {
+      if (!event.text.includes(pattern)) {
         return;
       }
     } else {
-      tempMatches = message.text.match(pattern);
+      tempMatches = event.text.match(pattern);
 
       if (tempMatches !== null) {
         context['matches'] = tempMatches;


### PR DESCRIPTION
###  Summary

Issue: https://github.com/slackapi/bolt-js/issues/489

This PR is for a new middleware to filter `app_mention`-event texts, based on feedback in #489.

cc: @seratch @stevengill 

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).