### PR TITLE
Adds text as an optional property for RespondArguments

### DIFF
--- a/integration-tests/package.json
+++ b/integration-tests/package.json
@@ -6,14 +6,14 @@
   "license": "MIT",
   "scripts": {
     "test": "npm run test:typechecker",
-    "test:typechecker": "dtslint types"
+    "test:typechecker": "dtslint --expectOnly types"
   },
   "dependencies": {
     "@slack/bolt": "file:..",
     "@types/node": "^10.0.0"
   },
   "devDependencies": {
-    "dtslint": "^0.5.4",
+    "dtslint": "^3.6.10",
     "typescript": "^3.7.3"
   }
 }

--- a/integration-tests/types/index.d.ts
+++ b/integration-tests/types/index.d.ts
@@ -1,2 +1,2 @@
 // tslint:disable:no-useless-files
-// TypeScript Version: 3.3
+// Minimum TypeScript Version: 3.7

--- a/integration-tests/types/utilities.ts
+++ b/integration-tests/types/utilities.ts
@@ -1,0 +1,18 @@
+import { App, InteractiveButtonClick } from '@slack/bolt';
+
+const app = new App({ token: 'TOKEN', signingSecret: 'Signing Secret' });
+
+app.action<InteractiveButtonClick>('my_callback_id', async ({ respond, say }) => {
+  // Expect respond to work with text
+  await respond({ text: 'Some text' });
+
+  // Expect respond to work without text
+  await respond({ delete_original: true });
+
+  // Expect say to work with text
+  await say({ text: 'Some more text' });
+
+  // Expect an error when calling say without text
+  // $ExpectError
+  await say({ blocks: [] });
+});

--- a/src/types/utilities.ts
+++ b/src/types/utilities.ts
@@ -11,11 +11,16 @@ export interface SayFn {
   (message: string | SayArguments): Promise<WebAPICallResult>;
 }
 
-export type RespondArguments = SayArguments & {
+export type RespondArguments =
+Pick<
+  ChatPostMessageArguments,
+  Exclude<KnownKeys<ChatPostMessageArguments>, 'channel' | 'text' >
+> & {
   /** Response URLs can be used to send ephemeral messages or in-channel messages using this argument */
   response_type?: 'in_channel' | 'ephemeral';
   replace_original?: boolean;
   delete_original?: boolean;
+  text?: string;
 };
 
 export interface RespondFn {


### PR DESCRIPTION
###  Summary

As described in #416, its not desirable for `text` to be a required argument when calling `respond()`.

Note: I tried factoring out the repeated code in the type definition of `SayArguments` and `RespondArguments` by creating the following type function (in `helpers.ts`):

```typescript
export type ExcludeKeys<T, Keys extends keyof T> = Pick<T, Exclude<KnownKeys<T>, Keys>>;
```

When I ran the integration tests, I got an error regarding `Exclude<KnownKeys<T>, Keys>` not extending `keyof T`. It seems that there's something about the definition of `KnownKeys` that the compiler actually cannot verify that the result of `KnownKeys<T>` extends `keyof T`. Should method arguments types have index signatures? If they didn't, this problem would likely go away.

Fixes #416 

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).