### PR TITLE
Add channel to all MessageEvent interfaces

### DIFF
--- a/src/middleware/builtin.spec.ts
+++ b/src/middleware/builtin.spec.ts
@@ -755,6 +755,7 @@ const botMessageEvent: MessageEvent = {
   ts: '123.123',
   text: 'this is my message',
   bot_id: 'B1234567',
+  channel_type: 'channel',
 };
 
 const noop = () => Promise.resolve(undefined);

--- a/src/middleware/builtin.spec.ts
+++ b/src/middleware/builtin.spec.ts
@@ -750,6 +750,7 @@ const appMentionEvent: AppMentionEvent = {
 const botMessageEvent: MessageEvent = {
   type: 'message',
   subtype: 'bot_message',
+  channel: 'CHANNEL_ID',
   user: 'U1234567',
   ts: '123.123',
   text: 'this is my message',

--- a/src/types/events/message-events.ts
+++ b/src/types/events/message-events.ts
@@ -38,6 +38,7 @@ export interface BotMessageEvent {
   type: 'message';
   subtype: 'bot_message';
   channel: string;
+  channel_type: string;
   ts: string;
   text: string;
   bot_id: string;
@@ -55,12 +56,14 @@ export interface BotMessageEvent {
     user: string;
     ts: string;
   };
+  thread_ts?: string;
 }
 
 export interface EKMAccessDeniedMessageEvent {
   type: 'message';
   subtype: 'ekm_access_denied';
   channel: string;
+  channel_type: string;
   ts: string;
   text: string; // This will not have any meaningful content within
   user: 'UREVOKEDU';
@@ -70,6 +73,7 @@ export interface MeMessageEvent {
   type: 'message';
   subtype: 'me_message';
   channel: string;
+  channel_type: string;
   user: string;
   text: string;
   ts: string;
@@ -80,6 +84,7 @@ export interface MessageChangedEvent {
   subtype: 'message_changed';
   hidden: true;
   channel: string;
+  channel_type: string;
   ts: string;
   message: MessageEvent;
 }
@@ -112,20 +117,20 @@ export interface MessageRepliedEvent {
 
 export interface ThreadBroadcastMessageEvent {
   type: 'message';
-  subtype: undefined;
-  channel: string;
-  message: {
-    type: 'message';
-    subtype: 'thread_broadcast';
+  subtype: 'thread_broadcast';
+  text: string;
+  user: string;
+  ts: string;
+  thread_ts?: string;
+  root: (GenericMessageEvent | BotMessageEvent) & {
     thread_ts: string;
-    user: string;
-    ts: string;
-    root: (GenericMessageEvent | BotMessageEvent) & {
-      thread_ts: string;
-      reply_count: number;
-      replies: { user: string; ts: string }[];
-      // TODO: unread_count doesn't appear in any other message event types, is this really the only place its included?
-      unread_count?: number;
-    };
+    reply_count: number;
+    reply_users_count: number;
+    latest_reply: string;
+    reply_users: string[];
   };
+  client_msg_id: string;
+  channel: string;
+  event_ts: string;
+  channel_type: string;
 }

--- a/src/types/events/message-events.ts
+++ b/src/types/events/message-events.ts
@@ -37,6 +37,7 @@ export interface GenericMessageEvent {
 export interface BotMessageEvent {
   type: 'message';
   subtype: 'bot_message';
+  channel: string;
   ts: string;
   text: string;
   bot_id: string;
@@ -59,6 +60,7 @@ export interface BotMessageEvent {
 export interface EKMAccessDeniedMessageEvent {
   type: 'message';
   subtype: 'ekm_access_denied';
+  channel: string;
   ts: string;
   text: string; // This will not have any meaningful content within
   user: 'UREVOKEDU';
@@ -111,6 +113,7 @@ export interface MessageRepliedEvent {
 export interface ThreadBroadcastMessageEvent {
   type: 'message';
   subtype: undefined;
+  channel: string;
   message: {
     type: 'message';
     subtype: 'thread_broadcast';

--- a/types-tests/message.test-d.ts
+++ b/types-tests/message.test-d.ts
@@ -7,7 +7,7 @@ expectType<void>(app.message(async ({ message }) => {
   expectType<MessageEvent>(message);
 
   if (message.subtype === undefined) {
-    expectError(message.user);
+    expectError(message.channel_type);
   } else if (message.subtype === 'bot_message') {
     expectType<BotMessageEvent>(message);
   }


### PR DESCRIPTION
###  Summary

Fixes #736.

Adds missing `channel` prop to some lacking interfaces that make up `MessageEvent`.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).