### PR TITLE
Steps from Apps document: Add await for async function calls in a listener

### DIFF
--- a/docs/_steps/configuring_workflow_steps.md
+++ b/docs/_steps/configuring_workflow_steps.md
@@ -36,9 +36,9 @@ Read the documentation for [`input` objects](https://api.slack.com/reference/wor
 // Your app will be called when user adds your step to their workflow
 app.action({ type: 'workflow_step_edit', callback_id: 'add_task' }, async ({ body, ack, client }) => {
   // Acknowledge the event
-  ack();
+  await ack();
   // Open the configuration modal using `views.open`
-  client.views.open({
+  await client.views.open({
     trigger_id: body.trigger_id,
     view: {
       type: 'workflow_step',
@@ -83,14 +83,14 @@ app.action({ type: 'workflow_step_edit', callback_id: 'add_task' }, async ({ bod
 
 app.views('add_task_config', async ({ ack, view, body, client }) => {
   // Acknowledge the submission
-  ack();
+  await ack();
   // Unique workflow edit ID
   let workflowEditId = body.workflow_step.workflow_step_edit_id;
   // Input values found in the view's state object
   let taskName = view.state.values.task_name_input.name;
   let taskDescription = view.state.values.task_description_input.description;
 
-  client.workflows.updateStep({
+  await client.workflows.updateStep({
     workflow_step_edit_id: workflowEditId,
     inputs: {
       taskName: { value: (taskName || '') },

--- a/docs/_steps/configuring_workflow_steps.md
+++ b/docs/_steps/configuring_workflow_steps.md
@@ -109,4 +109,5 @@ app.views('add_task_config', async ({ ack, view, body, client }) => {
       }
     ]
   });
+});
 ```

--- a/docs/_steps/executing_workflow_steps.md
+++ b/docs/_steps/executing_workflow_steps.md
@@ -17,7 +17,7 @@ app.event('workflow_step_execute', async ({ event, client }) => {
   let workflowExecuteId = event.workflow_step.workflow_step_execute_id;
   let inputs = event.workflow_step.inputs;
 
-  client.workflows.stepCompleted({
+  await client.workflows.stepCompleted({
     workflow_step_execute_id: workflowExecuteId,
     outputs: {
       taskName: inputs.taskName.value,


### PR DESCRIPTION
###  Summary

Related to #592 

This pull request adds `await` in front of async functions calls in a listener. This is a recommended coding style to avoid misbehavior.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).