### PR TITLE
Add missing message events & more type tests

### DIFF
--- a/src/types/events/index.ts
+++ b/src/types/events/index.ts
@@ -1,5 +1,14 @@
 export * from './base-events';
-export { BotMessageEvent, GenericMessageEvent } from './message-events';
+export {
+  BotMessageEvent,
+  GenericMessageEvent,
+  MessageRepliedEvent,
+  MeMessageEvent,
+  MessageDeletedEvent,
+  ThreadBroadcastMessageEvent,
+  MessageChangedEvent,
+  EKMAccessDeniedMessageEvent,
+} from './message-events';
 import { SlackEvent, BasicSlackEvent } from './base-events';
 import { StringIndexed } from '../helpers';
 import { SayFn } from '../utilities';

--- a/types-tests/command.test-d.ts
+++ b/types-tests/command.test-d.ts
@@ -1,0 +1,9 @@
+import { expectType } from 'tsd';
+import { App, SlashCommand } from '../dist';
+
+const app = new App({ token: 'TOKEN', signingSecret: 'Signing Secret' });
+
+expectType<void>(app.command('/hello', async ({ command }) => {
+  expectType<SlashCommand>(command);
+  await Promise.resolve(command);
+}));

--- a/types-tests/event.test-d.ts
+++ b/types-tests/event.test-d.ts
@@ -1,0 +1,20 @@
+import { expectNotType, expectType } from 'tsd';
+import { App, SlackEvent, AppMentionEvent, ReactionAddedEvent } from '..';
+
+const app = new App({ token: 'TOKEN', signingSecret: 'Signing Secret' });
+
+expectType<void>(
+  app.event('app_mention', async ({ event }) => {
+    expectType<AppMentionEvent>(event);
+    expectNotType<SlackEvent>(event);
+    await Promise.resolve(event);
+  })
+);
+
+expectType<void>(
+  app.event('reaction_added', async ({ event }) => {
+    expectType<ReactionAddedEvent>(event);
+    expectNotType<SlackEvent>(event);
+    await Promise.resolve(event);
+  })
+);

