### PR TITLE
Add missing section break to Getting Started guide

### DIFF
--- a/docs/_tutorials/getting_started.md
+++ b/docs/_tutorials/getting_started.md
@@ -50,6 +50,8 @@ Once you authorize the installation, you'll land on the **OAuth & Permissions** 
 
 > 💡 Treat your token like a password and [keep it safe](https://api.slack.com/docs/oauth-safety). Your app uses it to post and retrieve information from Slack workspaces.
 
+---
+
 ### Setting up your local project
 With the initial configuration handled, it's time to set up a new Bolt project. This is where you'll write the code that handles the logic for your app.
 


### PR DESCRIPTION
###  Summary

This pull request adds a missing section break (`---`) to the Getting Started guide for the section "Setting up your local project."

#### Before
![image](https://user-images.githubusercontent.com/21328/92653547-60739500-f2a3-11ea-9109-a40bdc2996cf.png)

#### After
![image](https://user-images.githubusercontent.com/21328/92653656-8305ae00-f2a3-11ea-856d-64b05d83386f.png)

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).