### PR TITLE
Update README to refer authorizations rather than authed_users

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Most of the app's functionality will be inside listener functions (the `fn` para
 | `client` | Web API client that uses the token associated with that event. For single-workspace installations, the token is provided to the constructor. For multi-workspace installations, the token is returned by the `authorize` function.
 | `respond` | Function that responds to an incoming event **if** it contains a `response_url` (shortcuts, actions, and slash commands). `respond` returns a promise that resolves with the results of responding using the `response_url`.
 | `context` | Event context. This object contains data about the event and the app, such as the `botId`. Middleware can add additional context before the event is passed to listeners.
-| `body` | Object that contains the entire body of the request (superset of `payload`). Some accessory data is only available outside of the payload (such as `trigger_id` and `authed_users`).
+| `body` | Object that contains the entire body of the request (superset of `payload`). Some accessory data is only available outside of the payload (such as `trigger_id` and `authorizations`).
 
 
 The arguments are grouped into properties of one object, so that it's easier to pick just the ones your listener needs (using


### PR DESCRIPTION
###  Summary

As accessing `authorizations` is the latest recommended way, you can update the part mentioning `authed_users` in README. https://api.slack.com/changelog/2020-09-15-events-api-truncate-authed-users

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).