### PR TITLE
Fix a typo in the OAuth document

### DIFF
--- a/docs/_basic/authenticating_oauth.md
+++ b/docs/_basic/authenticating_oauth.md
@@ -48,7 +48,7 @@ You can override the default OAuth using the `installerOptions` object, which ca
 - `installPath`: Override default path for "Add to Slack" button
 - `redirectUriPath`: Override default redirect url path
 - `callbackOptions`: Provide custom success and failure pages at the end of the OAuth flow
-- `stateStore`: Provide a custom state store instead of using the built in `ClearStatStore`
+- `stateStore`: Provide a custom state store instead of using the built in `ClearStateStore`
 
 </div>
 

--- a/docs/_basic/ja_authenticating_oauth.md
+++ b/docs/_basic/ja_authenticating_oauth.md
@@ -50,7 +50,7 @@ const app = new App({
 - `installPath`: "Add to Slack" ボタンのためのパスを変更するために使用
 - `redirectUriPath`: Redirect URL を変更するために使用
 - `callbackOptions`: OAuth フロー完了時の成功・エラー完了画面をカスタマイズするために使用
-- `stateStore`: 組み込みの `ClearStatStore` の代わりにカスタムのデータストアを有効にするために使用
+- `stateStore`: 組み込みの `ClearStateStore` の代わりにカスタムのデータストアを有効にするために使用
 
 </div>
 


### PR DESCRIPTION
###  Summary

s/ClearStatStore/ClearStateStore/

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).