### PR TITLE
Docs: Fix example code for team_join event

### DIFF
--- a/docs/_basic/listening_events.md
+++ b/docs/_basic/listening_events.md
@@ -20,7 +20,7 @@ app.event('team_join', async ({ event, client }) => {
     // Call chat.postMessage with the built-in client
     const result = await client.chat.postMessage({
       channel: welcomeChannelId,
-      text: `Welcome to the team, <@${event.user}>! 🎉 You can introduce yourself in this channel.`
+      text: `Welcome to the team, <@${event.user.id}>! 🎉 You can introduce yourself in this channel.`
     });
     console.log(result);
   }


### PR DESCRIPTION
Thanks for this lib! When using example from the documentation I ran into a bug. It appeared the bug leaked into the chunk of code.

###  Summary

This PR improves documentation. The `team_join` event looks like `{ user: {id: 'U1234567', ...}, ... }` and not like `{ user: 'U1234567', ... }`.

Since this is a trivial change, I figured not to clone the repo and just fork it and create PR directly from the browser. I hope this is fine in such a trivial case.

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).