### PR TITLE
Add "item" interface types for "ReactionAddedEvent"

### DIFF
--- a/src/types/events/base-events.ts
+++ b/src/types/events/base-events.ts
@@ -612,18 +612,18 @@ export interface PinRemovedEvent extends StringIndexed {
 }
 
 interface ReactionMessageItem {
-  type: "message";
+  type: 'message';
   channel: string;
   ts: string;
 }
 
 interface ReactionFileItem {
-  type: "file";
+  type: 'file';
   file: string;
 }
 
 interface ReactionFileCommentItem {
-  type: "file_comment";
+  type: 'file_comment';
   file_comment: string;
   file: string;
 }

--- a/src/types/events/base-events.ts
+++ b/src/types/events/base-events.ts
@@ -611,6 +611,23 @@ export interface PinRemovedEvent extends StringIndexed {
   event_ts: string;
 }
 
+interface ReactionMessageItem {
+  type: "message";
+  channel: string;
+  ts: string;
+}
+
+interface ReactionFileItem {
+  type: "file";
+  file: string;
+}
+
+interface ReactionFileCommentItem {
+  type: "file_comment";
+  file_comment: string;
+  file: string;
+}
+
 export interface ReactionAddedEvent extends StringIndexed {
   type: 'reaction_added';
   user: string;
@@ -618,8 +635,7 @@ export interface ReactionAddedEvent extends StringIndexed {
   item_user: string;
   // TODO: incomplete, should be message | file | file comment (deprecated)
   // https://api.slack.com/events/reaction_added
-  item: {
-  };
+  item: ReactionMessageItem | ReactionFileItem | ReactionFileCommentItem;
   event_ts: string;
 }
 

--- a/src/types/events/base-events.ts
+++ b/src/types/events/base-events.ts
@@ -622,6 +622,8 @@ interface ReactionFileItem {
   file: string;
 }
 
+// This type is deprecated.
+// See https://api.slack.com/changelog/2018-05-file-threads-soon-tread
 interface ReactionFileCommentItem {
   type: 'file_comment';
   file_comment: string;
@@ -633,8 +635,6 @@ export interface ReactionAddedEvent extends StringIndexed {
   user: string;
   reaction: string;
   item_user: string;
-  // TODO: incomplete, should be message | file | file comment (deprecated)
-  // https://api.slack.com/events/reaction_added
   item: ReactionMessageItem | ReactionFileItem | ReactionFileCommentItem;
   event_ts: string;
 }


### PR DESCRIPTION
###  Summary

Add possible interface types for the `items` field of the `ReactionAddedEvent`

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).