### PR TITLE
Add context to global error handler

### DIFF
--- a/src/App.spec.ts
+++ b/src/App.spec.ts
@@ -479,7 +479,8 @@ describe('App', () => {
           throw error;
         });
 
-        app.error(async (actualError) => {
+        app.error(async (actualError, middlewareArgs) => {
+          assert.isDefined(middlewareArgs);
           assert.instanceOf(actualError, UnknownError);
           assert.equal(actualError.message, error.message);
         });

--- a/src/App.ts
+++ b/src/App.ts
@@ -129,7 +129,7 @@ export interface ViewConstraints {
 }
 
 export interface ErrorHandler {
-  (error: CodedError): Promise<void>;
+  (error: CodedError, middlewareArgs?: Object): Promise<void>;
 }
 
 class WebClientPool {
@@ -673,15 +673,15 @@ export default class App {
         },
       );
     } catch (error) {
-      return this.handleError(error);
+      return this.handleError(error, { ...listenerArgs as AnyMiddlewareArgs, context, client, logger: this.logger });
     }
   }
 
   /**
    * Global error handler. The final destination for all errors (hopefully).
    */
-  private handleError(error: Error): Promise<void> {
-    return this.errorHandler(asCodedError(error));
+  private handleError(error: Error, middlewareArgs?: Object): Promise<void> {
+    return this.errorHandler(asCodedError(error), middlewareArgs);
   }
 
 }


### PR DESCRIPTION
###  Summary

When building an app, it's great to be able to have a central error handler where you can centralize all error handling logic. Similar to the way Express handles error middleware. But without the context of the request, the client, and logger, it becomes difficult and requires workarounds. 

Wasn't a big change, so went ahead and opened a PR per the guidelines.

**As a Dev, I Want To:** 

* Push a default error view upon error at view submission.
* Respond with a default message upon error at slash command invocation.
* Do some other specific error handling when an error is of a certain type that can appear often in the app.

Now passing the same args passed to a listener, to the error handler. Passed in everything, similar to the way Express passes in the enter `req` object to all middleware.

I wasn't sure which naming would be appropriate, so I named it `middlewareArgs`, and seeing as the content can be very different from request to request, also typed it as Object. Happy to improve!

### Requirements (place an `x` in each `[ ]`)

* [x ] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [ x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).