### PR TITLE
Branch name change from master to main

### DIFF
--- a/.github/contributing.md
+++ b/.github/contributing.md
@@ -52,7 +52,7 @@ If the contribution doesn't meet the above criteria, you may fail our automated 
 3.  :herb: Create a new branch and check it out.
 4.  :crystal_ball: Make your changes and commit them locally. Magic happens here!
 5.  :arrow_heading_up: Push your new branch to your fork. (e.g. `git push username fix-issue-16`).
-6.  :inbox_tray: Open a Pull Request on github.com from your new branch on your fork to `master` in this
+6.  :inbox_tray: Open a Pull Request on github.com from your new branch on your fork to `main` in this
     repository.
 
 ## Maintainers


### PR DESCRIPTION
In the contributing doc, master branch was still
in use. Changed to main

###  Summary

Describe the goal of this PR. Mention any related Issue numbers.

### Requirements (place an `x` in each `[ ]`)

* [X] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [X] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).