### PR TITLE
Fix #720 ack(options) does not compile in TypeScript

### DIFF
--- a/src/App.ts
+++ b/src/App.ts
@@ -571,14 +571,16 @@ export default class App {
     this.listeners.push([onlyCommands, matchCommandName(commandName), ...listeners] as Middleware<AnyMiddlewareArgs>[]);
   }
 
-  public options<Source extends OptionsSource = OptionsSource>(
+  public options<Source extends OptionsSource = 'block_suggestion'>(
     actionId: string | RegExp,
     ...listeners: Middleware<SlackOptionsMiddlewareArgs<Source>>[]
   ): void;
+  // TODO: reflect the type in constraits to Source
   public options<Source extends OptionsSource = OptionsSource>(
     constraints: ActionConstraints,
     ...listeners: Middleware<SlackOptionsMiddlewareArgs<Source>>[]
   ): void;
+  // TODO: reflect the type in constraits to Source
   public options<Source extends OptionsSource = OptionsSource>(
     actionIdOrConstraints: string | RegExp | ActionConstraints,
     ...listeners: Middleware<SlackOptionsMiddlewareArgs<Source>>[]

--- a/types-tests/options.test-d.ts
+++ b/types-tests/options.test-d.ts
@@ -1,38 +1,63 @@
-import { expectType, expectNotType } from 'tsd';
+import { expectType, expectNotType, expectError } from 'tsd';
 import { App, OptionsRequest, OptionsSource } from '../dist';
+import { Option } from '@slack/types';
 
 const app = new App({ token: 'TOKEN', signingSecret: 'Signing Secret' });
 
-expectType<void>(app.options('action-id-or-callback-id', async ({ options }) => {
-  expectType<OptionsRequest<OptionsSource>>(options);
+const blockSuggestionOptions: Option[] = [
+  {
+    "text": {
+      "type": "plain_text",
+      "text": "foo"
+    },
+    "value": "bar"
+  }
+];
+
+// set the default to block_suggestion
+expectType<void>(app.options('action-id-or-callback-id', async ({ options, ack }) => {
+  expectType<OptionsRequest<'block_suggestion'>>(options);
+  expectType<never>(options.callback_id);
+  options.block_id;
+  options.action_id;
+  // https://github.com/slackapi/bolt-js/issues/720
+  await ack({ options: blockSuggestionOptions });
   await Promise.resolve(options);
 }));
 
 // block_suggestion
-expectType<void>(app.options<'block_suggestion'>({ action_id: 'a' }, async ({ options }) => {
+expectType<void>(app.options<'block_suggestion'>({ action_id: 'a' }, async ({ options, ack }) => {
   expectNotType<OptionsRequest<OptionsSource>>(options);
   expectType<OptionsRequest<'block_suggestion'>>(options);
+  // https://github.com/slackapi/bolt-js/issues/720
+  await ack({ options: blockSuggestionOptions });
   await Promise.resolve(options);
 }));
 // FIXME: app.options({ type: 'block_suggestion', action_id: 'a' } does not work
 
 // interactive_message (attachments)
-expectType<void>(app.options<'interactive_message'>({ callback_id: 'a' }, async ({ options }) => {
+expectType<void>(app.options<'interactive_message'>({ callback_id: 'a' }, async ({ options, ack }) => {
   expectNotType<OptionsRequest<OptionsSource>>(options);
   expectType<OptionsRequest<'interactive_message'>>(options);
+  // https://github.com/slackapi/bolt-js/issues/720
+  expectError(ack({ options: blockSuggestionOptions }));
   await Promise.resolve(options);
 }));
 
-expectType<void>(app.options({ type: 'interactive_message', callback_id: 'a' }, async ({ options }) => {
+expectType<void>(app.options({ type: 'interactive_message', callback_id: 'a' }, async ({ options, ack }) => {
   // FIXME: the type should be OptionsRequest<'interactive_message'>
   expectType<OptionsRequest<OptionsSource>>(options);
+  // https://github.com/slackapi/bolt-js/issues/720
+  expectError(ack({ options: blockSuggestionOptions }));
   await Promise.resolve(options);
 }));
 
 // dialog_suggestion (dialog)
-expectType<void>(app.options<'dialog_suggestion'>({ callback_id: 'a' }, async ({ options }) => {
+expectType<void>(app.options<'dialog_suggestion'>({ callback_id: 'a' }, async ({ options, ack }) => {
   expectNotType<OptionsRequest<OptionsSource>>(options);
   expectType<OptionsRequest<'dialog_suggestion'>>(options);
+  // https://github.com/slackapi/bolt-js/issues/720
+  expectError(ack({ options: blockSuggestionOptions }));
   await Promise.resolve(options);
 }));
 // FIXME: app.options({ type: 'dialog_suggestion', callback_id: 'a' } does not work


### PR DESCRIPTION
###  Summary

This pull request resolves #720 

As most developers (perhaps 100%) handle only block_suggestion requests in `app.options` listeners. Thus, this pull request set the default Source to `block_suggestion` to ensure better developer experience in TypeScript.

If a developer would like to handle either `interactive_message` (user actions on attachments) or `dialog_suggestion` (the ones in legacy dialogs), the developer can have an explicit type parameter as below:

```typescript
app.options<'interactive_message'>({ callback_id: 'a' }, async ({ ack }) => {
  await ack();
});

app.options<'dialog_suggestion'>({ callback_id: 'a' }, async ({ ack }) => {
  await ack();
});
```

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).