### PR TITLE
WIP: Add type parameter of event subtype for app.message listeners #796

### DIFF
--- a/src/App.ts
+++ b/src/App.ts
@@ -29,6 +29,7 @@ import {
   SlackActionMiddlewareArgs,
   SlackCommandMiddlewareArgs,
   SlackEventMiddlewareArgs,
+  SlackSubtypedEventMiddlewareArgs,
   SlackOptionsMiddlewareArgs,
   SlackShortcutMiddlewareArgs,
   SlackViewMiddlewareArgs,
@@ -470,9 +471,16 @@ export default class App {
 
   // TODO: just make a type alias for Middleware<SlackEventMiddlewareArgs<'message'>>
   // TODO: maybe remove the first two overloads
-  public message(...listeners: Middleware<SlackEventMiddlewareArgs<'message'>>[]): void;
-  public message(pattern: string | RegExp, ...listeners: Middleware<SlackEventMiddlewareArgs<'message'>>[]): void;
-  public message(...patternsOrMiddleware: (string | RegExp | Middleware<SlackEventMiddlewareArgs<'message'>>)[]): void {
+  public message<Subtype extends string | undefined = '*'>(
+    ...listeners: Middleware<SlackSubtypedEventMiddlewareArgs<'message', Subtype>>[]
+  ): void;
+  public message<Subtype extends string | undefined = '*'>(
+    pattern: string | RegExp,
+    ...listeners: Middleware<SlackSubtypedEventMiddlewareArgs<'message', Subtype>>[]
+  ): void;
+  public message<Subtype extends string | undefined = '*'>(
+    ...patternsOrMiddleware: (string | RegExp | Middleware<SlackSubtypedEventMiddlewareArgs<'message', Subtype>>)[]
+  ): void {
     const messageMiddleware = patternsOrMiddleware.map((patternOrMiddleware) => {
       if (typeof patternOrMiddleware === 'string' || util.types.isRegExp(patternOrMiddleware)) {
         return matchMessage(patternOrMiddleware);

--- a/types-tests/message.test-d.ts
+++ b/types-tests/message.test-d.ts
@@ -4,8 +4,6 @@ import { App, MessageEvent, GenericMessageEvent, BotMessageEvent, MessageReplied
 const app = new App({ token: 'TOKEN', signingSecret: 'Signing Secret' });
 
 expectType<void>(
-  // TODO: Resolve the event type when having subtype in a listener constraint
-  // app.message({pattern: 'foo', subtype: 'message_replied'}, async ({ message }) => {});
   app.message(async ({ message }) => {
     expectType<MessageEvent>(message);
 
@@ -67,6 +65,32 @@ expectType<void>(
       message.root; // the property access should compile
     }
 
+    await Promise.resolve(message);
+  }),
+);
+
+// Resolve the event type when having subtype in a listener constraint
+// app.message<'message_replied'>('foo', async ({ message }) => {});
+
+expectType<void>(
+  app.message<'thread_broadcast'>('foo', async ({ message }) => {
+    expectNotType<MessageEvent>(message);
+    expectType<ThreadBroadcastMessageEvent>(message);
+    message.channel; // the property access should compile
+    message.thread_ts; // the property access should compile
+    message.ts; // the property access should compile
+    message.root; // the property access should compile
+    await Promise.resolve(message);
+  }),
+);
+expectType<void>(
+  // no subtype in the event payload
+  app.message<undefined>('foo', async ({ message }) => {
+    expectNotType<MessageEvent>(message);
+    expectType<GenericMessageEvent>(message);
+    message.user; // the property access should compile
+    message.channel; // the property access should compile
+    message.team; // the property access should compile
     await Promise.resolve(message);
   }),
 );


### PR DESCRIPTION
###  Summary

This pull request shows a possible improvement for #796 use case - better support for message event subtypes in TypeScript. I'm still wondering if there may be a better solution than this one. I would love to get inputs and feedback from anyone who is interested in this topic.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).