### PR TITLE
Add more type tests related to #861

### DIFF
--- a/types-tests/message.test-d.ts
+++ b/types-tests/message.test-d.ts
@@ -1,5 +1,5 @@
-import { expectNotType, expectType } from 'tsd';
-import { App, MessageEvent, BotMessageEvent, MessageRepliedEvent, MeMessageEvent, MessageDeletedEvent, ThreadBroadcastMessageEvent, MessageChangedEvent, EKMAccessDeniedMessageEvent } from '..';
+import { expectNotType, expectType, expectError } from 'tsd';
+import { App, MessageEvent, GenericMessageEvent, BotMessageEvent, MessageRepliedEvent, MeMessageEvent, MessageDeletedEvent, ThreadBroadcastMessageEvent, MessageChangedEvent, EKMAccessDeniedMessageEvent } from '..';
 
 const app = new App({ token: 'TOKEN', signingSecret: 'Signing Secret' });
 
@@ -9,33 +9,62 @@ expectType<void>(
   app.message(async ({ message }) => {
     expectType<MessageEvent>(message);
 
+    message.channel; // the property access should compile
+
+    // The type here is still a union type of all the possible subtyped events.
+    // Thus, only the fields available for all the types can be resolved outside if/else statements.
+    expectError(message.user);
+
+    if (message.subtype === undefined) {
+      expectType<GenericMessageEvent>(message);
+      expectNotType<MessageEvent>(message);
+      message.user; // the property access should compile
+      message.channel; // the property access should compile
+      message.team; // the property access should compile
+    }
     if (message.subtype === 'bot_message') {
       expectType<BotMessageEvent>(message);
       expectNotType<MessageEvent>(message);
+      message.user; // the property access should compile
+      message.channel; // the property access should compile
     }
     if (message.subtype === 'ekm_access_denied') {
       expectType<EKMAccessDeniedMessageEvent>(message);
       expectNotType<MessageEvent>(message);
+      message.user; // the property access should compile
+      message.channel; // the property access should compile
     }
     if (message.subtype === 'me_message') {
       expectType<MeMessageEvent>(message);
       expectNotType<MessageEvent>(message);
+      message.user; // the property access should compile
+      message.channel; // the property access should compile
     }
     if (message.subtype === 'message_replied') {
       expectType<MessageRepliedEvent>(message);
       expectNotType<MessageEvent>(message);
+      message.channel; // the property access should compile
+      message.message; // the property access should compile
     }
     if (message.subtype === 'message_changed') {
       expectType<MessageChangedEvent>(message);
       expectNotType<MessageEvent>(message);
+      message.channel; // the property access should compile
+      message.message; // the property access should compile
     }
     if (message.subtype === 'message_deleted') {
       expectType<MessageDeletedEvent>(message);
       expectNotType<MessageEvent>(message);
+      message.channel; // the property access should compile
+      message.ts; // the property access should compile
     }
     if (message.subtype === 'thread_broadcast') {
       expectType<ThreadBroadcastMessageEvent>(message);
       expectNotType<MessageEvent>(message);
+      message.channel; // the property access should compile
+      message.thread_ts; // the property access should compile
+      message.ts; // the property access should compile
+      message.root; // the property access should compile
     }
 
     await Promise.resolve(message);


### PR DESCRIPTION
###  Summary

This pull request adds more type tests demonstrating how the payload types in `app.message` listeners work. 

related to #861 

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).