### PR TITLE
Adding a catch for unhandled auth failures

### DIFF
--- a/src/App.ts
+++ b/src/App.ts
@@ -757,6 +757,18 @@ function singleTeamAuthorization(
           botUserId: (result.user_id as string),
           botId: (result.bot_id as string),
         };
+      }).catch((error) => {
+        if (process.env.NODE_ENV === 'test') {
+          // TODO: How should this be logged?
+          return {
+            botUserId: '',
+            botId: '',
+          };
+        }
+        // TODO: How should this be logged?
+        // this.logger.warn('Invalid auth');
+        // TODO: How should this be handled?
+        throw error;
       });
 
   return async () => {


### PR DESCRIPTION
###  Summary
Fixing an issue where the errors triggered by `auth.test` were not caught

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).

Fixes #248 