### PR TITLE
added v1 runtime deprecation notice

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,8 @@ import pleaseUpgradeNode from 'please-upgrade-node';
 
 pleaseUpgradeNode(packageJson);
 
+console.log('Bolt v1.x has been deprecated. Please upgrade to Bolt v2.x. Migration guide available at https://slack.dev/bolt-js/tutorial/migration-v2.');
+
 export {
   default as App,
   AppOptions,


### PR DESCRIPTION
###  Summary

Added runtime deprecation notice for bolt v1. This will only be applied to the v1 branch.

A new bolt@v1 release will be needed. 

Issue: #528 

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).