### PR TITLE
Fix incomplete logged sentence in SocketModeReciever

### DIFF
--- a/src/receivers/SocketModeReceiver.ts
+++ b/src/receivers/SocketModeReceiver.ts
@@ -121,7 +121,7 @@ export default class SocketModeReceiver implements Receiver {
             throw new Error(err);
           }
         } else {
-          this.logger.error(`Tried to reach ${req.url} which isn't a`);
+          this.logger.error(`Tried to reach ${req.url} which isn't a valid route.`);
           // Return 404 because we don't support route
           res.writeHead(404, {});
           res.end(`route ${req.url} doesn't exist!`);


### PR DESCRIPTION
###  Summary

```patch
-this.logger.error(`Tried to reach ${req.url} which isn't a`);	
+this.logger.error(`Tried to reach ${req.url} which isn't a valid route.`);
```

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).