### PR TITLE
Fix #496 Add clientOptions.logger option (and improvements to other attributes too)

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,2 +1,10 @@
 ignore:
   - "examples/"  # ignore examples folder and all its contents
+coverage:
+  status:
+    project:
+      default:
+        threshold: 2.0%
+    patch:
+      default:
+        target: 50%

--- a/src/App.ts
+++ b/src/App.ts
@@ -237,13 +237,21 @@ export default class App {
       this.logger.setLevel(this.logLevel);
     }
     this.errorHandler = defaultErrorHandler(this.logger);
-    this.clientOptions = {
-      agent,
-      // App propagates only the log level to WebClient as WebClient has its own logger
-      logLevel: this.logger.getLevel(),
-      tls: clientTls,
-      slackApiUrl: clientOptions !== undefined ? clientOptions.slackApiUrl : undefined,
-    };
+
+    this.clientOptions = clientOptions !== undefined ? clientOptions : {};
+    if (agent !== undefined && this.clientOptions.agent === undefined) {
+      this.clientOptions.agent = agent;
+    }
+    if (clientTls !== undefined && this.clientOptions.tls === undefined) {
+      this.clientOptions.tls = clientTls;
+    }
+    if (logLevel !== undefined && logger === undefined) {
+      // If the constructor has both, logLevel is ignored
+      this.clientOptions.logLevel = logLevel;
+    } else {
+      // Since v3.4, WebClient starts sharing loggger with App
+      this.clientOptions.logger = this.logger;
+    }
     // the public WebClient instance (app.client) - this one doesn't have a token
     this.client = new WebClient(undefined, this.clientOptions);
 

--- a/src/App.ts
+++ b/src/App.ts
@@ -246,9 +246,15 @@ export default class App {
       this.clientOptions.tls = clientTls;
     }
     if (logLevel !== undefined && logger === undefined) {
-      // If the constructor has both, logLevel is ignored
+      // only logLevel is passed
       this.clientOptions.logLevel = logLevel;
     } else {
+      if (logLevel !== undefined) {
+        // If the constructor has both, logLevel is ignored
+        this.logger.warn(
+          "As `logger` is passed as well, `logLevel` argument won't be used. Set the log level to the `logger` instance instead.",
+        );
+      }
       // Since v3.4, WebClient starts sharing loggger with App
       this.clientOptions.logger = this.logger;
     }


### PR DESCRIPTION
###  Summary

This pull request resolves #496 by passing `logger` to `WebClient` instance. Also, I've improved the initialization of other attributes.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).