### PR TITLE
fixed oauth custom expressReceiver bugs

### DIFF
--- a/docs/_basic/authenticating_oauth.md
+++ b/docs/_basic/authenticating_oauth.md
@@ -61,8 +61,8 @@ const app = new App({
   installerOptions: {
       authVersion: 'v1', // default  is 'v2', 'v1' is used for classic slack apps
       metadata: 'some session data',
-      installPath: 'slack/installApp',
-      redirectUriPath: 'slack/redirect',
+      installPath: '/slack/installApp',
+      redirectUriPath: '/slack/redirect',
       callbackOptions: {
         success: (installation, installOptions, req, res) => {
           // Do custom success logic here

--- a/src/App.ts
+++ b/src/App.ts
@@ -260,34 +260,32 @@ export default class App {
       }
     }
 
-    let usingBuiltinOauth = false;
-    if (
-      clientId !== undefined
-      && clientSecret !== undefined
-      && (stateSecret !== undefined || (installerOptions !== undefined && installerOptions.stateStore !== undefined))
-      && this.receiver instanceof ExpressReceiver
-    ) {
-      usingBuiltinOauth = true;
+    let usingOauth = false;
+    if ((this.receiver as ExpressReceiver).installer !== undefined
+        && (this.receiver as ExpressReceiver).installer!.authorize !== undefined) {
+      // This supports using the built in ExpressReceiver, declaring your own ExpressReceiver
+      // and theoretically, doing a fully custom (non express) receiver that implements OAuth
+      usingOauth = true;
     }
 
     if (token !== undefined) {
-      if (authorize !== undefined || usingBuiltinOauth) {
+      if (authorize !== undefined || usingOauth) {
         throw new AppInitializationError(
           `token as well as authorize options or oauth installer options were provided. ${tokenUsage}`,
         );
       }
       this.authorize = singleTeamAuthorization(this.client, { botId, botUserId, botToken: token });
-    } else if (authorize === undefined && !usingBuiltinOauth) {
+    } else if (authorize === undefined && !usingOauth) {
       throw new AppInitializationError(
         `No token, no authorize options, and no oauth installer options provided. ${tokenUsage}`,
       );
-    } else if (authorize !== undefined && usingBuiltinOauth) {
+    } else if (authorize !== undefined && usingOauth) {
       throw new AppInitializationError(
         `Both authorize options and oauth installer options provided. ${tokenUsage}`,
       );
-    } else if (authorize === undefined && usingBuiltinOauth) {
+    } else if (authorize === undefined && usingOauth) {
       this.authorize = (this.receiver as ExpressReceiver).installer!.authorize as Authorize;
-    } else if (authorize !== undefined && !usingBuiltinOauth) {
+    } else if (authorize !== undefined && !usingOauth) {
       this.authorize = authorize;
     } else {
       this.logger.error('Never should have reached this point, please report to the team');


### PR DESCRIPTION
###  Summary

When declaring a custom `ExpressReceiver`, OAuth should still be handled correctly if it exists. 

This fixes two bugs:

Firstly, the following code was successfully getting through our if statement check to see if the Oauth installer exists on the receiver. Which in this case it would not as `clientID`, `clientSecret` and `stateSecret` aren't being passed to `ExpressReceiver`
```
const expressReceiver = new ExpressReceiver({ 
  signingSecret: '',
})

const app = new App({
  receiver: expressReceiver,
  clientId: '',
  clientSecret: '',
  stateSecret: '',
})
```

Second bug is that we weren't properly supporting an extended `ExpressReceiver`. The following code was failing in the same If statement. In this case, it was failing because `clientId`, `clientSecret` and `stateSecret` were all undefined in App since they were passed directly to `ExpressReceiver`. 
```
const expressReceiver = new ExpressReceiver({ 
  signingSecret: '',
  clientId: '',
  clientSecret: '',
  stateSecret: '',
})

const app = new App({
  receiver: expressReceiver,
})
```

This PR fixes both cases above and theoretically should allow any custom receivers to implement their own OAuth if they follow the OAuth interface exposed in `ExpressReceiver`.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).