### PR TITLE
Use a client logger (if provided) for the ExpressReceiver InstallProvider

### DIFF
--- a/src/ExpressReceiver.ts
+++ b/src/ExpressReceiver.ts
@@ -100,6 +100,7 @@ export default class ExpressReceiver implements Receiver {
       (stateSecret !== undefined || installerOptions.stateStore !== undefined)
     ) {
       this.installer = new InstallProvider({
+        logger,
         clientId,
         clientSecret,
         stateSecret,


### PR DESCRIPTION
###  Summary

Ensure the ExpressReceiver's creation of the InstallProvider also uses the client provided logger.

Currently, if there's an error in an ExpressReceiver InstallProvider, the default logger is used regardless of whether a custom logger is provided in the installer options.

Fixes https://github.com/slackapi/bolt-js/issues/620

Example of my json transport logs inner mixed with the default bolt console logger....

```
{"level":"DEBUG","message":"apiCall('oauth.v2.access') start","line":148,"function":"apiCall","file":"node_modules/@slack/oauth/node_modules/@slack/web-api/src/WebClient.ts"}
{"level":"DEBUG","message":"will perform http request","line":308,"function":null,"file":"node_modules/@slack/oauth/node_modules/@slack/web-api/src/WebClient.ts"}
{"level":"DEBUG","message":"http response received","line":316,"function":null,"file":"node_modules/@slack/oauth/node_modules/@slack/web-api/src/WebClient.ts"}
[ERROR]  OAuth:InstallProvider:0 [Error: An API error occurred: invalid_code] {
  code: 'slack_webapi_platform_error',
  data: { ok: false, error: 'invalid_code', response_metadata: {} }
}
```

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).