### PR TITLE
Commonize the HTML rendering for OAuth install path

### DIFF
--- a/src/receivers/ExpressReceiver.ts
+++ b/src/receivers/ExpressReceiver.ts
@@ -13,6 +13,7 @@ import { InstallProvider, CallbackOptions, InstallProviderOptions, InstallURLOpt
 import App from '../App';
 import { ReceiverAuthenticityError, ReceiverMultipleAckError, ReceiverInconsistentStateError } from '../errors';
 import { AnyMiddlewareArgs, Receiver, ReceiverEvent } from '../types';
+import { renderHtmlForInstallPath } from './render-html-for-install-path';
 
 // TODO: we throw away the key names for endpoints, so maybe we should use this interface. is it better for migrations?
 // if that's the reason, let's document that with a comment.
@@ -145,10 +146,7 @@ export default class ExpressReceiver implements Receiver {
             scopes: scopes!,
             userScopes: installerOptions.userScopes,
           });
-          res.send(`<a href=${url}><img alt=""Add to Slack"" height="40" width="139"
-              src="https://platform.slack-edge.com/img/add_to_slack.png"
-              srcset="https://platform.slack-edge.com/img/add_to_slack.png 1x,
-              https://platform.slack-edge.com/img/add_to_slack@2x.png 2x" /></a>`);
+          res.send(renderHtmlForInstallPath(url));
         } catch (error) {
           next(error);
         }

--- a/src/receivers/HTTPReceiver.ts
+++ b/src/receivers/HTTPReceiver.ts
@@ -8,6 +8,7 @@ import { InstallProvider, CallbackOptions, InstallProviderOptions, InstallURLOpt
 import { verify as verifySlackAuthenticity, BufferedIncomingMessage } from './verify-request';
 import App from '../App';
 import { Receiver, ReceiverEvent } from '../types';
+import { renderHtmlForInstallPath } from './render-html-for-install-path';
 import {
   ReceiverMultipleAckError,
   ReceiverInconsistentStateError,
@@ -388,7 +389,7 @@ export default class HTTPReceiver implements Receiver {
         const url = await installer.generateInstallUrl(installUrlOptions);
 
         // Generate HTML response body
-        const body = htmlForInstallPath(url);
+        const body = renderHtmlForInstallPath(url);
 
         // Serve a basic HTML page including the "Add to Slack" button.
         // Regarding headers:
@@ -431,22 +432,6 @@ function parseBody(req: BufferedIncomingMessage) {
     return parsedQs;
   }
   return JSON.parse(bodyAsString);
-}
-
-function htmlForInstallPath(addToSlackUrl: string) {
-  return `<html>
-      <body>
-        <a href=${addToSlackUrl}>
-          <img
-            alt="Add to Slack"
-            height="40"
-            width="139"
-            src="https://platform.slack-edge.com/img/add_to_slack.png"
-            srcset="https://platform.slack-edge.com/img/add_to_slack.png 1x, https://platform.slack-edge.com/img/add_to_slack@2x.png 2x"
-          />
-        </a>
-      </body>
-    </html>`;
 }
 
 // Option keys for tls.createServer() and tls.createSecureContext(), exclusive of those for http.createServer()

--- a/src/receivers/SocketModeReceiver.ts
+++ b/src/receivers/SocketModeReceiver.ts
@@ -6,6 +6,7 @@ import { InstallProvider, CallbackOptions, InstallProviderOptions, InstallURLOpt
 import { WebAPICallResult } from '@slack/web-api';
 import App from '../App';
 import { Receiver, ReceiverEvent } from '../types';
+import { renderHtmlForInstallPath } from './render-html-for-install-path';
 
 // TODO: we throw away the key names for endpoints, so maybe we should use this interface. is it better for migrations?
 // if that's the reason, let's document that with a comment.
@@ -113,10 +114,7 @@ export default class SocketModeReceiver implements Receiver {
               userScopes: installerOptions.userScopes,
             });
             res.writeHead(200, {});
-            res.end(`<html><body><a href=${url}><img alt=""Add to Slack"" height="40" width="139"
-                src="https://platform.slack-edge.com/img/add_to_slack.png"
-                srcset="https://platform.slack-edge.com/img/add_to_slack.png 1x,
-                https://platform.slack-edge.com/img/add_to_slack@2x.png 2x" /></a></body></html>`);
+            res.end(renderHtmlForInstallPath(url));
           } catch (err) {
             throw new Error(err);
           }

--- a/src/receivers/render-html-for-install-path.ts
+++ b/src/receivers/render-html-for-install-path.ts
@@ -1,0 +1,15 @@
+export function renderHtmlForInstallPath(addToSlackUrl: string) {
+  return `<html>
+      <body>
+        <a href=${addToSlackUrl}>
+          <img
+            alt="Add to Slack"
+            height="40"
+            width="139"
+            src="https://platform.slack-edge.com/img/add_to_slack.png"
+            srcset="https://platform.slack-edge.com/img/add_to_slack.png 1x, https://platform.slack-edge.com/img/add_to_slack@2x.png 2x"
+          />
+        </a>
+      </body>
+    </html>`;
+}


### PR DESCRIPTION
###  Summary

This pull request improves the internals of built-in receivers by commonizing duplicated code across the implementations.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).