### PR TITLE
Update Getting Started guide to reference Getting Started example app

### DIFF
--- a/docs/_tutorials/getting_started.md
+++ b/docs/_tutorials/getting_started.md
@@ -14,6 +14,8 @@ redirect_from:
 This guide is meant to walk you through getting up and running with a Slack app using Bolt for JavaScript. Along the way, we’ll create a new Slack app, set up your local environment, and develop an app that listens and responds to messages from a Slack workspace.
 </div> 
 
+When you’re finished, you’ll have this ⚡️[Getting Started app](https://github.com/slackapi/bolt-js-getting-started-app) to run, modify, and make your own.
+
 ---
 
 ### Create an app
@@ -311,7 +313,7 @@ You can see that we used `app.action()` to listen for the `action_id` that we na
 ---
 
 ### Next steps
-You just built your first Bolt for JavaScript app! 🎉
+You just built your first [Bolt for JavaScript app](https://github.com/slackapi/bolt-js-getting-started-app)! 🎉
 
 Now that you have a basic app up and running, you can start exploring how to make your Bolt app stand out. Here are some ideas about what to explore next:
 


### PR DESCRIPTION
###  Summary

This pull request updates our **Getting Started guide** to reference our newly open sourced [Getting Started example app](https://github.com/slackapi/bolt-js-getting-started-app).

It follows the same wording used in the [Getting Started ⚡️ Bolt for Python guide](https://slack.dev/bolt-python/tutorial/getting-started) and [Deploying to Heroku ⚡️ Bolt for JavaScript guide](https://slack.dev/bolt-js/deployments/heroku).

### Preview

→ https://mwbrooks.github.io/bolt-js/tutorial/getting-started

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).