### PR TITLE
Fix a few array field definition errors in TypeScript

### DIFF
--- a/src/types/actions/block-action.spec.ts
+++ b/src/types/actions/block-action.spec.ts
@@ -1,0 +1,180 @@
+// tslint:disable:no-implicit-dependencies
+import { assert } from 'chai';
+import {
+  BlockAction,
+  MultiStaticSelectAction,
+  MultiChannelsSelectAction,
+  MultiUsersSelectAction,
+  MultiConversationsSelectAction,
+} from './block-action';
+
+describe('block-action action types', () => {
+  it('should be compatible with block_actions payloads', () => {
+    const payload: BlockAction = {
+      type: 'block_actions',
+      user: {
+        id: 'W111',
+        name: 'seratch',
+        team_id: 'T111',
+      },
+      api_app_id: 'A02',
+      token: 'Shh_its_a_seekrit',
+      container: {
+        type: 'message',
+        text: 'The contents of the original message where the action originated',
+      },
+      trigger_id: '12466734323.1395872398',
+      team: {
+        id: 'T111',
+        domain: 'foo',
+        enterprise_id: 'E111',
+        enterprise_name: 'Acme Corp',
+      },
+      enterprise: {
+        id: 'E111',
+        name: 'Acme Corp',
+      },
+      is_enterprise_install: false,
+      response_url: 'https://www.postresponsestome.com/T123567/1509734234',
+      // as of April 2021, actions have only one element though
+      actions: [
+        {
+          type: 'multi_conversations_select',
+          block_id: 'b',
+          action_id: 'multi_conversations_select-action',
+          selected_conversations: ['C111', 'C222'],
+          action_ts: '1618009079.687263',
+        },
+        {
+          type: 'multi_conversations_select',
+          block_id: 'b',
+          action_id: 'multi_conversations_select-action',
+          selected_conversations: ['C111', 'C222'],
+          action_ts: '1618009079.687263',
+        },
+      ],
+    };
+    assert.equal(payload.actions.length, 2);
+  });
+  it('should be compatible with multi_users_select payloads', () => {
+    const payload: MultiUsersSelectAction = {
+      type: 'multi_users_select',
+      block_id: 'b',
+      action_id: 'a',
+      action_ts: '111',
+      selected_users: ['W111', 'W222'],
+      initial_users: ['W111', 'W222'],
+    };
+    assert.equal(payload.selected_users.length, 2);
+    assert.equal(payload.initial_users?.length, 2);
+  });
+  it('should be compatible with multi_conversations_select payloads', () => {
+    const payload: MultiConversationsSelectAction = {
+      type: 'multi_conversations_select',
+      block_id: 'b',
+      action_id: 'a',
+      action_ts: '111',
+      selected_conversations: ['C111', 'C222'],
+      initial_conversations: ['C111', 'C222'],
+    };
+    assert.equal(payload.selected_conversations.length, 2);
+    assert.equal(payload.initial_conversations?.length, 2);
+  });
+  it('should be compatible with multi_channels_select payloads', () => {
+    const payload: MultiChannelsSelectAction = {
+      type: 'multi_channels_select',
+      block_id: 'b',
+      action_id: 'a',
+      action_ts: '111',
+      selected_channels: ['C111', 'C222'],
+      initial_channels: ['C111', 'C222'],
+    };
+    assert.equal(payload.selected_channels.length, 2);
+    assert.equal(payload.initial_channels?.length, 2);
+  });
+});
+
+describe('block-action element types', () => {
+  it('should be compatible with multi_static_select payloads', () => {
+    const payload: MultiStaticSelectAction = {
+      type: 'multi_static_select',
+      block_id: 'b',
+      action_id: 'a',
+      action_ts: '111',
+      selected_options: [
+        {
+          text: {
+            type: 'plain_text',
+            text: '*this is plain_text text*',
+            emoji: true,
+          },
+          value: 'value-0',
+        },
+        {
+          text: {
+            type: 'plain_text',
+            text: '*this is plain_text text*',
+            emoji: true,
+          },
+          value: 'value-1',
+        },
+      ],
+      initial_options: [
+        {
+          text: {
+            type: 'plain_text',
+            text: '*this is plain_text text*',
+            emoji: true,
+          },
+          value: 'value-0',
+        },
+        {
+          text: {
+            type: 'plain_text',
+            text: '*this is plain_text text*',
+            emoji: true,
+          },
+          value: 'value-1',
+        },
+      ],
+    };
+    assert.equal(payload.selected_options.length, 2);
+    assert.equal(payload.initial_options?.length, 2);
+  });
+  it('should be compatible with multi_users_select payloads', () => {
+    const payload: MultiUsersSelectAction = {
+      type: 'multi_users_select',
+      block_id: 'b',
+      action_id: 'a',
+      action_ts: '111',
+      selected_users: ['W111', 'W222'],
+      initial_users: ['W111', 'W222'],
+    };
+    assert.equal(payload.selected_users.length, 2);
+    assert.equal(payload.initial_users?.length, 2);
+  });
+  it('should be compatible with multi_conversations_select payloads', () => {
+    const payload: MultiConversationsSelectAction = {
+      type: 'multi_conversations_select',
+      block_id: 'b',
+      action_id: 'a',
+      action_ts: '111',
+      selected_conversations: ['C111', 'C222'],
+      initial_conversations: ['C111', 'C222'],
+    };
+    assert.equal(payload.selected_conversations.length, 2);
+    assert.equal(payload.initial_conversations?.length, 2);
+  });
+  it('should be compatible with multi_channels_select payloads', () => {
+    const payload: MultiChannelsSelectAction = {
+      type: 'multi_channels_select',
+      block_id: 'b',
+      action_id: 'a',
+      action_ts: '111',
+      selected_channels: ['C111', 'C222'],
+      initial_channels: ['C111', 'C222'],
+    };
+    assert.equal(payload.selected_channels.length, 2);
+    assert.equal(payload.initial_channels?.length, 2);
+  });
+});

