### PR TITLE
Standardize fetchInstallation to use installQuery as argument

### DIFF
--- a/docs/_basic/authenticating_oauth.md
+++ b/docs/_basic/authenticating_oauth.md
@@ -38,15 +38,15 @@ const app = new App({
       }
       throw new Error('Failed saving installation data to installationStore');
     },
-    fetchInstallation: async (InstallQuery) => {
+    fetchInstallation: async (installQuery) => {
       // change the line below so it fetches from your database
-      if (InstallQuery.isEnterpriseInstall && InstallQuery.enterpriseId !== undefined) {
+      if (installQuery.isEnterpriseInstall && installQuery.enterpriseId !== undefined) {
         // org wide app installation lookup
-        return await database.get(InstallQuery.enterpriseId);
+        return await database.get(installQuery.enterpriseId);
       }
-      if (InstallQuery.teamId !== undefined) {
+      if (installQuery.teamId !== undefined) {
         // single team app installation lookup
-        return await database.get(InstallQuery.teamId);
+        return await database.get(installQuery.teamId);
       }
       throw new Error('Failed fetching installation');
     },

--- a/docs/_basic/ja_authenticating_oauth.md
+++ b/docs/_basic/ja_authenticating_oauth.md
@@ -37,15 +37,15 @@ const app = new App({
       }
       throw new Error('Failed saving installation data to installationStore');
     },
-    fetchInstallation: async (InstallQuery) => {
+    fetchInstallation: async (installQuery) => {
       // 実際のデータベースから取得するために、ここのコードを変更
-      if (InstallQuery.isEnterpriseInstall && InstallQuery.enterpriseId !== undefined) {
+      if (installQuery.isEnterpriseInstall && installQuery.enterpriseId !== undefined) {
         // OrG 全体へのインストール情報の参照
-        return await database.get(InstallQuery.enterpriseId);
+        return await database.get(installQuery.enterpriseId);
       }
-      if (InstallQuery.teamId !== undefined) {
+      if (installQuery.teamId !== undefined) {
         // 単独のワークスペースへのインストール情報の参照
-        return await database.get(InstallQuery.teamId);
+        return await database.get(installQuery.teamId);
       }
       throw new Error('Failed fetching installation');
     },

--- a/docs/_tutorials/ja_migration_v3.md
+++ b/docs/_tutorials/ja_migration_v3.md
@@ -28,19 +28,19 @@ installationStore: {
       // change the line below so it saves to your database
       return await database.set(installation.team.id, installation);
     },
-    fetchInstallation: async (InstallQuery) => {
+    fetchInstallation: async (installQuery) => {
       // change the line below so it fetches from your database
-      return await database.get(InstallQuery.teamId);
+      return await database.get(installQuery.teamId);
     },
     storeOrgInstallation: async (installation) => {
       // include this method if you want your app to support org wide installations
       // change the line below so it saves to your database
       return await database.set(installation.enterprise.id, installation);
     },
-    fetchOrgInstallation: async (InstallQuery) => {
+    fetchOrgInstallation: async (installQuery) => {
       // include this method if you want your app to support org wide installations
       // change the line below so it fetches from your database
-      return await database.get(InstallQuery.enterpriseId);
+      return await database.get(installQuery.enterpriseId);
     },
   },
 ```
@@ -59,15 +59,15 @@ installationStore: {
       }
       throw new Error('Failed saving installation data to installationStore');
     },
-    fetchInstallation: async (InstallQuery) => {
+    fetchInstallation: async (installQuery) => {
       // replace database.get so it fetches from your database
-      if (InstallQuery.isEnterpriseInstall && InstallQuery.enterpriseId !== undefined) {
+      if (installQuery.isEnterpriseInstall && installQuery.enterpriseId !== undefined) {
         // org wide app installation lookup
-        return await database.get(InstallQuery.enterpriseId);
+        return await database.get(installQuery.enterpriseId);
       }
-      if (InstallQuery.teamId !== undefined) {
+      if (installQuery.teamId !== undefined) {
         // single team app installation lookup
-        return await database.get(InstallQuery.teamId);
+        return await database.get(installQuery.teamId);
       }
       throw new Error('Failed fetching installation');
     },

--- a/docs/_tutorials/migration_v3.md
+++ b/docs/_tutorials/migration_v3.md
@@ -28,19 +28,19 @@ installationStore: {
       // change the line below so it saves to your database
       return await database.set(installation.team.id, installation);
     },
-    fetchInstallation: async (InstallQuery) => {
+    fetchInstallation: async (installQuery) => {
       // change the line below so it fetches from your database
-      return await database.get(InstallQuery.teamId);
+      return await database.get(installQuery.teamId);
     },
     storeOrgInstallation: async (installation) => {
       // include this method if you want your app to support org wide installations
       // change the line below so it saves to your database
       return await database.set(installation.enterprise.id, installation);
     },
-    fetchOrgInstallation: async (InstallQuery) => {
+    fetchOrgInstallation: async (installQuery) => {
       // include this method if you want your app to support org wide installations
       // change the line below so it fetches from your database
-      return await database.get(InstallQuery.enterpriseId);
+      return await database.get(installQuery.enterpriseId);
     },
   },
 ```
@@ -59,15 +59,15 @@ installationStore: {
       }
       throw new Error('Failed saving installation data to installationStore');
     },
-    fetchInstallation: async (InstallQuery) => {
+    fetchInstallation: async (installQuery) => {
       // replace database.get so it fetches from your database
-      if (InstallQuery.isEnterpriseInstall && InstallQuery.enterpriseId !== undefined) {
+      if (installQuery.isEnterpriseInstall && installQuery.enterpriseId !== undefined) {
         // org wide app installation lookup
-        return await database.get(InstallQuery.enterpriseId);
+        return await database.get(installQuery.enterpriseId);
       }
-      if (InstallQuery.teamId !== undefined) {
+      if (installQuery.teamId !== undefined) {
         // single team app installation lookup
-        return await database.get(InstallQuery.teamId);
+        return await database.get(installQuery.teamId);
       }
       throw new Error('Failed fetching installation');
     },


### PR DESCRIPTION
###  Summary

Currently, `fetchInstallation` uses `InstallQuery` as an argument, which suggests a class is being passed. 

This PR aligns all instances to use `installQuery` instead of `InstallQuery`, aligning with corresponding changes to the Node SDK.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).