### PR TITLE
Fix #497 Add types of state.values on modal submission

### DIFF
--- a/src/types/view/index.ts
+++ b/src/types/view/index.ts
@@ -1,4 +1,4 @@
-import { View } from '@slack/types';
+import { View, PlainTextElement } from '@slack/types';
 import { StringIndexed } from '../helpers';
 import { AckFn } from '../utilities';
 
@@ -116,10 +116,31 @@ export interface ViewWorkflowStepClosedAction extends ViewClosedAction {
   };
 }
 
+export interface ViewStateSelectedOption {
+  text: PlainTextElement;
+  value: string;
+}
+
+export interface ViewStateValue {
+  type: string;
+  value?: string | null;
+  selected_date?: string | null;
+  selected_time?: string | null;
+  selected_conversation?: string | null;
+  selected_channel?: string | null;
+  selected_user?: string | null;
+  selected_option?: ViewStateSelectedOption | null;
+  selected_conversations?: string[];
+  selected_channels?: string[];
+  selected_users?: string[];
+  selected_options?: ViewStateSelectedOption[];
+}
+
 export interface ViewOutput {
   id: string;
   callback_id: string;
   team_id: string;
+  app_installed_team_id?: string;
   app_id: string | null;
   bot_id: string;
   title: PlainTextElementOutput;
@@ -130,7 +151,7 @@ export interface ViewOutput {
   state: {
     values: {
       [blockId: string]: {
-        [actionId: string]: any; // TODO: a union of all the input elements' output payload
+        [actionId: string]: ViewStateValue;
       };
     };
   };

--- a/types-tests/view.test-d.ts
+++ b/types-tests/view.test-d.ts
@@ -31,3 +31,70 @@ expectType<void>(
     await Promise.resolve(view);
   })
 );
+
+const viewSubmissionPayload: ViewOutput = {
+  "id": "V111",
+  "team_id": "T111",
+  "type": "modal",
+  "blocks": [
+    {
+      "type": "divider",
+      "block_id": "+3ht"
+    }
+  ],
+  "private_metadata": "",
+  "callback_id": "",
+  "state": {
+    "values": {
+      "aPVYH": {
+        "g/t5": {
+          "type": "radio_buttons",
+          "selected_option": null
+        }
+      },
+      "1pSa": {
+        "h3R": {
+          "type": "multi_static_select",
+          "selected_options": []
+        }
+      },
+      "a/Rt": {
+        "zmPQ": {
+          "type": "plain_text_input",
+          "value": null
+        }
+      },
+      "7/wWO": {
+        "HdJj": {
+          "type": "plain_text_input",
+          "value": "test"
+        }
+      }
+    }
+  },
+  "hash": "1618378109.3ndA0Spf",
+  "title": {
+    "type": "plain_text",
+    "text": "Workplace check-in",
+    "emoji": true
+  },
+  "clear_on_close": false,
+  "notify_on_close": false,
+  "close": {
+    "type": "plain_text",
+    "text": "Cancel",
+    "emoji": true
+  },
+  "submit": {
+    "type": "plain_text",
+    "text": "Submit",
+    "emoji": true
+  },
+  "previous_view_id": null,
+  "root_view_id": "V1234567890",
+  "app_id": "A02",
+  "external_id": "",
+  "app_installed_team_id": "T5J4Q04QG",
+  "bot_id": "B00"
+};
+expectType<ViewOutput>(viewSubmissionPayload);


### PR DESCRIPTION
###  Summary

This pull request resolves #497 by adding complete types for the elements in `view.state.values` in `view_submission` payloads

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).