### PR TITLE
add endpoints hint to command example

### DIFF
--- a/docs/_basic/listening_responding_commands.md
+++ b/docs/_basic/listening_responding_commands.md
@@ -16,6 +16,13 @@ When configuring commands within your app configuration, you'll continue to appe
 </div>
 
 ```javascript
+// Enable the command endpoint in your app
+const app = new App({
+  endpoints: {
+     commands: '/slack/commands'
+   },
+});
+
 // The echo command simply echoes on command
 app.command('/echo', async ({ command, ack, say }) => {
   // Acknowledge command request


### PR DESCRIPTION
###  Summary

When trying to implement a command I didn't realise that the command endpoint wasn't enabled until I looked at the App class code. I was doing this to try to help someone else that was also having trouble implementing a command, and it turns out this was the sole issue we were both having.
I figured it would be helpful to hint other peeps around this.

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).