### PR TITLE
Add blocks / attachments to app_mention event interface

### DIFF
--- a/src/types/events/base-events.ts
+++ b/src/types/events/base-events.ts
@@ -1,4 +1,4 @@
-import { View } from '@slack/types';
+import { View, MessageAttachment, KnownBlock, Block } from '@slack/types';
 import { MessageEvent as AllMessageEvents } from './message-events';
 
 /**
@@ -152,6 +152,8 @@ export interface AppMentionEvent {
   username: string;
   user?: string;
   text: string;
+  attachments?: MessageAttachment[];
+  blocks?: (KnownBlock | Block)[];
   ts: string;
   channel: string;
   event_ts: string;


### PR DESCRIPTION
###  Summary

In alignment with https://github.com/slackapi/java-slack-sdk/pull/739 , this pull request adds missing fields in app_mention event payload interface.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).