### PR TITLE
[#804] Fix AWS Lambda deploy guide using @vendia/serverless-express

### DIFF
--- a/docs/_deployments/aws-lambda.md
+++ b/docs/_deployments/aws-lambda.md
@@ -113,8 +113,10 @@ By default, Bolt listens for HTTP requests. In this section, we'll customize you
 First, install the [Serverless Express](https://github.com/vendia/serverless-express) module to transform Express HTTP requests to Lambda function events:
 
 ```bash
-npm install @vendia/serverless-express
+npm install --save @vendia/serverless-express
 ```
+
+> 💡 This guide requires version `4.x.x` or later.
 
 Next, update the [source code that imports your modules](https://github.com/slackapi/bolt-js-getting-started-app/blob/main/app.js#L1) in `app.js` to require Bolt's Express receiver and the AWS Serverless Express module:
 

--- a/docs/_deployments/ja_aws-lambda.md
+++ b/docs/_deployments/ja_aws-lambda.md
@@ -114,8 +114,10 @@ Bolt アプリを用意できました。次に AWS Lambda と Serverless Framew
 まず、[Serverless Express](https://github.com/vendia/serverless-express) モジュールをインストールします。このモジュールを使って Express HTTP リクエストを Lambda 関数のイベントに変換します。
 
 ```bash
-npm install @vendia/serverless-express
+npm install --save @vendia/serverless-express
 ```
+
+> 💡 このガイドはバージョン 4.x.x 以上を必要とします
 
 次に、`app.js` のソースコードのなかで[モジュールのインポートを行う部分](https://github.com/slackapi/bolt-js-getting-started-app/blob/main/app.js#L1)を編集し、Bolt の Express レシーバーと AWS Serverless Express モジュールを require します。
 
@@ -323,7 +325,7 @@ npx serverless deploy
 
 [aws-cli-configure]: https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-quickstart.html#cli-configure-quickstart-config
 [aws-cli-install]: https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html
-[aws-cli-output-format]: https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-quickstart.html#cli-configure-quickstart-format 
+[aws-cli-output-format]: https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-quickstart.html#cli-configure-quickstart-format
 [aws-cli-region]: https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-quickstart.html#cli-configure-quickstart-region
 [aws-iam-user]: https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-quickstart.html#cli-configure-quickstart-creds
 [aws-lambda]: https://aws.amazon.com/lambda/

--- a/examples/deploy-aws-lambda/package.json
+++ b/examples/deploy-aws-lambda/package.json
@@ -10,7 +10,7 @@
   "license": "MIT",
   "dependencies": {
     "@slack/bolt": "^3.2.0",
-    "aws-serverless-express": "^3.3.8"
+    "@vendia/serverless-express": "^4.3.2"
   },
   "devDependencies": {
     "serverless": "^2.13.0",


### PR DESCRIPTION
###  Summary

Fixes #804 

This pull request updates the AWS Lambda deployment guide and example to fix the error `serverlessExpress is not a fucntion`.

We accomplish this by updating the `@vendia/serverless-express` package version to be `4.x.x` or later. The earlier versions used the original `.createServer` and `.proxy` interface, while `>=4.0.0` introduced a new single function interface.

I've updated the documentation and example app to use the latest version. In the guide, I call out that we required `>=4.0.0` in case a developer uses an older version.

I've tested this locally using `serverless-offline` and on AWS Lambda.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).