### PR TITLE
adding more detail to workflow step action/event types

### DIFF
--- a/src/types/actions/workflow-step-edit.ts
+++ b/src/types/actions/workflow-step-edit.ts
@@ -27,7 +27,17 @@ export interface WorkflowStepEdit {
   workflow_step: {
     workflow_id: string;
     step_id: string;
-    inputs: object;
-    outputs: [];
+    inputs: {
+      [key: string]: {
+        value: any;
+      },
+    };
+    outputs: {
+      name: string;
+      type: string;
+      label: string;
+    }[];
+    step_name?: string;
+    step_image_url?: string;
   };
 }

--- a/src/types/events/base-events.ts
+++ b/src/types/events/base-events.ts
@@ -761,7 +761,11 @@ export interface WorkflowStepExecuteEvent extends StringIndexed {
     workflow_id: string;
     workflow_instance_id: string;
     step_id: string;
-    inputs: object;
+    inputs: {
+      [key: string]: {
+        value: any;
+      },
+    };
     outputs: {
       name: string;
       type: string;

--- a/src/types/view/index.ts
+++ b/src/types/view/index.ts
@@ -44,6 +44,11 @@ export interface ViewSubmitAction {
   view: ViewOutput;
   api_app_id: string;
   token: string;
+  workflow_step?: {
+    workflow_step_edit_id: string;
+    workflow_id: string;
+    step_id: string;
+  };
 }
 
 /**
@@ -68,6 +73,11 @@ export interface ViewClosedAction {
   api_app_id: string;
   token: string;
   is_cleared: boolean;
+  workflow_step?: {
+    workflow_step_edit_id: string;
+    workflow_id: string;
+    step_id: string;
+  };
 }
 
 export interface ViewOutput {


### PR DESCRIPTION
###  Summary

This PR flushes out some of the types associated with the workflow_step feature a bit more. There is also an optional `workflow_step` object on view submit/close events now too that this accounts for.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).