### PR TITLE
Fix #859 Improve the way to handle authorize fn errors in built-in receivers

### DIFF
--- a/src/App.ts
+++ b/src/App.ts
@@ -55,7 +55,7 @@ import {
   WorkflowStepEdit,
 } from './types';
 import { IncomingEventType, getTypeAndConversation, assertNever } from './helpers';
-import { CodedError, asCodedError, AppInitializationError, MultipleListenerError } from './errors';
+import { CodedError, asCodedError, AppInitializationError, MultipleListenerError, ErrorCode } from './errors';
 // eslint-disable-next-line import/order
 import allSettled = require('promise.allsettled'); // eslint-disable-line @typescript-eslint/no-require-imports
 // eslint-disable-next-line @typescript-eslint/no-require-imports, import/no-commonjs
@@ -692,7 +692,7 @@ export default class App {
     } catch (error) {
       const e = error as any;
       this.logger.warn('Authorization of incoming event did not succeed. No listeners will be called.');
-      e.code = 'slack_bolt_authorization_error';
+      e.code = ErrorCode.AuthorizationError;
       // disabling due to https://github.com/typescript-eslint/typescript-eslint/issues/1277
       // eslint-disable-next-line consistent-return
       return this.handleError(e);
@@ -907,7 +907,7 @@ export default class App {
 }
 
 function defaultErrorHandler(logger: Logger): ErrorHandler {
-  return (error) => {
+  return (error: CodedError) => {
     logger.error(error);
 
     return Promise.reject(error);

--- a/src/receivers/HTTPReceiver.ts
+++ b/src/receivers/HTTPReceiver.ts
@@ -15,6 +15,7 @@ import {
   ReceiverInconsistentStateError,
   HTTPReceiverDeferredRequestError,
   ErrorCode,
+  CodedError,
 } from '../errors';
 
 // Option keys for tls.createServer() and tls.createSecureContext(), exclusive of those for http.createServer()
@@ -406,6 +407,17 @@ export default class HTTPReceiver implements Receiver {
         }
       } catch (err) {
         const e = err as any;
+        if ('code' in e) {
+          // CodedError has code: string
+          const errorCode = (e as CodedError).code;
+          if (errorCode === ErrorCode.AuthorizationError) {
+            // authorize function threw an exception, which means there is no valid installation data
+            res.writeHead(401);
+            res.end();
+            isAcknowledged = true;
+            return;
+          }
+        }
         this.logger.error('An unhandled error occurred while Bolt processed an event');
         this.logger.debug(`Error details: ${e}, storedResponse: ${storedResponse}`);
         res.writeHead(500);


### PR DESCRIPTION
###  Summary

This pull request closes #859 by improving the error handling of `authorize` function failures. As described [here](https://github.com/slackapi/bolt-js/issues/859#issuecomment-809037463), the current implementation returns 500 Internal Server Error in the case and displays the following warn/error logs.

```
[WARN]  bolt-app Authorization of incoming event did not succeed. No listeners will be called.
[ERROR]  bolt-app Error: Failed fetching data from the Installation Store
    at new AuthorizationError (/path-to-app/node_modules/@slack/oauth/dist/errors.js:71:28)
    at InstallProvider.<anonymous> (/path-to-app/node_modules/@slack/oauth/dist/index.js:158:31)
    at step (/path-to-app/node_modules/@slack/oauth/dist/index.js:44:23)
    at Object.next (/path-to-app/node_modules/@slack/oauth/dist/index.js:25:53)
    at fulfilled (/path-to-app/node_modules/@slack/oauth/dist/index.js:16:58)
    at processTicksAndRejections (internal/process/task_queues.js:97:5) {
  code: 'slack_bolt_authorization_error'
}
[ERROR]   An unhandled error occurred while Bolt processed an event
[DEBUG]   Error details: Error: Failed fetching data from the Installation Store, storedResponse: undefined
[ERROR]   An incoming event was not acknowledged within 3 seconds. Ensure that the ack() argument is called in a listener.
```

As we recommend throwing an exception if there is no valid installation data in `fetchInstallation` method, this pattern should be handled as a normal case, not an internal server error.

This pull request fixes #364 too.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).