### PR TITLE
<Source>OptionsRequest interfaces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,7 @@
 
 # macOS
 .DS_Store
+
+# IDE
+.idea/
+

--- a/src/types/options/index.ts
+++ b/src/types/options/index.ts
@@ -54,17 +54,17 @@ export interface BlockOptionsRequest extends OptionsRequest<'block_suggestion'> 
   block_id: string;
   container: StringIndexed;
 }
-export interface DialogOptionsRequest extends OptionsRequest<'dialog_suggestion'> {
-  name: string;
-  callback_id: string;
-  action_ts: string;
-}
 export interface MessageOptionsRequest extends OptionsRequest<'interactive_message'> {
   name: string;
   callback_id: string;
   action_ts: string;
   message_ts: string;
   attachment_id: string;
+}
+export interface DialogOptionsRequest extends OptionsRequest<'dialog_suggestion'> {
+  name: string;
+  callback_id: string;
+  action_ts: string;
 }
 
 /**

--- a/src/types/options/index.ts
+++ b/src/types/options/index.ts
@@ -38,18 +38,6 @@ export interface OptionsRequest<Source extends OptionsSource = OptionsSource> ex
   };
   token: string;
 
-  name: Source extends 'interactive_message' | 'dialog_suggestion' ? string : never;
-  callback_id: Source extends 'interactive_message' | 'dialog_suggestion' ? string : never;
-  action_ts: Source extends 'interactive_message' | 'dialog_suggestion' ? string : never;
-
-  message_ts: Source extends 'interactive_message' ? string : never;
-  attachment_id: Source extends 'interactive_message' ? string : never;
-
-  api_app_id: Source extends 'block_suggestion' ? string : never;
-  action_id: Source extends 'block_suggestion' ? string : never;
-  block_id: Source extends 'block_suggestion' ? string : never;
-  container: Source extends 'block_suggestion' ? StringIndexed : never;
-
   // this appears in the block_suggestions schema, but we're not sure when its present or what its type would be
   app_unfurl?: any;
 
@@ -59,6 +47,24 @@ export interface OptionsRequest<Source extends OptionsSource = OptionsSource> ex
     id: string;
     name: string;
   };
+}
+export interface BlockOptionsRequest extends OptionsRequest<'block_suggestion'> {
+  api_app_id: string;
+  action_id: string;
+  block_id: string;
+  container: StringIndexed;
+}
+export interface DialogOptionsRequest extends OptionsRequest<'dialog_suggestion'> {
+  name: string;
+  callback_id: string;
+  action_ts: string;
+}
+export interface MessageOptionsRequest extends OptionsRequest<'interactive_message'> {
+  name: string;
+  callback_id: string;
+  action_ts: string;
+  message_ts: string;
+  attachment_id: string;
 }
 
 /**

--- a/src/types/options/index.ts
+++ b/src/types/options/index.ts
@@ -38,6 +38,18 @@ export interface OptionsRequest<Source extends OptionsSource = OptionsSource> ex
   };
   token: string;
 
+  name?: Source extends 'interactive_message' | 'dialog_suggestion' ? string : never;
+  callback_id?: Source extends 'interactive_message' | 'dialog_suggestion' ? string : never;
+  action_ts?: Source extends 'interactive_message' | 'dialog_suggestion' ? string : never;
+
+  message_ts?: Source extends 'interactive_message' ? string : never;
+  attachment_id?: Source extends 'interactive_message' ? string : never;
+
+  api_app_id?: Source extends 'block_suggestion' ? string : never;
+  action_id?: Source extends 'block_suggestion' ? string : never;
+  block_id?: Source extends 'block_suggestion' ? string : never;
+  container?: Source extends 'block_suggestion' ? StringIndexed : never;
+
   // this appears in the block_suggestions schema, but we're not sure when its present or what its type would be
   app_unfurl?: any;
 


### PR DESCRIPTION
###  Summary

The exported interface `OptionsRequest<OptionsSource>` cannot be used directly because it contains properties with type `never` which is not assignable. This PR fixes that issue by creating three interfaces which extend `OptionsRequest<OptionsSource>` (one for each possible options source).

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).