### PR TITLE
Add thread_ts to AppMentionEvent interface

### DIFF
--- a/src/middleware/builtin.spec.ts
+++ b/src/middleware/builtin.spec.ts
@@ -745,6 +745,7 @@ const appMentionEvent: AppMentionEvent = {
   ts: '123.123',
   channel: 'C1234567',
   event_ts: '123.123',
+  thread_ts: '123.123',
 };
 
 const botMessageEvent: MessageEvent = {

--- a/src/middleware/builtin.spec.ts
+++ b/src/middleware/builtin.spec.ts
@@ -740,6 +740,7 @@ const validCommandPayload: SlashCommand = {
 
 const appMentionEvent: AppMentionEvent = {
   type: 'app_mention',
+  username: 'USERNAME',
   user: 'U1234567',
   text: 'this is my message',
   ts: '123.123',

--- a/src/types/events/base-events.ts
+++ b/src/types/events/base-events.ts
@@ -146,6 +146,7 @@ export interface AppMentionEvent {
   ts: string;
   channel: string;
   event_ts: string;
+  thread_ts: string;
 }
 
 // TODO: this event doesn't use the envelope. write test cases to make sure its works without breaking, and figure out

--- a/src/types/events/base-events.ts
+++ b/src/types/events/base-events.ts
@@ -141,7 +141,10 @@ export interface AppHomeOpenedEvent {
 // of `ts`
 export interface AppMentionEvent {
   type: 'app_mention';
-  user: string;
+  subtype?: string;
+  bot_id?: string;
+  username: string;
+  user?: string;
   text: string;
   ts: string;
   channel: string;


### PR DESCRIPTION
###  Summary

Fixes #735.

Adds missing `thread_ts` to `AppMentionEvent` interface (resolving surfaced error due to changes in #709).

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).