--- a/types-tests/message.test-d.ts
+++ b/types-tests/message.test-d.ts
@@ -1,14 +1,41 @@
-import { expectType } from 'tsd';
-import { App, MessageEvent, BotMessageEvent } from '../';
+import { expectNotType, expectType } from 'tsd';
+import { App, MessageEvent, BotMessageEvent, MessageRepliedEvent, MeMessageEvent, MessageDeletedEvent, ThreadBroadcastMessageEvent, MessageChangedEvent, EKMAccessDeniedMessageEvent } from '..';
 
 const app = new App({ token: 'TOKEN', signingSecret: 'Signing Secret' });
 
 expectType<void>(
+  // TODO: Resolve the event type when having subtype in a listener constraint
+  // app.message({pattern: 'foo', subtype: 'message_replied'}, async ({ message }) => {});
   app.message(async ({ message }) => {
     expectType<MessageEvent>(message);
 
     if (message.subtype === 'bot_message') {
       expectType<BotMessageEvent>(message);
+      expectNotType<MessageEvent>(message);
+    }
+    if (message.subtype === 'ekm_access_denied') {
+      expectType<EKMAccessDeniedMessageEvent>(message);
+      expectNotType<MessageEvent>(message);
+    }
+    if (message.subtype === 'me_message') {
+      expectType<MeMessageEvent>(message);
+      expectNotType<MessageEvent>(message);
+    }
+    if (message.subtype === 'message_replied') {
+      expectType<MessageRepliedEvent>(message);
+      expectNotType<MessageEvent>(message);
+    }
+    if (message.subtype === 'message_changed') {
+      expectType<MessageChangedEvent>(message);
+      expectNotType<MessageEvent>(message);
+    }
+    if (message.subtype === 'message_deleted') {
+      expectType<MessageDeletedEvent>(message);
+      expectNotType<MessageEvent>(message);
+    }
+    if (message.subtype === 'thread_broadcast') {
+      expectType<ThreadBroadcastMessageEvent>(message);
+      expectNotType<MessageEvent>(message);
     }
 
     await Promise.resolve(message);

--- a/types-tests/options.test-d.ts
+++ b/types-tests/options.test-d.ts
@@ -1,0 +1,38 @@
+import { expectType, expectNotType } from 'tsd';
+import { App, OptionsRequest, OptionsSource } from '../dist';
+
+const app = new App({ token: 'TOKEN', signingSecret: 'Signing Secret' });
+
+expectType<void>(app.options('action-id-or-callback-id', async ({ options }) => {
+  expectType<OptionsRequest<OptionsSource>>(options);
+  await Promise.resolve(options);
+}));
+
+// block_suggestion
+expectType<void>(app.options<'block_suggestion'>({ action_id: 'a' }, async ({ options }) => {
+  expectNotType<OptionsRequest<OptionsSource>>(options);
+  expectType<OptionsRequest<'block_suggestion'>>(options);
+  await Promise.resolve(options);
+}));
+// FIXME: app.options({ type: 'block_suggestion', action_id: 'a' } does not work
+
+// interactive_message (attachments)
+expectType<void>(app.options<'interactive_message'>({ callback_id: 'a' }, async ({ options }) => {
+  expectNotType<OptionsRequest<OptionsSource>>(options);
+  expectType<OptionsRequest<'interactive_message'>>(options);
+  await Promise.resolve(options);
+}));
+
+expectType<void>(app.options({ type: 'interactive_message', callback_id: 'a' }, async ({ options }) => {
+  // FIXME: the type should be OptionsRequest<'interactive_message'>
+  expectType<OptionsRequest<OptionsSource>>(options);
+  await Promise.resolve(options);
+}));
+
+// dialog_suggestion (dialog)
+expectType<void>(app.options<'dialog_suggestion'>({ callback_id: 'a' }, async ({ options }) => {
+  expectNotType<OptionsRequest<OptionsSource>>(options);
+  expectType<OptionsRequest<'dialog_suggestion'>>(options);
+  await Promise.resolve(options);
+}));
+// FIXME: app.options({ type: 'dialog_suggestion', callback_id: 'a' } does not work

--- a/types-tests/view.test-d.ts
+++ b/types-tests/view.test-d.ts
@@ -1,0 +1,33 @@
+import { expectType } from 'tsd';
+import { App, SlackViewAction, ViewOutput } from '..';
+
+const app = new App({ token: 'TOKEN', signingSecret: 'Signing Secret' });
+
+// view_submission
+expectType<void>(
+  app.view('modal-id', async ({ body, view }) => {
+    // TODO: the body can be more specific (ViewSubmitAction) here
+    expectType<SlackViewAction>(body);
+    expectType<ViewOutput>(view);
+    await Promise.resolve(view);
+  })
+);
+
+expectType<void>(
+  app.view({ type: 'view_submission', callback_id: 'modal-id' }, async ({ body, view }) => {
+    // TODO: the body can be more specific (ViewSubmitAction) here
+    expectType<SlackViewAction>(body);
+    expectType<ViewOutput>(view);
+    await Promise.resolve(view);
+  })
+);
+
+// view_closed
+expectType<void>(
+  app.view({ type: 'view_closed', callback_id: 'modal-id' }, async ({ body, view }) => {
+    // TODO: the body can be more specific (ViewClosedAction) here
+    expectType<SlackViewAction>(body);
+    expectType<ViewOutput>(view);
+    await Promise.resolve(view);
+  })
+);


### PR DESCRIPTION
###  Summary

This pull request adds a few subtyped message events to top-level exports (currently, only `BotMessageEvent` is available in `from `@slack/bolt`). Also, as the very first step for #826 improvements, I've added a few more tests with TODO comments.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).