### PR TITLE
Google Cloud Functions Receiver

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,7 @@ export { default as ExpressReceiver, ExpressReceiverOptions } from './receivers/
 export { default as SocketModeReceiver, SocketModeReceiverOptions } from './receivers/SocketModeReceiver';
 export { default as HTTPReceiver, HTTPReceiverOptions } from './receivers/HTTPReceiver';
 export { default as AwsLambdaReceiver, AwsLambdaReceiverOptions } from './receivers/AwsLambdaReceiver';
+export { default as GCPFunctionReceiver, GCPFunctionReceiverOptions } from './receivers/GCPFunctionReceiver';
 
 export * from './errors';
 export * from './middleware/builtin';

--- a/src/receivers/GCPFunctionReceiver.spec.ts
+++ b/src/receivers/GCPFunctionReceiver.spec.ts
@@ -1,0 +1,396 @@
+/* eslint @typescript-eslint/naming-convention: off */
+import { Response, Request } from 'express';
+import sinon from 'sinon';
+import { ConsoleLogger } from '@slack/logger';
+import { assert } from 'chai';
+import 'mocha';
+import { default as GCPFunctionReceiver, isSignatureValid, parseRequestBody } from './GCPFunctionReceiver';
+import crypto from 'crypto';
+import rewiremock from 'rewiremock';
+import { WebClientOptions } from '@slack/web-api';
+import { ReceiverMultipleAckError } from '../errors';
+
+function mockResponse() {
+  return {
+    status: sinon.stub<Parameters<Response['status']>, Response>().returnsThis(),
+    send: sinon.stub<Parameters<Response['send']>, Response>().returnsThis(),
+    json: sinon.stub<Parameters<Response['json']>, Response>().returnsThis(),
+  };
+}
+
+function mockInteractionRequest() {
+  const timestamp = Math.floor(Date.now() / 1000);
+  const body =
+    'payload=%7B%22type%22%3A%22shortcut%22%2C%22token%22%3A%22fixed-value%22%2C%22action_ts%22%3A%221612879511.716075%22%2C%22team%22%3A%7B%22id%22%3A%22T111%22%2C%22domain%22%3A%22domain-value%22%2C%22enterprise_id%22%3A%22E111%22%2C%22enterprise_name%22%3A%22Sandbox+Org%22%7D%2C%22user%22%3A%7B%22id%22%3A%22W111%22%2C%22username%22%3A%22primary-owner%22%2C%22team_id%22%3A%22T111%22%7D%2C%22is_enterprise_install%22%3Afalse%2C%22enterprise%22%3A%7B%22id%22%3A%22E111%22%2C%22name%22%3A%22Kaz+SDK+Sandbox+Org%22%7D%2C%22callback_id%22%3A%22bolt-js-aws-lambda-shortcut%22%2C%22trigger_id%22%3A%22111.222.xxx%22%7D';
+  const signature = crypto.createHmac('sha256', 'my-secret').update(`v0:${timestamp}:${body}`).digest('hex');
+  return {
+    headers: {
+      'content-type': 'application/x-www-form-urlencoded',
+      'x-slack-request-timestamp': `${timestamp}`,
+      'x-slack-signature': `v0=${signature}`,
+    },
+    rawBody: Buffer.from(body),
+  };
+}
+
+describe('GCPFunctionReceiver', function () {
+  it('should instantiate with default logger', async () => {
+    const receiver = new GCPFunctionReceiver({
+      signingSecret: 'my-secret',
+    });
+    assert.instanceOf(receiver.logger, ConsoleLogger);
+  });
+
+  it('should have start method', async () => {
+    const receiver = new GCPFunctionReceiver({
+      signingSecret: 'my-secret',
+    });
+    const handler = await receiver.start();
+    assert.isNotNull(handler);
+  });
+
+  it('should have stop method', async () => {
+    const receiver = new GCPFunctionReceiver({
+      signingSecret: 'my-secret',
+    });
+    assert.isNotOk(await receiver.stop());
+  });
+
+  it('should throw if request is missing rawBody', async () => {
+    const receiver = new GCPFunctionReceiver({
+      signingSecret: 'my-secret',
+    });
+
+    const handler = receiver.toHandler();
+    try {
+      await handler({} as Request, mockResponse() as any);
+    } catch (e) {
+      assert.instanceOf(e, Error);
+    }
+  });
+
+  it('should accept events', async () => {
+    const receiver = new GCPFunctionReceiver({
+      signingSecret: 'my-secret',
+      logger: sinon.createStubInstance(ConsoleLogger),
+    });
+    const handler = receiver.toHandler();
+    const timestamp = Math.floor(Date.now() / 1000);
+    const body = JSON.stringify({
+      token: 'fixed-value',
+      team_id: 'T111',
+      enterprise_id: 'E111',
+      api_app_id: 'A111',
+      event: {
+        client_msg_id: '977a7fa8-c9b3-4b51-a0b6-3b6c647e2165',
+        type: 'app_mention',
+        text: '<@U222> test',
+        user: 'W111',
+        ts: '1612879521.002100',
+        team: 'T111',
+        channel: 'C111',
+        event_ts: '1612879521.002100',
+      },
+      type: 'event_callback',
+      event_id: 'Ev111',
+      event_time: 1612879521,
+      authorizations: [
+        {
+          enterprise_id: 'E111',
+          team_id: 'T111',
+          user_id: 'W111',
+          is_bot: true,
+          is_enterprise_install: false,
+        },
+      ],
+      is_ext_shared_channel: false,
+      event_context: '1-app_mention-T111-C111',
+    });
+    const signature = crypto.createHmac('sha256', 'my-secret').update(`v0:${timestamp}:${body}`).digest('hex');
+    const request = {
+      headers: {
+        'content-type': 'application/json',
+        'x-slack-request-timestamp': `${timestamp}`,
+        'x-slack-signature': `v0=${signature}`,
+      },
+      rawBody: Buffer.from(body),
+    };
+    const response1 = mockResponse();
+    await handler(request as any, response1 as any);
+    assert.isTrue(response1.status.calledWithExactly(404));
+    assert.isTrue(response1.send.calledWithExactly(''));
+
+    const App = await importApp();
+    const app = new App({
+      token: 'xoxb-',
+      receiver: receiver,
+    });
+    app.event('app_mention', async ({}) => {});
+    const response2 = mockResponse();
+    await handler(request as any, response2 as any);
+    assert.isTrue(response2.send.calledWithExactly(''));
+  });
+
+  it('should accept interactivity requests', async () => {
+    const receiver = new GCPFunctionReceiver({
+      signingSecret: () => 'my-secret',
+      logger: sinon.createStubInstance(ConsoleLogger),
+    });
+    const handler = receiver.toHandler();
+    const response1 = mockResponse();
+    await handler(mockInteractionRequest() as any, response1 as any);
+    assert.isTrue(response1.status.calledWithExactly(404));
+    assert.isTrue(response1.send.calledWithExactly(''));
+    const App = await importApp();
+    const app = new App({
+      token: 'xoxb-',
+      receiver: receiver,
+    });
+    app.shortcut('bolt-js-aws-lambda-shortcut', async ({ ack }) => {
+      await ack();
+    });
+    const response2 = mockResponse();
+    await handler(mockInteractionRequest() as any, response2 as any);
+    assert.isTrue(response2.send.calledWithExactly(''));
+  });
+
+  it('should accept slash commands', async () => {
+    const receiver = new GCPFunctionReceiver({
+      signingSecret: () => Promise.resolve('my-secret'),
+      logger: sinon.createStubInstance(ConsoleLogger),
+    });
+    const handler = receiver.toHandler();
+    const timestamp = Math.floor(Date.now() / 1000);
+    const body =
+      'token=fixed-value&team_id=T111&team_domain=domain-value&channel_id=C111&channel_name=random&user_id=W111&user_name=primary-owner&command=%2Fhello-bolt-js&text=&api_app_id=A111&is_enterprise_install=false&enterprise_id=E111&enterprise_name=Sandbox+Org&response_url=https%3A%2F%2Fhooks.slack.com%2Fcommands%2FT111%2F111%2Fxxx&trigger_id=111.222.xxx';
+    const signature = crypto.createHmac('sha256', 'my-secret').update(`v0:${timestamp}:${body}`).digest('hex');
+    const request = {
+      headers: {
+        'content-type': 'application/x-www-form-urlencoded',
+        'x-slack-request-timestamp': `${timestamp}`,
+        'x-slack-signature': `v0=${signature}`,
+      },
+      rawBody: Buffer.from(body),
+    };
+    const response1 = mockResponse();
+    await handler(request as any, response1 as any);
+    assert.isTrue(response1.status.calledWithExactly(404));
+    assert.isTrue(response1.send.calledWithExactly(''));
+    const App = await importApp();
+    const app = new App({
+      token: 'xoxb-',
+      receiver: receiver,
+    });
+    app.command('/hello-bolt-js', async ({ ack }) => {
+      await ack('string response');
+      try {
+        await ack();
+      } catch (e) {
+        assert.instanceOf(e, ReceiverMultipleAckError);
+      }
+    });
+    const response2 = mockResponse();
+    await handler(request as any, response2 as any);
+    assert.isTrue(response2.send.calledWithExactly('string response'));
+  });
+
+  it('should handle json ack', async () => {
+    const receiver = new GCPFunctionReceiver({
+      signingSecret: 'my-secret',
+      logger: sinon.createStubInstance(ConsoleLogger),
+    });
+    const App = await importApp();
+    const app = new App({
+      token: 'xoxb-',
+      receiver: receiver,
+    });
+    const ackResponse = { ack: true };
+    app.shortcut('bolt-js-aws-lambda-shortcut', async ({ ack }) => {
+      await ack(ackResponse as any);
+    });
+    const response1 = mockResponse();
+    await receiver.toHandler()(mockInteractionRequest() as any, response1 as any);
+    assert.deepEqual(response1.json.firstCall.args[0], ackResponse);
+  });
+
+  it('should handle exceptions while processing events', async () => {
+    const receiver = new GCPFunctionReceiver({
+      signingSecret: 'my-secret',
+      logger: sinon.createStubInstance(ConsoleLogger),
+    });
+    const App = await importApp();
+    const app = new App({
+      token: 'xoxb-',
+      receiver: receiver,
+    });
+    app.processEvent = () => {
+      throw new Error();
+    };
+    app.shortcut('bolt-js-aws-lambda-shortcut', async () => {});
+    const response1 = mockResponse();
+    await receiver.toHandler()(mockInteractionRequest() as any, response1 as any);
+    assert.isTrue(response1.status.calledWithExactly(500));
+    assert.isTrue(response1.send.calledWithExactly('Internal server error'));
+  });
+
+  it('should accept ssl check', async () => {
+    const receiver = new GCPFunctionReceiver({
+      signingSecret: 'my-secret',
+    });
+
+    const handler = receiver.toHandler();
+    const response1 = mockResponse();
+    await handler(
+      {
+        headers: { 'content-type': 'application/json' },
+        rawBody: Buffer.from(JSON.stringify({ ssl_check: true })),
+      } as any,
+      response1 as any,
+    );
+    assert.isTrue(response1.send.calledWithExactly(''));
+  });
+
+  it('should accept url verification', async () => {
+    const receiver = new GCPFunctionReceiver({
+      signingSecret: 'my-secret',
+    });
+
+    const handler = receiver.toHandler();
+    const body = JSON.stringify({ challenge: 'challenge', type: 'url_verification' });
+    const timestamp = Math.floor(Date.now() / 1000);
+    const signature = crypto.createHmac('sha256', 'my-secret').update(`v0:${timestamp}:${body}`).digest('hex');
+    const request = {
+      headers: {
+        'content-type': 'application/json',
+        'x-slack-request-timestamp': `${timestamp}`,
+        'x-slack-signature': `v0=${signature}`,
+      },
+      rawBody: Buffer.from(body),
+    };
+    const response1 = mockResponse();
+    await handler(request as any, response1 as any);
+    assert.deepEqual(response1.json.firstCall.args[0], { challenge: 'challenge' });
+  });
+
+  it('should handle bad signature', async () => {
+    const receiver = new GCPFunctionReceiver({
+      signingSecret: 'wrong-secret',
+      logger: sinon.createStubInstance(ConsoleLogger),
+    });
+
+    const handler = receiver.toHandler();
+    const body = JSON.stringify({ challenge: 'challenge', type: 'url_verification' });
+    const timestamp = Math.floor(Date.now() / 1000);
+    const signature = crypto.createHmac('sha256', 'my-secret').update(`v0:${timestamp}:${body}`).digest('hex');
+    const request = {
+      headers: {
+        'content-type': 'application/json',
+        'x-slack-request-timestamp': `${timestamp}`,
+        'x-slack-signature': `v0=${signature}`,
+      },
+      rawBody: Buffer.from(body),
+    };
+    const response1 = mockResponse();
+    await handler(request as any, response1 as any);
+    assert.isTrue(response1.status.calledWithExactly(401));
+    assert.isTrue(response1.send.calledWithExactly(''));
+  });
+
+  describe('isSignatureValid', () => {
+    it('should handle missing signature/timestamp', () => {
+      const logger = sinon.createStubInstance(ConsoleLogger);
+      assert.isFalse(isSignatureValid('secret', '', undefined, undefined, logger));
+      assert.equal(logger.warn.firstCall.args[0], 'request signing verification failed. Some headers are missing.');
+
+      assert.isFalse(isSignatureValid('secret', '', 'signature', undefined, logger));
+      assert.equal(logger.warn.secondCall.args[0], 'request signing verification failed. Some headers are missing.');
+    });
+
+    it('should handle bad timestamp', () => {
+      const logger = sinon.createStubInstance(ConsoleLogger);
+      assert.isFalse(isSignatureValid('secret', '', 'signature', 'undefined', logger));
+      assert.isTrue(logger.warn.calledWithExactly('request signing verification failed. Timestamp is invalid.'));
+    });
+
+    it('should handle expired timestamp', () => {
+      const logger = sinon.createStubInstance(ConsoleLogger);
+      assert.isFalse(isSignatureValid('secret', '', 'signature', Math.floor(Date.now() / 1000) - 60 * 10, logger));
+      assert.isTrue(logger.warn.calledWithExactly('request signing verification failed. Timestamp is too old.'));
+    });
+  });
+
+  describe('parseRequestBody', () => {
+    it('should handle malformed body', () => {
+      const logger = sinon.createStubInstance(ConsoleLogger);
+      assert.deepEqual(parseRequestBody('"', 'application/json', logger), {});
+      assert.isTrue(logger.warn.calledWithExactly('Unable to parse body'));
+    });
+  });
+});
+
+export interface Override {
+  [packageName: string]: {
+    [exportName: string]: any;
+  };
+}
+
+export function mergeOverrides(...overrides: Override[]): Override {
+  let currentOverrides: Override = {};
+  for (const override of overrides) {
+    currentOverrides = mergeObjProperties(currentOverrides, override);
+  }
+  return currentOverrides;
+}
+
+function mergeObjProperties(first: Override, second: Override): Override {
+  const merged: Override = {};
+  const props = Object.keys(first).concat(Object.keys(second));
+  for (const prop of props) {
+    if (second[prop] === undefined && first[prop] !== undefined) {
+      merged[prop] = first[prop];
+    } else if (first[prop] === undefined && second[prop] !== undefined) {
+      merged[prop] = second[prop];
+    } else {
+      // second always overwrites the first
+      merged[prop] = { ...first[prop], ...second[prop] };
+    }
+  }
+  return merged;
+}
+
+// Composable overrides
+function withNoopWebClient(): Override {
+  return {
+    '@slack/web-api': {
+      WebClient: class {
+        public token?: string;
+        constructor(token?: string, _options?: WebClientOptions) {
+          this.token = token;
+        }
+        public auth = {
+          test: sinon.fake.resolves({
+            enterprise_id: 'E111',
+            team_id: 'T111',
+            bot_id: 'B111',
+            user_id: 'W111',
+          }),
+        };
+      },
+    },
+  };
+}
+
+function withNoopAppMetadata(): Override {
+  return {
+    '@slack/web-api': {
+      addAppMetadata: sinon.fake(),
+    },
+  };
+}
+
+// Loading the system under test using overrides
+async function importApp(
+  overrides: Override = mergeOverrides(withNoopAppMetadata(), withNoopWebClient()),
+): Promise<typeof import('../App').default> {
+  return (await rewiremock.module(() => import('../App'), overrides)).default;
+}

