### PR TITLE
Update issue template to include example code type

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -7,6 +7,7 @@ Describe your issue here.
 - [ ] enhancement (feature request)
 - [ ] question
 - [ ] documentation related
+- [ ] example code related
 - [ ] testing related
 - [ ] discussion
 


### PR DESCRIPTION
###  Summary

This pull request updates the GitHub Issues Template to include the category `example code related`.

When a contributor selects the example code type, we can use the `area:examples` label to categorize the issue. Exampel code can be found in the `examples/` directory or one of our example repositories (e.g. [slackapi/bolt-js-getting-started-app](https://github.com/slackapi/bolt-js-getting-started-app)).

Related to:
- https://github.com/slackapi/bolt-js-getting-started-app/pull/2

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).