### PR TITLE
Document: Add text arg when having blocks in say() calls

### DIFF
--- a/docs/_tutorials/getting_started.md
+++ b/docs/_tutorials/getting_started.md
@@ -217,22 +217,23 @@ app.message('hello', async ({ message, say }) => {
   // say() sends a message to the channel where the event was triggered
   await say({
     blocks: [
-    {
-      "type": "section",
-      "text": {
-        "type": "mrkdwn",
-        "text": `Hey there <@${message.user}>!`
-      },
-      "accessory": {
-        "type": "button",
+      {
+        "type": "section",
         "text": {
-          "type": "plain_text",
-          "text": "Click Me"
+          "type": "mrkdwn",
+          "text": `Hey there <@${message.user}>!`
         },
-        "action_id": "button_click"
+        "accessory": {
+          "type": "button",
+          "text": {
+            "type": "plain_text",
+            "text": "Click Me"
+          },
+          "action_id": "button_click"
+        }
       }
-    }
-    ]
+    ],
+    text: `Hey there <@${message.user}>!`
   });
 });
 
@@ -282,7 +283,8 @@ app.message('hello', async ({ message, say }) => {
           "action_id": "button_click"
         }
       }
-    ]
+    ],
+    text: `Hey there <@${message.user}>!`
   });
 });
 

--- a/docs/_tutorials/ja_getting_started.md
+++ b/docs/_tutorials/ja_getting_started.md
@@ -218,22 +218,23 @@ app.message('hello', async ({ message, say }) => {
   // say() sends a message to the channel where the event was triggered
   await say({
     blocks: [
-    {
-      "type": "section",
-      "text": {
-        "type": "mrkdwn",
-        "text": `Hey there <@${message.user}>!`
-      },
-      "accessory": {
-        "type": "button",
+      {
+        "type": "section",
         "text": {
-          "type": "plain_text",
-          "text": "Click Me"
+          "type": "mrkdwn",
+          "text": `Hey there <@${message.user}>!`
         },
-        "action_id": "button_click"
+        "accessory": {
+          "type": "button",
+          "text": {
+            "type": "plain_text",
+            "text": "Click Me"
+          },
+          "action_id": "button_click"
+        }
       }
-    }
-    ]
+    ],
+    text: `Hey there <@${message.user}>!`
   });
 });
 
@@ -283,7 +284,8 @@ app.message('hello', async ({ message, say }) => {
           "action_id": "button_click"
         }
       }
-    ]
+    ],
+    text: `Hey there <@${message.user}>!`
   });
 });
 


### PR DESCRIPTION
###  Summary

This pull request improves the code snippets in the "Getting Started" document by adding `text` argument when using `blocks` for composing a message. This enables the code to be more optimal in terms of usability plus compatible with TypeScript.

For context: https://github.com/slackapi/bolt-js/issues/532#issuecomment-653256523

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).