### PR TITLE
Add workflow steps beta documentation

### DIFF
--- a/docs/_advanced/configuring_workflow_steps.md
+++ b/docs/_advanced/configuring_workflow_steps.md
@@ -13,7 +13,7 @@ When a builder is adding your step to a new or existing workflow, your app will 
 
 **1. Listening for `workflow_step_edit` action**
 
-When the builder initially adds your step to their workflow, your app will receive a `workflow_step_edit` action. Your app can listen to `workflow_step_edit` using `action()` and the `callback_id` in your app's configuration.
+When a builder initially adds (or later edits) your step in their workflow, your app will receive a `workflow_step_edit` action. Your app can listen to `workflow_step_edit` using `action()` and the `callback_id` in your app's configuration.
 
 **2. Opening and listening to configuration modal**
 

--- a/docs/_advanced/configuring_workflow_steps.md
+++ b/docs/_advanced/configuring_workflow_steps.md
@@ -1,0 +1,114 @@
+---
+title: Configuring and updating workflow steps
+lang: en
+slug: configuring-steps
+order: 10
+beta: true
+---
+{% raw %} 
+<div class='section-content'>
+⚠️ Workflow [steps from apps](https://api.slack.com/workflows/steps) is a beta feature. As the feature is developed, **Bolt for JavaScript's API will change to add better native support.**
+
+When a builder is adding your step to a new or existing workflow, your app will need to configure and update that step:
+
+**1. Listening for `workflow_step_edit` action**
+
+When the builder initially adds your step to their workflow, your app will receive a `workflow_step_edit` action. Your app can listen to `workflow_step_edit` using `action()` and the `callback_id` in your app's configuration.
+
+**2. Opening and listening to configuration modal**
+
+The `workflow_step_edit` action will contain a `trigger_id`. Your app will call `views.open` with this `trigger_id` to open a modal of type `workflow_step`. This modal has more restrictions than typical modals–most notably you cannot include `title`, `submit`, or `close` properties in the payload.
+
+Similar to other modals, your app can listen to this `view_submission` payload with the built-in [`views()` method](#view_submissions).
+
+To learn more about configuration modals, [read the documentation](https://api.slack.com/workflows/steps#handle_config_view).
+
+**3. Updating the builder's workflow**
+
+After your app listens to the `view_submission`, you'll call [`workflows.updateStep`](https://api.slack.com/methods/workflows.updateStep) with the unique `workflow_step_id` (found in the `body`'s `workflow_step` object) to save the configuration for that builder's specific workflow. Two important parameters:
+- `input` indicates the data your app expects to receive from the user when the workflow step is executed. You can include handlebar-style syntax (`{{ variable }}`) for variables that are collected earlier in a workflow.
+- `output` indicates the data your app will provide upon completion.
+
+Read the documentation [for `input`](https://api.slack.com/reference/workflows/workflow_step#input) and [for `output`](https://api.slack.com/reference/workflows/workflow_step#output) to learn more.
+
+</div>
+{% endraw %} 
+
+```javascript
+// Your app will be called when user adds your step to their workflow
+app.action({ type: 'workflow_step_edit', callback_id: 'add_task' }, async ({ body, ack, client }) => {
+  // Acknowledge the event
+  ack();
+  // Open the configuration modal using `views.open`
+  client.views.open({
+    trigger_id: body.trigger_id,
+    view: {
+      type: 'workflow_step',
+      // callback_id to listen to view_submission
+      callback_id: 'add_task_config',
+      blocks: [
+        // Input blocks will allow users to pass variables from a previous step to your's
+        { 'type': 'input',
+          'block_id': 'task_name_input',
+          'element': {
+            'type': 'plain_text_input',
+            'action_id': 'name',
+            'placeholder': {
+              'type': 'plain_text',
+              'text': 'Add a task name'
+            }
+          },
+          'label': {
+            'type': 'plain_text',
+            'text': 'Task name'
+          }
+        },
+        { 'type': 'input',
+          'block_id': 'task_description_input',
+          'element': {
+            'type': 'plain_text_input',
+            'action_id': 'description',
+            'placeholder': {
+              'type': 'plain_text',
+              'text': 'Add a task description'
+            }
+          },
+          'label': {
+            'type': 'plain_text',
+            'text': 'Task description'
+          }
+        }
+      ]
+    }
+  });
+});
+
+app.views('add_task_config', async ({ ack, view, body, client }) => {
+  // Acknowledge the submission
+  ack();
+  // Unique workflow edit ID
+  let workflowEditId = body.workflow_step.workflow_step_edit_id;
+  // Input values found in the view's state object
+  let taskName = view.state.values.task_name_input.name;
+  let taskDescription = view.state.values.task_description_input.description;
+
+  client.workflows.updateStep({
+    workflow_step_edit_id: workflowEditId,
+    inputs: {
+      taskName: { value: (taskName || '') },
+      taskDescription: { value: (taskDescription || '') }
+    },
+    outputs: [
+      {
+        name: 'taskName',
+        type: 'text',
+        label: 'Task name',
+      },
+      {
+        name: 'taskDescription',
+        type: 'text',
+        label: 'Task description',
+      }
+    ]
+  });
+```

--- a/docs/_advanced/configuring_workflow_steps.md
+++ b/docs/_advanced/configuring_workflow_steps.md
@@ -26,7 +26,7 @@ Similar to other modals, your app can listen to this `view_submission` payload w
 **3. Updating the builder's workflow**
 
 After your app listens to the `view_submission`, you'll call [`workflows.updateStep`](https://api.slack.com/methods/workflows.updateStep) with the unique `workflow_step_id` (found in the `body`'s `workflow_step` object) to save the configuration for that builder's specific workflow. Two important parameters:
-- `inputs` is an object with keyed child objects representing the data your app expects to receive from the user upon workflow execution. You can include handlebar-style syntax (`{{ variable }}`) for variables that are collected earlier in a workflow.
+- `inputs` is an object with keyed child objects representing the data your app expects to receive from the user upon workflow step execution. You can include handlebar-style syntax (`{{ variable }}`) for variables that are collected earlier in a workflow.
 - `outputs` is an array of objects indicating the data your app will provide upon workflow step completion.
 
 Read the documentation for [`input` objects](https://api.slack.com/reference/workflows/workflow_step#input) and [`output` objects](https://api.slack.com/reference/workflows/workflow_step#output) to learn more about how to structure these parameters.

--- a/docs/_advanced/configuring_workflow_steps.md
+++ b/docs/_advanced/configuring_workflow_steps.md
@@ -26,7 +26,7 @@ Similar to other modals, your app can listen to this `view_submission` payload w
 **3. Updating the builder's workflow**
 
 After your app listens to the `view_submission`, you'll call [`workflows.updateStep`](https://api.slack.com/methods/workflows.updateStep) with the unique `workflow_step_id` (found in the `body`'s `workflow_step` object) to save the configuration for that builder's specific workflow. Two important parameters:
-- `inputs` is an object with keyed objects representing the data your app expects to receive from the user upo workflow execution. You can include handlebar-style syntax (`{{ variable }}`) for variables that are collected earlier in a workflow.
+- `inputs` is an object with keyed child objects representing the data your app expects to receive from the user upo workflow execution. You can include handlebar-style syntax (`{{ variable }}`) for variables that are collected earlier in a workflow.
 - `outputs` is an array of objects indicating the data your app will provide upon workflow step completion.
 
 Read the documentation for [`input` objects](https://api.slack.com/reference/workflows/workflow_step#input) and [`output` objects](https://api.slack.com/reference/workflows/workflow_step#output) to learn more about how to structure these parameters.

--- a/docs/_advanced/configuring_workflow_steps.md
+++ b/docs/_advanced/configuring_workflow_steps.md
@@ -7,7 +7,7 @@ beta: true
 ---
 {% raw %} 
 <div class='section-content'>
-⚠️ Workflow [steps from apps](https://api.slack.com/workflows/steps) is a beta feature. As the feature is developed, **Bolt for JavaScript's API will change to add better native support.**
+⚠️ Workflow [steps from apps](https://api.slack.com/workflows/steps) is a beta feature. As the feature is developed, **Bolt for JavaScript's API will change to add better native support.** To develop with workflow steps in Bolt, use the `@slack/bolt@feat-workflow-steps` version of the package rather than the standard `@slack/bolt`.
 
 When a builder is adding your step to a new or existing workflow, your app will need to configure and update that step:
 

--- a/docs/_advanced/configuring_workflow_steps.md
+++ b/docs/_advanced/configuring_workflow_steps.md
@@ -17,19 +17,19 @@ When the builder initially adds your step to their workflow, your app will recei
 
 **2. Opening and listening to configuration modal**
 
-The `workflow_step_edit` action will contain a `trigger_id`. Your app will call `views.open` with this `trigger_id` to open a modal of type `workflow_step`. This modal has more restrictions than typical modals–most notably you cannot include `title`, `submit`, or `close` properties in the payload.
-
-Similar to other modals, your app can listen to this `view_submission` payload with the built-in [`views()` method](#view_submissions).
+The `workflow_step_edit` action will contain a `trigger_id` which your app will use to call `views.open` to open a modal of type `workflow_step`. This configuration modal has more restrictions than typical modals—most notably you cannot include `title`, `submit`, or `close` properties in the payload.
 
 To learn more about configuration modals, [read the documentation](https://api.slack.com/workflows/steps#handle_config_view).
+
+Similar to other modals, your app can listen to this `view_submission` payload with the built-in [`views()` method](#view_submissions).
 
 **3. Updating the builder's workflow**
 
 After your app listens to the `view_submission`, you'll call [`workflows.updateStep`](https://api.slack.com/methods/workflows.updateStep) with the unique `workflow_step_id` (found in the `body`'s `workflow_step` object) to save the configuration for that builder's specific workflow. Two important parameters:
-- `input` indicates the data your app expects to receive from the user when the workflow step is executed. You can include handlebar-style syntax (`{{ variable }}`) for variables that are collected earlier in a workflow.
-- `output` indicates the data your app will provide upon completion.
+- `inputs` is an object with keyed objects representing the data your app expects to receive from the user upo workflow execution. You can include handlebar-style syntax (`{{ variable }}`) for variables that are collected earlier in a workflow.
+- `outputs` is an array of objects indicating the data your app will provide upon workflow step completion.
 
-Read the documentation [for `input`](https://api.slack.com/reference/workflows/workflow_step#input) and [for `output`](https://api.slack.com/reference/workflows/workflow_step#output) to learn more.
+Read the documentation for [`input` objects](https://api.slack.com/reference/workflows/workflow_step#input) and [`output` objects](https://api.slack.com/reference/workflows/workflow_step#output) to learn more about how to structure these parameters.
 
 </div>
 {% endraw %} 

--- a/docs/_advanced/configuring_workflow_steps.md
+++ b/docs/_advanced/configuring_workflow_steps.md
@@ -26,7 +26,7 @@ Similar to other modals, your app can listen to this `view_submission` payload w
 **3. Updating the builder's workflow**
 
 After your app listens to the `view_submission`, you'll call [`workflows.updateStep`](https://api.slack.com/methods/workflows.updateStep) with the unique `workflow_step_id` (found in the `body`'s `workflow_step` object) to save the configuration for that builder's specific workflow. Two important parameters:
-- `inputs` is an object with keyed child objects representing the data your app expects to receive from the user upo workflow execution. You can include handlebar-style syntax (`{{ variable }}`) for variables that are collected earlier in a workflow.
+- `inputs` is an object with keyed child objects representing the data your app expects to receive from the user upon workflow execution. You can include handlebar-style syntax (`{{ variable }}`) for variables that are collected earlier in a workflow.
 - `outputs` is an array of objects indicating the data your app will provide upon workflow step completion.
 
 Read the documentation for [`input` objects](https://api.slack.com/reference/workflows/workflow_step#input) and [`output` objects](https://api.slack.com/reference/workflows/workflow_step#output) to learn more about how to structure these parameters.

--- a/docs/_advanced/executing_workflow_steps.md
+++ b/docs/_advanced/executing_workflow_steps.md
@@ -9,7 +9,7 @@ beta: true
 <div class="section-content">
 ⚠️ Workflow [steps from apps](https://api.slack.com/workflows/steps) is a beta feature. As the feature is developed, **Bolt for JavaScript's API will change to add better native support.**
 
-When your workflow is executed by an end user, your app will receive a `workflow_step_execute` event. This event includes the user's `inputs` and a unique workflow execution ID. Your app must call [`workflows.stepCompleted`](https://api.slack.com/methods/workflows.stepCompleted) with the `outputs` you specified in `workflows.updateStep`.
+When your workflow is executed by an end user, your app will receive a `workflow_step_execute` event. This event includes the user's `inputs` and a unique workflow execution ID. Your app must either call [`workflows.stepCompleted`](https://api.slack.com/methods/workflows.stepCompleted) with the `outputs` you specified in `workflows.updateStep`, or [`workflows.stepFailed`](https://api.slack.com/methods/workflows.stepFailed) to indicate the step failed.
 </div>
 
 ```javascript

--- a/docs/_advanced/executing_workflow_steps.md
+++ b/docs/_advanced/executing_workflow_steps.md
@@ -7,7 +7,7 @@ beta: true
 ---
 
 <div class="section-content">
-⚠️ Workflow [steps from apps](https://api.slack.com/workflows/steps) is a beta feature. As the feature is developed, **Bolt for JavaScript's API will change to add better native support.**
+⚠️ Workflow [steps from apps](https://api.slack.com/workflows/steps) is a beta feature. As the feature is developed, **Bolt for JavaScript's API will change to add better native support.** To develop with workflow steps in Bolt, use the `@slack/bolt@feat-workflow-steps` version of the package rather than the standard `@slack/bolt`.
 
 When your workflow is executed by an end user, your app will receive a `workflow_step_execute` event. This event includes the user's `inputs` and a unique workflow execution ID. Your app must either call [`workflows.stepCompleted`](https://api.slack.com/methods/workflows.stepCompleted) with the `outputs` you specified in `workflows.updateStep`, or [`workflows.stepFailed`](https://api.slack.com/methods/workflows.stepFailed) to indicate the step failed.
 </div>

--- a/docs/_advanced/executing_workflow_steps.md
+++ b/docs/_advanced/executing_workflow_steps.md
@@ -1,0 +1,32 @@
+---
+title: Executing workflow steps
+lang: en
+slug: executing-steps
+order: 11
+beta: true
+---
+
+<div class="section-content">
+⚠️ Workflow [steps from apps](https://api.slack.com/workflows/steps) is a beta feature. As the feature is developed, **Bolt for JavaScript's API will change to add better native support.**
+
+When your workflow is executed by an end-user, your app will receive a `workflow_step_execute` event. This event will include the user's inputs and a unique workflow execute ID. Your app must call [`workflows.stepCompleted`](https://api.slack.com/methods/workflows.stepCompleted) with the `outputs` you specified in `workflows.updateStep`.
+</div>
+
+```javascript
+app.event('workflow_step_execute', async ({ event, client }) => {
+  // Unique workflow edit ID
+  let workflowExecuteId = event.workflow_step.workflow_step_execute_id;
+  let inputs = event.workflow_step.inputs;
+
+  client.workflows.stepCompleted({
+    workflow_step_execute_id: workflowExecuteId,
+    outputs: {
+      taskName: inputs.taskName.value,
+      taskDescription: inputs.taskDescription.value
+    }
+  });
+  
+  // You can do anything else you want here. Some ideas:
+  // Display results on the user's home tab, update your database, or send a message into a channel
+});
+```

--- a/docs/_advanced/executing_workflow_steps.md
+++ b/docs/_advanced/executing_workflow_steps.md
@@ -9,7 +9,7 @@ beta: true
 <div class="section-content">
 ⚠️ Workflow [steps from apps](https://api.slack.com/workflows/steps) is a beta feature. As the feature is developed, **Bolt for JavaScript's API will change to add better native support.**
 
-When your workflow is executed by an end-user, your app will receive a `workflow_step_execute` event. This event will include the user's inputs and a unique workflow execute ID. Your app must call [`workflows.stepCompleted`](https://api.slack.com/methods/workflows.stepCompleted) with the `outputs` you specified in `workflows.updateStep`.
+When your workflow is executed by an end user, your app will receive a `workflow_step_execute` event. This event includes the user's `inputs` and a unique workflow execution ID. Your app must call [`workflows.stepCompleted`](https://api.slack.com/methods/workflows.stepCompleted) with the `outputs` you specified in `workflows.updateStep`.
 </div>
 
 ```javascript

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -39,7 +39,7 @@ t:
     contribute: 貢献
 
 # Metadata
-repo_name: bolt
+repo_name: bolt-js
 github_username: SlackAPI
 
 code_of_conduct_url: https://slackhq.github.io/code-of-conduct

--- a/docs/_includes/sidebar.html
+++ b/docs/_includes/sidebar.html
@@ -42,7 +42,12 @@
     {% assign advanced_sections = site.advanced | sort: "order" | where: "lang", page.lang %}
     {% for section in advanced_sections %}
       <a href="{{ site.url | append: site.baseurl | append: localized_base_url }}/concepts#{{ section.slug }}">
-        <li>{{section.title}}</li>
+        <li>
+          {% if section.beta == true %}
+            <span class="beta">Beta</span>
+          {% endif %}
+         {{section.title}}
+        </li>
       </a>
     {% endfor %}
   </ul>

--- a/docs/assets/style.css
+++ b/docs/assets/style.css
@@ -83,6 +83,18 @@ body {
   color: var(--black);
 }
 
+.panel .sidebar-content ul.sidebar-section li span.beta {
+  background-color: #E8F5FA;
+  color: #1264A3;
+  padding: 2px 6px;
+  margin-right: 2px;
+  border-radius: 6px;
+  border: 1px solid #D4ECF6;
+  text-transform: uppercase;
+  font-weight: 600;
+  font-size: 0.8em;
+}
+
 .panel .sidebar-content ul.sidebar-section li:hover {
   background-color: #D7D7D7;
 }


### PR DESCRIPTION
###  Summary

Supports the open beta launch of workflow steps from apps (https://api.slack.com/workflows/steps).

This is in place while a more native Bolt for JavaScript API is developed.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).