--- a/src/receivers/GCPFunctionReceiver.ts
+++ b/src/receivers/GCPFunctionReceiver.ts
@@ -1,0 +1,210 @@
+import type { Request, Response } from 'express';
+import type { Logger } from '@slack/logger';
+import { ConsoleLogger, LogLevel } from '@slack/logger';
+import crypto from 'crypto';
+import querystring from 'querystring';
+import tsscmp from 'tsscmp';
+import App from '../App';
+import { Receiver, ReceiverEvent } from '../types';
+import { ReceiverMultipleAckError } from '../errors';
+
+export interface GCPFunctionReceiverOptions {
+  signingSecret: string | (() => string | PromiseLike<string>);
+  logger?: Logger;
+  logLevel?: LogLevel;
+}
+
+/*
+ * Receiver implementation for Google Cloud Functions w/ Http Triggers
+ *
+ * Note that this receiver does not support Slack OAuth flow.
+ * For OAuth flow endpoints, deploy another Lambda function built with ExpressReceiver.
+ */
+export default class GCPFunctionReceiver implements Receiver {
+  private app?: App;
+
+  public readonly logger: Logger;
+
+  private readonly signingSecret: GCPFunctionReceiverOptions['signingSecret'];
+
+  constructor({ signingSecret, logger = undefined, logLevel = LogLevel.INFO }: GCPFunctionReceiverOptions) {
+    this.signingSecret = signingSecret;
+    this.logger =
+      logger ??
+      (() => {
+        const defaultLogger = new ConsoleLogger();
+        defaultLogger.setLevel(logLevel);
+        return defaultLogger;
+      })();
+  }
+
+  public init(app: App) {
+    this.app = app;
+  }
+
+  public async start() {
+    return Promise.resolve(this.toHandler());
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  public async stop() {
+    return Promise.resolve();
+  }
+
+  public toHandler() {
+    return async (request: Request, response: Response) => {
+      if (!hasRawBody(request)) {
+        throw new Error('GCPFunction interface missing Request.rawBody');
+      }
+
+      this.logger.debug(
+        'incoming:',
+        JSON.stringify({
+          body: request.body as unknown,
+          headers: request.headers,
+        }),
+      );
+
+      const rawBody = String(request.rawBody);
+      const body = parseRequestBody(rawBody, request.headers['content-type'], this.logger);
+
+      // ssl_check (for Slash Commands)
+      // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
+      if (body.ssl_check) {
+        response.send('');
+        return;
+      }
+
+      // request signature verification
+      const signingSecret = typeof this.signingSecret === 'string' ? this.signingSecret : await this.signingSecret();
+      if (
+        !isSignatureValid(
+          signingSecret,
+          rawBody,
+          request.headers['x-slack-signature'],
+          request.headers['x-slack-request-timestamp'],
+          this.logger,
+        )
+      ) {
+        response.status(401).send('');
+        return;
+      }
+
+      // url_verification (Events API)
+      if (body.type === 'url_verification') {
+        response.json({ challenge: body.challenge });
+        return;
+      }
+
+      // Setup ack timeout warning
+      const timeoutId = setTimeout(() => {
+        this.logger.error(
+          'An incoming event was not acknowledged within 3 seconds. ' +
+            'Ensure that the ack() argument is called in a listener.',
+        );
+      }, 3001);
+
+      // Structure the ReceiverEvent
+      let isAcknowledged = false;
+      let storedResponse: unknown;
+      const event: ReceiverEvent = {
+        ack: async (ackResponse) => {
+          if (isAcknowledged) {
+            throw new ReceiverMultipleAckError();
+          }
+          isAcknowledged = true;
+          clearTimeout(timeoutId);
+          if (typeof ackResponse === 'undefined' || ackResponse === null) {
+            storedResponse = '';
+          } else {
+            storedResponse = ackResponse;
+          }
+          return Promise.resolve();
+        },
+        body,
+      };
+
+      // Send the event to the app for processing
+      try {
+        await this.app?.processEvent(event);
+        if (storedResponse !== undefined) {
+          if (typeof storedResponse === 'string') {
+            response.send(storedResponse);
+            return;
+          }
+          response.json(storedResponse);
+          return;
+        }
+      } catch (err) {
+        this.logger.error('An unhandled error occurred while Bolt processed an event');
+        this.logger.debug(`Error details: ${String(err)}, storedResponse: ${String(storedResponse)}`);
+        response.status(500).send('Internal server error');
+        return;
+      }
+      response.status(404).send('');
+    };
+  }
+}
+
+export function parseRequestBody(stringBody: string, contentType: string | undefined | string[], logger: Logger) {
+  if (contentType === 'application/x-www-form-urlencoded') {
+    const parsedBody = querystring.parse(stringBody);
+
+    if (typeof parsedBody.payload === 'string') {
+      return JSON.parse(parsedBody.payload) as Record<string, unknown>;
+    }
+
+    return parsedBody;
+  }
+
+  try {
+    return JSON.parse(stringBody) as Record<string, unknown>;
+  } catch (e) {
+    logger.warn('Unable to parse body');
+    return {};
+  }
+}
+
+function hasRawBody(request: Request): request is Request & { rawBody: Buffer } {
+  return ((request as unknown) as { rawBody: unknown }).rawBody instanceof Buffer;
+}
+
+export function isSignatureValid(
+  signingSecret: string,
+  body: string,
+  signature: unknown,
+  requestTimestamp: unknown,
+  logger: Logger,
+) {
+  // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
+  if (!signature || !requestTimestamp) {
+    logger.warn('request signing verification failed. Some headers are missing.');
+    return false;
+  }
+
+  const ts = Number(requestTimestamp);
+  // eslint-disable-next-line no-restricted-globals
+  if (isNaN(ts)) {
+    logger.warn('request signing verification failed. Timestamp is invalid.');
+    return false;
+  }
+
+  // Divide current date to match Slack ts format
+  // Subtract 5 minutes from current time
+  const fiveMinutesAgo = Math.floor(Date.now() / 1000) - 60 * 5;
+
+  if (ts < fiveMinutesAgo) {
+    logger.warn('request signing verification failed. Timestamp is too old.');
+    return false;
+  }
+
+  const hmac = crypto.createHmac('sha256', signingSecret);
+  const [version, hash] = String(signature).split('=');
+  hmac.update(`${version}:${ts}:${body}`);
+
+  if (!tsscmp(hash, hmac.digest('hex'))) {
+    logger.warn('request signing verification failed. Signature mismatch.');
+    return false;
+  }
+  return true;
+}


### PR DESCRIPTION
###  Summary

Google Cloud Functions Receiver heavily adapted from `AwsLambdaReceiver` and `ExpressReceiver`.

### Example

```ts
import { App, GCPFunctionReceiver } from "@slack/bolt"

// initialize receiver
const receiver = new GCPFunctionReceiver({
  signingSecret: '...',
  // signingSecret: () => Promise.resolve('async secret is also supported')
})

// initialize app
const app = new App({ receiver })
// app.action(/* ... */)

// export http function handler
export const myGCPFunction = receiver.toHandler()
```

Note: calling `app.start()` is not necessary since we're not starting a web server.

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).