### PR TITLE
Fix #911 TypeScript error when using builtin onlyViewActions middleware

### DIFF
--- a/src/middleware/builtin.ts
+++ b/src/middleware/builtin.ts
@@ -13,8 +13,6 @@ import {
   SlackAction,
   SlackShortcut,
   SlashCommand,
-  ViewSubmitAction,
-  ViewClosedAction,
   SlackOptions,
   BlockSuggestion,
   InteractiveMessageSuggestion,
@@ -26,6 +24,7 @@ import {
   BlockElementAction,
   SlackViewAction,
   EventTypePattern,
+  ViewOutput,
 } from '../types';
 import { ActionConstraints, ViewConstraints, ShortcutConstraints } from '../App';
 import { ContextMissingPropertyError } from '../errors';
@@ -107,10 +106,7 @@ export const onlyEvents: Middleware<AnyMiddlewareArgs & { event?: SlackEvent }> 
 /**
  * Middleware that filters out any event that isn't a view_submission or view_closed event
  */
-export const onlyViewActions: Middleware<AnyMiddlewareArgs & { view?: ViewSubmitAction | ViewClosedAction }> = async ({
-  view,
-  next,
-}) => {
+export const onlyViewActions: Middleware<AnyMiddlewareArgs & { view?: ViewOutput }> = async ({ view, next }) => {
   // Filter out anything that doesn't have a view
   if (view === undefined) {
     return;

--- a/src/receivers/HTTPReceiver.ts
+++ b/src/receivers/HTTPReceiver.ts
@@ -4,6 +4,7 @@ import { ListenOptions } from 'net';
 import { parse as qsParse } from 'querystring';
 import { Logger, ConsoleLogger, LogLevel } from '@slack/logger';
 import { InstallProvider, CallbackOptions, InstallProviderOptions, InstallURLOptions } from '@slack/oauth';
+import { URL } from 'url';
 
 import { verify as verifySlackAuthenticity, BufferedIncomingMessage } from './verify-request';
 import App from '../App';

--- a/types-tests/middleware.test-d.ts
+++ b/types-tests/middleware.test-d.ts
@@ -1,0 +1,12 @@
+import App from '../src/App';
+import { onlyViewActions, onlyCommands } from '../src/middleware/builtin';
+
+const app = new App({ token: 'TOKEN', signingSecret: 'Signing Secret' });
+
+// https://github.com/slackapi/bolt-js/issues/911
+app.use(async (args) => {
+  onlyViewActions(args);
+});
+app.use(async (args) => {
+  onlyCommands(args);
+});


### PR DESCRIPTION
###  Summary

This pull request resolves #911. Refer to the issue for details.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).