### PR TITLE
Fix #897 Add built-in fields to Context object type

### DIFF
--- a/src/types/middleware.ts
+++ b/src/types/middleware.ts
@@ -31,6 +31,40 @@ export interface Middleware<Args> {
   (args: Args & AllMiddlewareArgs): Promise<void>;
 }
 
-export interface Context extends StringIndexed {}
+/**
+ * Context object, which provides contextual information associated with an incoming requests.
+ * You can set any other custom attributes in global middleware as long as the key does not conflict with others.
+ */
+export interface Context extends StringIndexed {
+  /**
+   * A bot token, which starts with `xoxb-`.
+   * This value can be used by `say` (preferred over userToken),
+   */
+  botToken?: string; // used by `say` (preferred over userToken)
+  /**
+   * A bot token, which starts with `xoxp-`.
+   * This value can be used by `say` (overridden by botToken),
+   */
+  userToken?: string;
+  /**
+   * This app's bot ID in the installed workspace.
+   * This is required for `ignoreSelf` global middleware.
+   * see also: https://github.com/slackapi/bolt-js/issues/874
+   */
+  botId?: string;
+  /**
+   * This app's bot user ID in the installed workspace.
+   * This value is optional but allows `ignoreSelf` global middleware be more filter more than just message events.
+   */
+  botUserId?: string;
+  /**
+   * Workspace ID.
+   */
+  teamId?: string;
+  /**
+   * Enterprise Grid Organization ID.
+   */
+  enterpriseId?: string;
+}
 
 export type NextFn = () => Promise<void>;

--- a/src/types/middleware.ts
+++ b/src/types/middleware.ts
@@ -40,7 +40,7 @@ export interface Context extends StringIndexed {
    * A bot token, which starts with `xoxb-`.
    * This value can be used by `say` (preferred over userToken),
    */
-  botToken?: string; // used by `say` (preferred over userToken)
+  botToken?: string;
   /**
    * A bot token, which starts with `xoxp-`.
    * This value can be used by `say` (overridden by botToken),


### PR DESCRIPTION
###  Summary

This pull request adds the built-in fields in `Context` interface. The change does not bring any breaking changes. It just bring minor improvements for TypeScript users and better auto-completion in VS Code. Feedback / suggestions about the comments are welcome!

As I would like to know others' thoughts on this, this is still in draft stage. If other maintainers are fine with this, I will add this to v3.4 milestone.

This PR fixes #897 if it's merged.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).