### PR TITLE
Fix arguments type for App.start()

### DIFF
--- a/src/App.ts
+++ b/src/App.ts
@@ -400,7 +400,9 @@ export default class App {
    *
    * @param args receiver-specific start arguments
    */
-  public start(...args: Parameters<HTTPReceiver['start'] | SocketModeReceiver["start"]>): ReturnType<HTTPReceiver['start']> {
+  public start(
+    ...args: Parameters<HTTPReceiver['start'] | SocketModeReceiver['start']>
+  ): ReturnType<HTTPReceiver['start']> {
     return this.receiver.start(...args) as ReturnType<HTTPReceiver['start']>;
   }
 

--- a/src/App.ts
+++ b/src/App.ts
@@ -400,7 +400,7 @@ export default class App {
    *
    * @param args receiver-specific start arguments
    */
-  public start(...args: Parameters<HTTPReceiver['start']>): ReturnType<HTTPReceiver['start']> {
+  public start(...args: Parameters<HTTPReceiver['start'] | SocketModeReceiver["start"]>): ReturnType<HTTPReceiver['start']> {
     return this.receiver.start(...args) as ReturnType<HTTPReceiver['start']>;
   }
 


### PR DESCRIPTION
###  Summary

`app.start()` doesn't need any arguments if the socket mode receiver (socketMode: true) is used, so the type needs to be changed to support that

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).

Merges https://github.com/KhushrajRathod/slack-bolt/pull/2