--- a/src/types/actions/block-action.ts
+++ b/src/types/actions/block-action.ts
@@ -65,13 +65,11 @@ export interface StaticSelectAction extends BasicElementAction<'static_select'> 
  * An action from a multi select menu with static options
  */
 export interface MultiStaticSelectAction extends BasicElementAction<'multi_static_select'> {
-  selected_options: [
-    {
-      text: PlainTextElement;
-      value: string;
-    },
-  ];
-  initial_options?: [Option];
+  selected_options: {
+    text: PlainTextElement;
+    value: string;
+  }[];
+  initial_options?: Option[];
   placeholder?: PlainTextElement;
   confirm?: Confirmation;
 }
@@ -90,8 +88,8 @@ export interface UsersSelectAction extends BasicElementAction<'users_select'> {
  * An action from a multi select menu with user list
  */
 export interface MultiUsersSelectAction extends BasicElementAction<'multi_users_select'> {
-  selected_users: [string];
-  initial_users?: [string];
+  selected_users: string[];
+  initial_users?: string[];
   placeholder?: PlainTextElement;
   confirm?: Confirmation;
 }
@@ -110,8 +108,8 @@ export interface ConversationsSelectAction extends BasicElementAction<'conversat
  * An action from a multi select menu with conversations list
  */
 export interface MultiConversationsSelectAction extends BasicElementAction<'multi_conversations_select'> {
-  selected_conversations: [string];
-  initial_conversations?: [string];
+  selected_conversations: string[];
+  initial_conversations?: string[];
   placeholder?: PlainTextElement;
   confirm?: Confirmation;
 }
@@ -130,8 +128,8 @@ export interface ChannelsSelectAction extends BasicElementAction<'channels_selec
  * An action from a multi select menu with channels list
  */
 export interface MultiChannelsSelectAction extends BasicElementAction<'multi_channels_select'> {
-  selected_channels: [string];
-  initial_channels?: [string];
+  selected_channels: string[];
+  initial_channels?: string[];
   placeholder?: PlainTextElement;
   confirm?: Confirmation;
 }
@@ -151,8 +149,8 @@ export interface ExternalSelectAction extends BasicElementAction<'external_selec
  * An action from a multi select menu with external data source
  */
 export interface MultiExternalSelectAction extends BasicElementAction<'multi_external_select'> {
-  selected_options?: [Option];
-  initial_options?: [Option];
+  selected_options?: Option[];
+  initial_options?: Option[];
   placeholder?: PlainTextElement;
   min_query_length?: number;
   confirm?: Confirmation;
@@ -211,7 +209,7 @@ export interface PlainTextInputAction extends BasicElementAction<'plain_text_inp
  */
 export interface BlockAction<ElementAction extends BasicElementAction = BlockElementAction> {
   type: 'block_actions';
-  actions: [ElementAction];
+  actions: ElementAction[];
   team: {
     id: string;
     domain: string;

--- a/src/types/actions/interactive-message.spec.ts
+++ b/src/types/actions/interactive-message.spec.ts
@@ -1,0 +1,53 @@
+// tslint:disable:no-implicit-dependencies
+import { assert } from 'chai';
+import { InteractiveMessage, ButtonClick } from './interactive-message';
+
+describe('interactive-message action types', () => {
+  it('should be compatible with block_actions payloads', () => {
+    const payload: InteractiveMessage<ButtonClick> = {
+      type: 'interactive_message',
+      actions: [
+        {
+          name: 'foo',
+          type: 'button',
+          value: 'bar',
+        },
+        {
+          name: 'foo',
+          type: 'button',
+          value: 'bar',
+        },
+      ],
+      callback_id: 'id',
+      enterprise: {
+        id: 'E111',
+        name: 'test-org',
+      },
+      team: {
+        id: 'T111',
+        domain: 'team-domain',
+        enterprise_id: 'E111',
+        enterprise_name: 'test-org',
+      },
+      channel: {
+        id: 'C111',
+        name: 'random',
+      },
+      user: {
+        id: 'W111',
+        name: 'seratch',
+        team_id: 'T111',
+      },
+      action_ts: '111.222',
+      message_ts: '222.333',
+      attachment_id: 'XXX',
+      token: 'verificationt-oken',
+      is_app_unfurl: false,
+      original_message: {},
+      response_url: 'https://hooks.slack.com/xxx',
+      trigger_id: '1111111',
+      is_enterprise_install: false,
+    };
+    assert.equal(payload.actions.length, 2);
+  });
+});

--- a/src/types/actions/interactive-message.ts
+++ b/src/types/actions/interactive-message.ts
@@ -32,7 +32,7 @@ export interface MenuSelect {
 export interface InteractiveMessage<Action extends InteractiveAction = InteractiveAction> {
   type: 'interactive_message';
   callback_id: string;
-  actions: [Action];
+  actions: Action[];
   team: {
     id: string;
     domain: string;


### PR DESCRIPTION
###  Summary

This pull request resolves a few type errors in block_actions & interactive_message payloads. As these are obvious bugs, we should not keep the backward compatibility with the types.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).