### PR TITLE
Export Reaction Interfaces

### DIFF
--- a/src/types/events/base-events.ts
+++ b/src/types/events/base-events.ts
@@ -502,20 +502,20 @@ export interface PinRemovedEvent {
   event_ts: string;
 }
 
-interface ReactionMessageItem {
+export interface ReactionMessageItem {
   type: 'message';
   channel: string;
   ts: string;
 }
 
-interface ReactionFileItem {
+export interface ReactionFileItem {
   type: 'file';
   file: string;
 }
 
 // This type is deprecated.
 // See https://api.slack.com/changelog/2018-05-file-threads-soon-tread
-interface ReactionFileCommentItem {
+export interface ReactionFileCommentItem {
   type: 'file_comment';
   file_comment: string;
   file: string;


### PR DESCRIPTION
###  Summary

Accessing the "channel" type on event.item requires a type cast / type guard since multiple types exist. However, the types are not exported so this isn't possible.

#### Now:
```ts
app.event('reaction_added', async ({ event }) => {
        console.log(event.item.channel)
})
``` 
results in

```
Property 'channel' does not exist on type 'ReactionMessageItem | ReactionFileItem | ReactionFileCommentItem'.
  Property 'channel' does not exist on type 'ReactionFileItem'
```

#### After patch:

(preferred)
```ts
import { ReactionMessageItem } from '@slack/bolt' 
app.event('reaction_added', async ({ event }) => {
    if (reactionIsMessageItem(event.item)) {
        console.log(event.item.channel)
    }
})

function reactionIsMessageItem (reaction: ReactionMessageItem | ReactionFileItem | ReactionFileCommentItem): reaction is ReactionMessageItem {
    return !! (reaction as ReactionMessageItem).channel
}
```

or

```ts
import { ReactionMessageItem } from '@slack/bolt' 
app.event('reaction_added', async ({ event }) => {
    console.log(event.item.channel as ReactionMessageItem)
})
```

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).

---

Fixes https://github.com/slackapi/bolt-js/issues/765