### PR TITLE
Fix #718 add tokenVerificationEnabled flag to App constructor

### DIFF
--- a/src/App.spec.ts
+++ b/src/App.spec.ts
@@ -235,6 +235,33 @@ describe('App', () => {
       assert.strictEqual(clientOptions.slackApiUrl, options.slackApiUrl);
       assert.strictEqual(LogLevel.ERROR, options.logLevel, 'override logLevel');
     });
+    it('should not perform auth.test API call if tokenVerificationEnabled is false', async () => {
+      // Arrange
+      const fakeConstructor = sinon.fake();
+      const overrides = mergeOverrides(withNoopAppMetadata(), {
+        '@slack/web-api': {
+          WebClient: class {
+            constructor() {
+              fakeConstructor(...arguments);
+            }
+            public auth = {
+              test: () => {
+                throw new Error('This API method call should not be performed');
+              },
+            };
+          },
+        },
+      });
+
+      const App = await importApp(overrides); // eslint-disable-line  @typescript-eslint/naming-convention,
+      const app = new App({
+        token: 'xoxb-completely-invalid-token',
+        signingSecret: 'invalid-one',
+        tokenVerificationEnabled: false,
+      });
+      // Assert
+      assert.instanceOf(app, App);
+    });
     // TODO: tests for ignoreSelf option
     // TODO: tests for logger and logLevel option
     // TODO: tests for providing botId and botUserId options


### PR DESCRIPTION
###  Summary

This pull request resolves #718 by introducing a new flag in the `App` constructor. See the issue for details.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).