### PR TITLE
Fix code snippet in custom HTTP route document

### DIFF
--- a/docs/_advanced/custom_routes.md
+++ b/docs/_advanced/custom_routes.md
@@ -38,5 +38,5 @@ receiver.router.post('/secret-page', (req, res) => {
 (async () => {
   await app.start(8080);
   console.log('app is running');
-}());
+})();
 ```

--- a/docs/_advanced/ja_custom_routes.md
+++ b/docs/_advanced/ja_custom_routes.md
@@ -38,5 +38,5 @@ receiver.router.post('/secret-page', (req, res) => {
 (async () => {
   await app.start(8080);
   console.log('app is running');
-}());
+})();
 ```


### PR DESCRIPTION
###  Summary

This pull request fixes a wrong code snippet in the "Adding Custom HTTP routes" document.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).