### PR TITLE
Updated docs for org wide installations

### DIFF
--- a/docs/_basic/authenticating_oauth.md
+++ b/docs/_basic/authenticating_oauth.md
@@ -13,6 +13,8 @@ Bolt for JavaScript will create a **Redirect URL** `slack/oauth_redirect`, which
 Bolt for JavaScript will also create a `slack/install` route, where you can find an `Add to Slack` button for your app to perform direct installs of your app. If you need any additional authorizations (user tokens) from users inside a team when your app is already installed or a reason to dynamically generate an install URL, manually instantiate an `ExpressReceiver`, assign the instance to a variable named `receiver`, and then call `receiver.installer.generateInstallUrl()`. Read more about `generateInstallUrl()` in the [OAuth docs](https://slack.dev/node-slack-sdk/oauth#generating-an-installation-url).
 
 To learn more about the OAuth installation flow with Slack, [read the API documentation](https://api.slack.com/authentication/oauth-v2).
+
+To add support for [org wide installations](https://api.slack.com/enterprise/apps), you will need Bolt for JavaScript version `2.5.0` or newer. You will have to update your `installationStore` to include `storeOrgInstallation` and `fetchOrgInstallation` methods. Lastly, make sure you have enabled org wide installations in your app configuration settings under **Org Level Apps**.
 </div>
 
 ```javascript
@@ -30,6 +32,16 @@ const app = new App({
     fetchInstallation: async (InstallQuery) => {
       // change the line below so it fetches from your database
       return await database.get(InstallQuery.teamId);
+    },
+    storeOrgInstallation: async (installation) => {
+      // include this method if you want your app to support org wide installations
+      // change the line below so it saves to your database
+      return await database.set(installation.enterprise.id, installation);
+    },
+    fetchOrgInstallation: async (InstallQuery) => {
+      // include this method if you want your app to support org wide installations
+      // change the line below so it fetches from your database
+      return await database.get(InstallQuery.enterpriseId);
     },
   },
 });

--- a/docs/_basic/web_api.md
+++ b/docs/_basic/web_api.md
@@ -12,7 +12,7 @@ Your Bolt app also has a top-level `app.client` which you can manually pass the 
 
 Calling one of the [`WebClient`](https://slack.dev/node-slack-sdk/web-api)'s methods will return a Promise containing the response from Slack, regardless of whether you use the top-level or listener's client.
 
-Since the introduction of [org wide app installations](https://api.slack.com/enterprise/apps), [some web-api methods](https://api.slack.com/enterprise/apps/changes-apis#methods) now require `team_id` to indicate which workspace to act on. Bolt for JavaScript will attempt to infer the `team_id` based on incoming payloads and pass it along to `client`. This is handy for existing applications looking to add support for org wide installations and not spend time updating all of these web api calls.
+Since the introduction of [org wide app installations](https://api.slack.com/enterprise/apps), [some web-api methods](https://api.slack.com/enterprise/apps/changes-apis#methods) now require `team_id` to indicate which workspace to act on. Bolt for JavaScript will attempt to infer the `team_id` based on incoming payloads and pass it along to `client`. This is handy for existing applications looking to add support for org wide installations and not spend time updating all of these web-api calls.
 </div>
 
 ```javascript

--- a/docs/_basic/web_api.md
+++ b/docs/_basic/web_api.md
@@ -11,6 +11,8 @@ You can call [any Web API method](https://api.slack.com/methods) using the [`Web
 Your Bolt app also has a top-level `app.client` which you can manually pass the `token` parameter. If the incoming event is not authorized or you're calling a method from outside of a listener, use the top-level `app.client`.
 
 Calling one of the [`WebClient`](https://slack.dev/node-slack-sdk/web-api)'s methods will return a Promise containing the response from Slack, regardless of whether you use the top-level or listener's client.
+
+Since the introduction of [org wide app installations](https://api.slack.com/enterprise/apps), [some web-api methods](https://api.slack.com/enterprise/apps/changes-apis#methods) now require `team_id` to indicate which workspace to act on. Bolt for JavaScript will attempt to infer the `team_id` based on incoming payloads and pass it along to `client`. This is handy for existing applications looking to add support for org wide installations and not spend time updating all of these web api calls.
 </div>
 
 ```javascript


### PR DESCRIPTION
###  Summary

Updated docs for the upcoming release of org wide app installations.

This will be Merged on Dec 1st, 2020

The links to the api site I added will be live on Dec 1 as well. 

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).