### PR TITLE
Fix #726 #729 by checking if enteprise is null

### DIFF
--- a/src/App.spec.ts
+++ b/src/App.spec.ts
@@ -807,6 +807,47 @@ describe('App', () => {
             {
               ...baseEvent,
               body: {
+                type: 'view_submission',
+                channel: {},
+                user: {},
+                team: null,
+                enterprise: {},
+                view: {
+                  callback_id: 'view_callback_id',
+                },
+              },
+            },
+            {
+              ...baseEvent,
+              body: {
+                type: 'view_submission',
+                channel: {},
+                user: {},
+                enterprise: {},
+                // Although {team: undefined} pattern does not exist as of Jan 2021,
+                // this test verifies if App works even if the field is missing.
+                view: {
+                  callback_id: 'view_callback_id',
+                },
+              },
+            },
+            {
+              ...baseEvent,
+              body: {
+                type: 'view_submission',
+                channel: {},
+                user: {},
+                team: {},
+                // Although {enterprise: undefined} pattern does not exist as of Jan 2021,
+                // this test verifies if App works even if the field is missing.
+                view: {
+                  callback_id: 'view_callback_id',
+                },
+              },
+            },
+            {
+              ...baseEvent,
+              body: {
                 type: 'view_closed',
                 channel: {},
                 user: {},
@@ -1155,7 +1196,7 @@ describe('App', () => {
           // Assert
           assert.equal(actionFn.callCount, 3);
           assert.equal(shortcutFn.callCount, 4);
-          assert.equal(viewFn.callCount, 2);
+          assert.equal(viewFn.callCount, 5);
           assert.equal(optionsFn.callCount, 2);
           assert.equal(ackFn.callCount, dummyReceiverEvents.length);
           assert(fakeErrorHandler.notCalled);

--- a/src/App.ts
+++ b/src/App.ts
@@ -800,7 +800,10 @@ function buildSource<IsEnterpriseInstall extends boolean>(
       )['body'];
 
       // When the app is installed using org-wide deployment, team property will be null
-      if (bodyAsActionOrOptionsOrViewActionOrShortcut.team !== null) {
+      if (
+        typeof bodyAsActionOrOptionsOrViewActionOrShortcut.team !== 'undefined' &&
+        bodyAsActionOrOptionsOrViewActionOrShortcut.team !== null
+      ) {
         return bodyAsActionOrOptionsOrViewActionOrShortcut.team.id;
       }
 
@@ -842,12 +845,18 @@ function buildSource<IsEnterpriseInstall extends boolean>(
         | SlackShortcutMiddlewareArgs
       )['body'];
 
-      if (bodyAsActionOrOptionsOrViewActionOrShortcut.enterprise !== undefined) {
+      if (
+        typeof bodyAsActionOrOptionsOrViewActionOrShortcut.enterprise !== 'undefined' &&
+        bodyAsActionOrOptionsOrViewActionOrShortcut.enterprise !== null
+      ) {
         return bodyAsActionOrOptionsOrViewActionOrShortcut.enterprise.id;
       }
 
       // When the app is installed using org-wide deployment, team property will be null
-      if (bodyAsActionOrOptionsOrViewActionOrShortcut.team !== null) {
+      if (
+        typeof bodyAsActionOrOptionsOrViewActionOrShortcut.team !== 'undefined' &&
+        bodyAsActionOrOptionsOrViewActionOrShortcut.team !== null
+      ) {
         return bodyAsActionOrOptionsOrViewActionOrShortcut.team.enterprise_id;
       }
 


### PR DESCRIPTION
###  Summary

This pull request fixes both #726 and #729 by improving the null/undefined check logic for `enterprise` field in payloads.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).