### PR TITLE
Fix check for is_enterprise_install for slash commands

### DIFF
--- a/src/App.spec.ts
+++ b/src/App.spec.ts
@@ -683,6 +683,7 @@ describe('App', () => {
               ...baseEvent,
               body: {
                 command: '/COMMAND_NAME',
+                is_enterprise_install: 'false',
               },
             },
             {

--- a/src/App.ts
+++ b/src/App.ts
@@ -927,8 +927,8 @@ function isBodyWithTypeEnterpriseInstall(body: AnyMiddlewareArgs['body'], type: 
     }
   }
   // command payloads have this property set as a string
-  if (body.is_enterprise_install === 'true') {
-    return true;
+  if (typeof body.is_enterprise_install === 'string') {
+    return body.is_enterprise_install === 'true';
   }
   // all remaining types have a boolean property
   if (body.is_enterprise_install !== undefined) {


### PR DESCRIPTION
###  Summary

Describe the goal of this PR. Mention any related Issue numbers.

### Requirements (place an `x` in each `[ ]`)

* [X ] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [ X] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).

Not sure yet when or why this suddenly started failing in the past couple days, but this fixes an issue I ran into today where "is_enterprise_install" === "false", but still passes a truthiness check further down the code path.

I posted an issue originally here: https://github.com/slackapi/bolt-js/issues/737