### PR TITLE
Add userScopes to AppOptions

### DIFF
--- a/src/App.ts
+++ b/src/App.ts
@@ -68,6 +68,7 @@ export interface AppOptions {
   stateSecret?: ExpressReceiverOptions['stateSecret']; // required when using default stateStore
   installationStore?: ExpressReceiverOptions['installationStore']; // default MemoryInstallationStore
   scopes?: ExpressReceiverOptions['scopes'];
+  userScopes?: ExpressReceiverOptions['userScopes'];
   installerOptions?: ExpressReceiverOptions['installerOptions'];
   agent?: Agent;
   clientTls?: Pick<SecureContextOptions, 'pfx' | 'key' | 'passphrase' | 'cert' | 'ca'>;
@@ -197,6 +198,7 @@ export default class App {
     stateSecret = undefined,
     installationStore = undefined,
     scopes = undefined,
+    userScopes = undefined,
     installerOptions = undefined,
   }: AppOptions = {}) {
 
@@ -255,6 +257,7 @@ export default class App {
           installationStore,
           installerOptions,
           scopes,
+          userScopes,
           logger: this.logger,
         });
       }

--- a/src/App.ts
+++ b/src/App.ts
@@ -68,7 +68,6 @@ export interface AppOptions {
   stateSecret?: ExpressReceiverOptions['stateSecret']; // required when using default stateStore
   installationStore?: ExpressReceiverOptions['installationStore']; // default MemoryInstallationStore
   scopes?: ExpressReceiverOptions['scopes'];
-  userScopes?: ExpressReceiverOptions['userScopes'];
   installerOptions?: ExpressReceiverOptions['installerOptions'];
   agent?: Agent;
   clientTls?: Pick<SecureContextOptions, 'pfx' | 'key' | 'passphrase' | 'cert' | 'ca'>;
@@ -198,7 +197,6 @@ export default class App {
     stateSecret = undefined,
     installationStore = undefined,
     scopes = undefined,
-    userScopes = undefined,
     installerOptions = undefined,
   }: AppOptions = {}) {
 
@@ -257,7 +255,6 @@ export default class App {
           installationStore,
           installerOptions,
           scopes,
-          userScopes,
           logger: this.logger,
         });
       }

--- a/src/ExpressReceiver.spec.ts
+++ b/src/ExpressReceiver.spec.ts
@@ -45,9 +45,9 @@ describe('ExpressReceiver', () => {
         clientSecret: 'my-client-secret',
         stateSecret: 'state-secret',
         scopes: ['channels:read'],
-        userScopes: ['chat:write'],
         installerOptions: {
           authVersion: 'v2',
+          userScopes: ['chat:write'],
         },
       });
       assert.isNotNull(receiver);

