### PR TITLE
Bradh workflow extension support

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -50,7 +50,7 @@ export function getTypeAndConversation(body: any): { type?: IncomingEventType, c
       conversationId: optionsBody.channel !== undefined ? optionsBody.channel.id : undefined,
     };
   }
-  if (body.actions !== undefined || body.type === 'dialog_submission' || body.type === 'workflow_step_action') {
+  if (body.actions !== undefined || body.type === 'dialog_submission' || body.type === 'workflow_step_edit') {
     const actionBody = (body as SlackActionMiddlewareArgs<SlackAction>['body']);
     return {
       type: IncomingEventType.Action,

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -50,7 +50,7 @@ export function getTypeAndConversation(body: any): { type?: IncomingEventType, c
       conversationId: optionsBody.channel !== undefined ? optionsBody.channel.id : undefined,
     };
   }
-  if (body.actions !== undefined || body.type === 'dialog_submission') {
+  if (body.actions !== undefined || body.type === 'dialog_submission' || body.type === 'workflow_step_action') {
     const actionBody = (body as SlackActionMiddlewareArgs<SlackAction>['body']);
     return {
       type: IncomingEventType.Action,

--- a/src/types/actions/index.ts
+++ b/src/types/actions/index.ts
@@ -4,6 +4,7 @@ export * from './dialog-action';
 
 import { BlockAction } from './block-action';
 import { InteractiveMessage } from './interactive-message';
+import { WorkflowStepAction } from './workflow-step-action';
 import { DialogSubmitAction, DialogValidation } from './dialog-action';
 import { SayFn, SayArguments, RespondFn, AckFn } from '../utilities';
 
@@ -21,7 +22,7 @@ import { SayFn, SayArguments, RespondFn, AckFn } from '../utilities';
  * offered when no generic parameter is bound would be limited to BasicElementAction rather than the union of known
  * actions - ElementAction.
  */
-export type SlackAction = BlockAction | InteractiveMessage | DialogSubmitAction;
+export type SlackAction = BlockAction | InteractiveMessage | DialogSubmitAction | WorkflowStepAction;
 
 /**
  * Arguments which listeners and middleware receive to process an action from Slack's Block Kit interactive components,
@@ -40,7 +41,7 @@ export interface SlackActionMiddlewareArgs<Action extends SlackAction = SlackAct
   action: this['payload'];
   body: Action;
   // all action types except dialog submission have a channel context
-  say: Action extends Exclude<SlackAction, DialogSubmitAction> ? SayFn : never;
+  say: Action extends Exclude<SlackAction, DialogSubmitAction | WorkflowStepAction> ? SayFn : never;
   respond: RespondFn;
   ack: ActionAckFn<Action>;
 }

--- a/src/types/actions/index.ts
+++ b/src/types/actions/index.ts
@@ -4,7 +4,7 @@ export * from './dialog-action';
 
 import { BlockAction } from './block-action';
 import { InteractiveMessage } from './interactive-message';
-import { WorkflowStepAction } from './workflow-step-action';
+import { WorkflowStepEdit } from './workflow-step-edit';
 import { DialogSubmitAction, DialogValidation } from './dialog-action';
 import { SayFn, SayArguments, RespondFn, AckFn } from '../utilities';
 
@@ -22,7 +22,7 @@ import { SayFn, SayArguments, RespondFn, AckFn } from '../utilities';
  * offered when no generic parameter is bound would be limited to BasicElementAction rather than the union of known
  * actions - ElementAction.
  */
-export type SlackAction = BlockAction | InteractiveMessage | DialogSubmitAction | WorkflowStepAction;
+export type SlackAction = BlockAction | InteractiveMessage | DialogSubmitAction | WorkflowStepEdit;
 
 /**
  * Arguments which listeners and middleware receive to process an action from Slack's Block Kit interactive components,
@@ -41,7 +41,7 @@ export interface SlackActionMiddlewareArgs<Action extends SlackAction = SlackAct
   action: this['payload'];
   body: Action;
   // all action types except dialog submission have a channel context
-  say: Action extends Exclude<SlackAction, DialogSubmitAction | WorkflowStepAction> ? SayFn : never;
+  say: Action extends Exclude<SlackAction, DialogSubmitAction | WorkflowStepEdit> ? SayFn : never;
   respond: RespondFn;
   ack: ActionAckFn<Action>;
 }

--- a/src/types/actions/workflow-step-action.ts
+++ b/src/types/actions/workflow-step-action.ts
@@ -1,0 +1,30 @@
+/**
+ * A Slack workflow step action wrapped in the standard metadata.
+ *
+ * This describes the entire JSON-encoded body of a request from Slack workflow step actions.
+ */
+export interface WorkflowStepAction {
+  type: 'workflow_step_action';
+  callback_id: string;
+  trigger_id: string;
+  user: {
+    id: string;
+    name: string;
+    team_id?: string; // undocumented
+  };
+  team: {
+    id: string;
+    domain: string;
+    enterprise_id?: string; // undocumented
+    enterprise_name?: string; // undocumented
+  };
+  channel?: {
+    id?: string;
+    name?: string;
+  };
+  token: string;
+  action_ts: string; // undocumented
+  workflow_step: {
+    context_id: string;
+  };
+}

--- a/src/types/actions/workflow-step-edit.ts
+++ b/src/types/actions/workflow-step-edit.ts
@@ -25,6 +25,7 @@ export interface WorkflowStepEdit {
   token: string;
   action_ts: string; // undocumented
   workflow_step: {
-    workflow_step_edit_id: string;
+    workflow_id: string;
+    step_id: string;
   };
 }

--- a/src/types/actions/workflow-step-edit.ts
+++ b/src/types/actions/workflow-step-edit.ts
@@ -9,7 +9,7 @@ export interface WorkflowStepEdit {
   trigger_id: string;
   user: {
     id: string;
-    name: string;
+    username: string;
     team_id?: string; // undocumented
   };
   team: {
@@ -27,5 +27,7 @@ export interface WorkflowStepEdit {
   workflow_step: {
     workflow_id: string;
     step_id: string;
+    inputs: object;
+    outputs: [];
   };
 }

--- a/src/types/actions/workflow-step-edit.ts
+++ b/src/types/actions/workflow-step-edit.ts
@@ -3,8 +3,8 @@
  *
  * This describes the entire JSON-encoded body of a request from Slack workflow step actions.
  */
-export interface WorkflowStepAction {
-  type: 'workflow_step_action';
+export interface WorkflowStepEdit {
+  type: 'workflow_step_edit';
   callback_id: string;
   trigger_id: string;
   user: {
@@ -25,6 +25,6 @@ export interface WorkflowStepAction {
   token: string;
   action_ts: string; // undocumented
   workflow_step: {
-    context_id: string;
+    workflow_step_edit_id: string;
   };
 }

--- a/src/types/events/base-events.ts
+++ b/src/types/events/base-events.ts
@@ -67,7 +67,7 @@ export type SlackEvent =
   | TeamRenameEvent
   | TokensRevokedEvent
   | UserChangeEvent
-  | WorkflowStepStartedEvent;
+  | WorkflowStepExecuteEvent;
 
 /**
  * Any event in Slack's Events API
@@ -737,12 +737,12 @@ export interface UserChangeEvent extends StringIndexed {
   };
 }
 
-export interface WorkflowStepStartedEvent extends StringIndexed {
-  type: 'workflow_step_started';
+export interface WorkflowStepExecuteEvent extends StringIndexed {
+  type: 'workflow_step_execute';
   callback_id: string;
   workflow_step: {
     workflow_step: {
-      context_id: string;
+      workflow_step_execute_id: string;
       inputs: object;
       outputs: {
         name: string;

--- a/src/types/events/base-events.ts
+++ b/src/types/events/base-events.ts
@@ -741,15 +741,16 @@ export interface WorkflowStepExecuteEvent extends StringIndexed {
   type: 'workflow_step_execute';
   callback_id: string;
   workflow_step: {
-    workflow_step: {
-      workflow_step_execute_id: string;
-      inputs: object;
-      outputs: {
-        name: string;
-        type: string;
-        label: string;
-      }[];
-    };
+    workflow_step_execute_id: string;
+    workflow_id: string,
+    workflow_instance_id: string,
+    step_id: string,
+    inputs: object;
+    outputs: {
+      name: string;
+      type: string;
+      label: string;
+    }[];
   };
   event_ts: string;
 }

--- a/src/types/events/base-events.ts
+++ b/src/types/events/base-events.ts
@@ -66,7 +66,8 @@ export type SlackEvent =
   | TeamJoinEvent
   | TeamRenameEvent
   | TokensRevokedEvent
-  | UserChangeEvent;
+  | UserChangeEvent
+  | WorkflowStepStartedEvent;
 
 /**
  * Any event in Slack's Events API
@@ -734,6 +735,23 @@ export interface UserChangeEvent extends StringIndexed {
   // https://api.slack.com/types/user
   user: {
   };
+}
+
+export interface WorkflowStepStartedEvent extends StringIndexed {
+  type: 'workflow_step_started';
+  callback_id: string;
+  workflow_step: {
+    workflow_step: {
+      context_id: string;
+      inputs: object;
+      outputs: {
+        name: string;
+        type: string;
+        label: string;
+      }[];
+    };
+  };
+  event_ts: string;
 }
 
 // NOTE: `user_resourced_denied`, `user_resource_granted`, `user_resourced_removed` are left out because they are

--- a/src/types/events/base-events.ts
+++ b/src/types/events/base-events.ts
@@ -742,9 +742,9 @@ export interface WorkflowStepExecuteEvent extends StringIndexed {
   callback_id: string;
   workflow_step: {
     workflow_step_execute_id: string;
-    workflow_id: string,
-    workflow_instance_id: string,
-    step_id: string,
+    workflow_id: string;
+    workflow_instance_id: string;
+    step_id: string;
     inputs: object;
     outputs: {
       name: string;


### PR DESCRIPTION
###  Summary

This PR adds support for a new feature entering open beta called Workflow Steps from Apps. It allows Slack apps to provide custom steps for Slack Workflows. This new feature requires the following updates to Bolt, encompassed in these changes:

* A new `workflow_step_edit` action
* A new `workflow_step_execute` event
* Exclusion of the `say` function from the `workflow_step_edit` handler
* Updating `getTypeAndConversation()` to allow `workflow_step_edit` action to fall into the action handling logic


### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).