### PR TITLE
Add documentation for publishing to home tab

### DIFF
--- a/docs/_basic/authenticating_oauth.md
+++ b/docs/_basic/authenticating_oauth.md
@@ -2,7 +2,7 @@
 title: Authenticating with OAuth
 lang: en
 slug: authenticating-oauth
-order: 14
+order: 15
 ---
 
 <div class="section-content">

--- a/docs/_basic/listening_responding_options.md
+++ b/docs/_basic/listening_responding_options.md
@@ -2,7 +2,7 @@
 title: Listening and responding to options
 lang: en
 slug: options
-order: 13
+order: 14
 ---
 
 <div class="section-content">

--- a/docs/_basic/publishing_views.md
+++ b/docs/_basic/publishing_views.md
@@ -1,0 +1,50 @@
+---
+title: Publishing views to App Home
+lang: en
+slug: publishing-views
+order: 13
+---
+
+<div class="section-content">
+<a href="https://api.slack.com/surfaces/tabs/using">Home tabs</a> are customizable surfaces accessible via the sidebar and search that allow apps to display views on a per-user basis. After enabling App Home within your app configuration, home tabs can be published and updated by passing a `user_id` and <a href="https://api.slack.com/reference/block-kit/views">view payload</a> to the <a href="https://api.slack.com/methods/views.publish">`views.publish`</a> method.
+
+You can subscribe to the <a href="https://api.slack.com/events/app_home_opened">`app_home_opened`</a> event to listen for when users open your App Home.
+</div>
+
+```javascript
+// Listen for users opening your App Home
+app.event('app_home_opened', async ({ event, client }) => {
+  try {
+    // Call views.publish with the built-in client
+    const result = await client.views.publish({
+      // Use the user ID associated with the event
+      user_id: event.user,
+      view: {
+        // Home tabs must be enabled in your app configuration page under "App Home"
+        "type": "home",
+        "blocks": [
+          {
+            "type": "section",
+            "text": {
+              "type": "mrkdwn",
+              "text": "*Welcome home, <@" + event.user + "> :house:*"
+            }
+          },
+          {
+            "type": "section",
+            "text": {
+              "type": "mrkdwn",
+              "text": "Learn how home tabs can be more useful and interactive <https://api.slack.com/surfaces/tabs/using|*in the documentation*>."
+            }
+          }
+        ]
+      }
+    });
+
+    console.log(result);
+  }
+  catch (error) {
+    console.error(error);
+  }
+});
+```


### PR DESCRIPTION
###  Summary
This should have been added a while ago, but better late than never.

This section shows how to use `views.publish` and the `app_home_opened` event to update a user's home tab.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).