### PR TITLE
Update template URLs to use main

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -11,7 +11,7 @@ Describe your issue here.
 - [ ] discussion
 
 ### Requirements (place an `x` in each of the `[ ]`)
-* [ ] I've read and understood the [Contributing guidelines](https://github.com/slackapi/bolt/blob/master/.github/contributing.md) and have done my best effort to follow them.
+* [ ] I've read and understood the [Contributing guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
 * [ ] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
 * [ ] I've searched for any related issues and avoided creating a duplicate issue.
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,5 +4,5 @@ Describe the goal of this PR. Mention any related Issue numbers.
 
 ### Requirements (place an `x` in each `[ ]`)
 
-* [ ] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/master/.github/contributing.md) and have done my best effort to follow them.
+* [ ] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
 * [ ] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).


### PR DESCRIPTION
###  Summary

Template URLs for Contributing Guidelines is currently pointing to `master`, resulting in a redirect. Switch to `main`. 

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).