### PR TITLE
fix(App): Can't catch async errors from `singleAuthorization`.

### DIFF
--- a/src/App.spec.ts
+++ b/src/App.spec.ts
@@ -60,6 +60,7 @@ describe('App', () => {
       it.only('should throws', async () => {
         // Arrange
         const error = new Error("An API error occurred: something's wrong");
+        const fakeLogger = createFakeLogger();
         const overrides = mergeOverrides(withNoopAppMetadata(), withUnsuccessfulBotUserFetchingWebClient(error));
         const App = await importApp(overrides); // eslint-disable-line  @typescript-eslint/naming-convention, no-underscore-dangle, id-blacklist, id-match
         const event: ReceiverEvent = {
@@ -73,11 +74,13 @@ describe('App', () => {
         };
 
         // Act
-        const app = new App({ token: '', signingSecret: '' });
+        const app = new App({ token: '', signingSecret: '', logger: fakeLogger });
 
         // Assert
         assert.equal(await app.processEvent(event).catch((e) => e as Error), error);
         assert.equal(await app.processEvent(event).catch((e) => e as Error), error); // retry
+        assert.equal(fakeLogger.warn.callCount, 2);
+        assert.equal(fakeLogger.error.callCount, 2);
       });
     });
     it('should succeed with an authorize callback', async () => {

--- a/src/App.spec.ts
+++ b/src/App.spec.ts
@@ -57,7 +57,7 @@ describe('App', () => {
     });
 
     describe('with unsuccessful single team authorization results', () => {
-      it.only('should throws', async () => {
+      it('should throws', async () => {
         // Arrange
         const error = new Error("An API error occurred: something's wrong");
         const fakeLogger = createFakeLogger();

--- a/src/App.ts
+++ b/src/App.ts
@@ -1064,7 +1064,8 @@ function singleAuthorization(
       identifiers =
         authorization.botUserId !== undefined && authorization.botId !== undefined
           ? { botUserId: authorization.botUserId, botId: authorization.botId }
-          : await client.auth.test({ token: authorization.botToken }).then((result) => {
+          : // While test is failing, the identifiers will not be assigned
+            await client.auth.test({ token: authorization.botToken }).then((result) => {
               return {
                 botUserId: result.user_id as string,
                 botId: result.bot_id as string,

--- a/src/App.ts
+++ b/src/App.ts
@@ -80,6 +80,7 @@ export interface AppOptions {
   clientOptions?: Pick<WebClientOptions, 'slackApiUrl'>;
   socketMode?: boolean;
   developerMode?: boolean;
+  tokenVerificationEnabled?: boolean;
 }
 
 export { LogLevel, Logger } from '@slack/logger';
@@ -210,6 +211,7 @@ export default class App {
     installerOptions = undefined,
     socketMode = undefined,
     developerMode = false,
+    tokenVerificationEnabled = true,
   }: AppOptions = {}) {
     // this.logLevel = logLevel;
     this.developerMode = developerMode;
@@ -354,7 +356,21 @@ export default class App {
           `token as well as authorize or oauth installer options were provided. ${tokenUsage}`,
         );
       }
-      this.authorize = singleAuthorization(this.client, { botId, botUserId, botToken: token });
+
+      if (botUserId !== undefined && botId !== undefined) {
+        this.authorize = ({ isEnterpriseInstall }) =>
+          Promise.resolve({
+            isEnterpriseInstall,
+            botId,
+            botUserId,
+          });
+      } else {
+        this.authorize = singleAuthorizeFactory({
+          client: this.client,
+          botToken: token,
+          tokenVerificationEnabled,
+        });
+      }
     } else if (authorize === undefined && !usingOauth) {
       throw new AppInitializationError(
         `No token, no authorize, and no oauth installer options provided. ${tokenUsage}`,
@@ -1052,28 +1068,42 @@ function defaultErrorHandler(logger: Logger): ErrorHandler {
   };
 }
 
-function singleAuthorization(
-  client: WebClient,
-  authorization: Partial<AuthorizeResult> & { botToken: Required<AuthorizeResult>['botToken'] },
-): Authorize<boolean> {
-  // TODO: warn when something needed isn't found
+function authTest(client: WebClient, token: string) {
+  return client.auth.test({ token }).then(({ user_id, bot_id }) => ({
+    botUserId: user_id as string,
+    botId: bot_id as string,
+  }));
+}
+
+interface SingleAuthorizeFactoryArgs {
+  client: WebClient;
+  tokenVerificationEnabled: boolean;
+  botToken: string;
+}
+
+function singleAuthorizeFactory({
+  client,
+  botToken,
+  tokenVerificationEnabled,
+}: SingleAuthorizeFactoryArgs): App['authorize'] {
   let identifiers: { botUserId: string; botId: string };
 
+  const authPromise = tokenVerificationEnabled ? authTest(client, botToken) : undefined;
+
   return async ({ isEnterpriseInstall }) => {
-    if (identifiers === undefined) {
-      identifiers =
-        authorization.botUserId !== undefined && authorization.botId !== undefined
-          ? { botUserId: authorization.botUserId, botId: authorization.botId }
-          : // While test is failing, the identifiers will not be assigned
-            await client.auth.test({ token: authorization.botToken }).then((result) => {
-              return {
-                botUserId: result.user_id as string,
-                botId: result.bot_id as string,
-              };
-            });
+    if (!identifiers) {
+      if (authPromise) {
+        identifiers = await authPromise;
+      } else {
+        identifiers = await authTest(client, botToken);
+      }
     }
 
-    return { isEnterpriseInstall, botToken: authorization.botToken, ...identifiers };
+    return {
+      isEnterpriseInstall,
+      botToken,
+      ...identifiers,
+    };
   };
 }
 


### PR DESCRIPTION
###  Summary

In `singleAuthorization`, errors from `client.auth.test` can't be catched.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).