### PR TITLE
Fix events documentation code sample to use event.user

### DIFF
--- a/docs/_basic/ja_listening_events.md
+++ b/docs/_basic/ja_listening_events.md
@@ -19,7 +19,7 @@ app.event('team_join', async ({ event, client }) => {
   try {
     const result = await client.chat.postMessage({
       channel: welcomeChannelId,
-      text: `Welcome to the team, <@${event.user.id}>! 🎉 You can introduce yourself in this channel.`
+      text: `Welcome to the team, <@${event.user}>! 🎉 You can introduce yourself in this channel.`
     });
     console.log(result);
   }

--- a/docs/_basic/listening_events.md
+++ b/docs/_basic/listening_events.md
@@ -20,7 +20,7 @@ app.event('team_join', async ({ event, client }) => {
     // Call chat.postMessage with the built-in client
     const result = await client.chat.postMessage({
       channel: welcomeChannelId,
-      text: `Welcome to the team, <@${event.user.id}>! 🎉 You can introduce yourself in this channel.`
+      text: `Welcome to the team, <@${event.user}>! 🎉 You can introduce yourself in this channel.`
     });
     console.log(result);
   }


### PR DESCRIPTION
###  Summary

The event documentation's code sample references `event.user.id` which is `undefined`. The user ID is available with `event.user`.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).