--- a/src/ExpressReceiver.spec.ts
+++ b/src/ExpressReceiver.spec.ts
@@ -45,7 +45,7 @@ describe('ExpressReceiver', () => {
         clientSecret: 'my-client-secret',
         stateSecret: 'state-secret',
         scopes: ['channels:read'],
-        userScopes: ['chat:write:user'],
+        userScopes: ['chat:writeFix'],
         installerOptions: {
           authVersion: 'v2',
         },

--- a/src/ExpressReceiver.spec.ts
+++ b/src/ExpressReceiver.spec.ts
@@ -45,6 +45,7 @@ describe('ExpressReceiver', () => {
         clientSecret: 'my-client-secret',
         stateSecret: 'state-secret',
         scopes: ['channels:read'],
+        userScopes: ['chat:write:user'],
         installerOptions: {
           authVersion: 'v2',
         },

--- a/src/ExpressReceiver.spec.ts
+++ b/src/ExpressReceiver.spec.ts
@@ -45,7 +45,7 @@ describe('ExpressReceiver', () => {
         clientSecret: 'my-client-secret',
         stateSecret: 'state-secret',
         scopes: ['channels:read'],
-        userScopes: ['chat:writeFix'],
+        userScopes: ['chat:write'],
         installerOptions: {
           authVersion: 'v2',
         },

--- a/src/ExpressReceiver.ts
+++ b/src/ExpressReceiver.ts
@@ -114,9 +114,9 @@ export default class ExpressReceiver implements Receiver {
       this.router.get(installPath, async (_req, res, next) => {
         try {
           const url = await this.installer!.generateInstallUrl({
+            userScopes,
             metadata: installerOptions.metadata,
             scopes: scopes!,
-            userScopes
           });
           res.send(`<a href=${url}><img alt=""Add to Slack"" height="40" width="139"
               src="https://platform.slack-edge.com/img/add_to_slack.png"

--- a/src/ExpressReceiver.ts
+++ b/src/ExpressReceiver.ts
@@ -24,7 +24,6 @@ export interface ExpressReceiverOptions {
   stateSecret?: string; // ClearStateStoreOptions['secret']; // required when using default stateStore
   installationStore?: InstallationStore; // default MemoryInstallationStore
   scopes?: string | string[];
-  userScopes?: string | string[];
   installerOptions?: InstallerOptions;
 }
 
@@ -36,6 +35,7 @@ interface InstallerOptions {
   installPath?: string;
   redirectUriPath?: string;
   callbackOptions?: CallbackOptions;
+  userScopes?: string | string[];
 }
 
 /**
@@ -63,7 +63,6 @@ export default class ExpressReceiver implements Receiver {
     stateSecret = undefined,
     installationStore = undefined,
     scopes = undefined,
-    userScopes = undefined,
     installerOptions = {},
   }: ExpressReceiverOptions) {
     this.app = express();
@@ -114,9 +113,9 @@ export default class ExpressReceiver implements Receiver {
       this.router.get(installPath, async (_req, res, next) => {
         try {
           const url = await this.installer!.generateInstallUrl({
-            userScopes,
             metadata: installerOptions.metadata,
             scopes: scopes!,
+            userScopes: installerOptions.userScopes,
           });
           res.send(`<a href=${url}><img alt=""Add to Slack"" height="40" width="139"
               src="https://platform.slack-edge.com/img/add_to_slack.png"

--- a/src/ExpressReceiver.ts
+++ b/src/ExpressReceiver.ts
@@ -116,7 +116,7 @@ export default class ExpressReceiver implements Receiver {
           const url = await this.installer!.generateInstallUrl({
             metadata: installerOptions.metadata,
             scopes: scopes!,
-            userScopes: userScopes,
+            userScopes
           });
           res.send(`<a href=${url}><img alt=""Add to Slack"" height="40" width="139"
               src="https://platform.slack-edge.com/img/add_to_slack.png"

--- a/src/ExpressReceiver.ts
+++ b/src/ExpressReceiver.ts
@@ -24,6 +24,7 @@ export interface ExpressReceiverOptions {
   stateSecret?: string; // ClearStateStoreOptions['secret']; // required when using default stateStore
   installationStore?: InstallationStore; // default MemoryInstallationStore
   scopes?: string | string[];
+  userScopes?: string | string[];
   installerOptions?: InstallerOptions;
 }
 
@@ -62,6 +63,7 @@ export default class ExpressReceiver implements Receiver {
     stateSecret = undefined,
     installationStore = undefined,
     scopes = undefined,
+    userScopes = undefined,
     installerOptions = {},
   }: ExpressReceiverOptions) {
     this.app = express();
@@ -114,6 +116,7 @@ export default class ExpressReceiver implements Receiver {
           const url = await this.installer!.generateInstallUrl({
             metadata: installerOptions.metadata,
             scopes: scopes!,
+            userScopes: userScopes,
           });
           res.send(`<a href=${url}><img alt=""Add to Slack"" height="40" width="139"
               src="https://platform.slack-edge.com/img/add_to_slack.png"


### PR DESCRIPTION
- Support for userScopes is already provided by @slack/oauth

###  Summary

This PR adds "userScopes" to `AppOptions` so that they may be populated when using the `/slack/install` resource.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).