### PR TITLE
Make API response types more specific utilizing the types in web-api 6.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@slack/oauth": "^2.0.0",
     "@slack/socket-mode": "^1.0.0",
     "@slack/types": "^2.0.0",
-    "@slack/web-api": "^6.0.0",
+    "@slack/web-api": "^6.2.3",
     "@types/express": "^4.16.1",
     "@types/node": ">=12",
     "@types/promise.allsettled": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   "dependencies": {
     "@slack/logger": "^3.0.0",
     "@slack/oauth": "^2.0.0",
-    "@slack/socket-mode": "^1.0.0",
+    "@slack/socket-mode": "^1.1.0",
     "@slack/types": "^2.0.0",
     "@slack/web-api": "^6.2.3",
     "@types/express": "^4.16.1",

--- a/src/WorkflowStep.ts
+++ b/src/WorkflowStep.ts
@@ -1,4 +1,11 @@
-import { WebAPICallResult, KnownBlock, Block } from '@slack/web-api';
+import {
+  KnownBlock,
+  Block,
+  ViewsOpenResponse,
+  WorkflowsUpdateStepResponse,
+  WorkflowsStepCompletedResponse,
+  WorkflowsStepFailedResponse,
+} from '@slack/web-api';
 import {
   Middleware,
   AllMiddlewareArgs,
@@ -55,19 +62,19 @@ export interface StepFailArguments {
 }
 
 export interface StepConfigureFn {
-  (params: StepConfigureArguments): Promise<WebAPICallResult>;
+  (params: StepConfigureArguments): Promise<ViewsOpenResponse>;
 }
 
 export interface StepUpdateFn {
-  (params?: StepUpdateArguments): Promise<WebAPICallResult>;
+  (params?: StepUpdateArguments): Promise<WorkflowsUpdateStepResponse>;
 }
 
 export interface StepCompleteFn {
-  (params?: StepCompleteArguments): Promise<WebAPICallResult>;
+  (params?: StepCompleteArguments): Promise<WorkflowsStepCompletedResponse>;
 }
 
 export interface StepFailFn {
-  (params: StepFailArguments): Promise<WebAPICallResult>;
+  (params: StepFailArguments): Promise<WorkflowsStepFailedResponse>;
 }
 
 export interface WorkflowStepConfig {

--- a/src/receivers/SocketModeReceiver.ts
+++ b/src/receivers/SocketModeReceiver.ts
@@ -3,7 +3,7 @@ import { SocketModeClient } from '@slack/socket-mode';
 import { createServer } from 'http';
 import { Logger, ConsoleLogger, LogLevel } from '@slack/logger';
 import { InstallProvider, CallbackOptions, InstallProviderOptions, InstallURLOptions } from '@slack/oauth';
-import { WebAPICallResult } from '@slack/web-api';
+import { AppsConnectionsOpenResponse } from '@slack/web-api';
 import App from '../App';
 import { Receiver, ReceiverEvent } from '../types';
 import { renderHtmlForInstallPath } from './render-html-for-install-path';
@@ -146,10 +146,8 @@ export default class SocketModeReceiver implements Receiver {
     this.app = app;
   }
 
-  public start(): Promise<void | WebAPICallResult> {
+  public start(): Promise<AppsConnectionsOpenResponse> {
     // start socket mode client
-    // TODO: We can update the returned type from WebAPICallResult to AppsConnectionsOpenResponse
-    // once we release a newer version of @slack/socket-mode relying on @slack/web-api 6.2
     return this.client.start();
   }
 

--- a/src/receivers/SocketModeReceiver.ts
+++ b/src/receivers/SocketModeReceiver.ts
@@ -148,6 +148,8 @@ export default class SocketModeReceiver implements Receiver {
 
   public start(): Promise<void | WebAPICallResult> {
     // start socket mode client
+    // TODO: We can update the returned type from WebAPICallResult to AppsConnectionsOpenResponse
+    // once we release a newer version of @slack/socket-mode relying on @slack/web-api 6.2
     return this.client.start();
   }
 

--- a/src/types/utilities.ts
+++ b/src/types/utilities.ts
@@ -1,4 +1,4 @@
-import { ChatPostMessageArguments, WebAPICallResult } from '@slack/web-api';
+import { ChatPostMessageArguments, ChatPostMessageResponse } from '@slack/web-api';
 
 // (issue#951) KnownKeys<ChatPostMessageArguments> no longer works in TypeScript 4.3
 type ChatPostMessageArgumentsKnownKeys =
@@ -26,7 +26,7 @@ export type SayArguments = Pick<ChatPostMessageArguments, Exclude<ChatPostMessag
 };
 
 export interface SayFn {
-  (message: string | SayArguments): Promise<WebAPICallResult>;
+  (message: string | SayArguments): Promise<ChatPostMessageResponse>;
 }
 
 export type RespondArguments = Pick<

--- a/types-tests/utilities.test-d.ts
+++ b/types-tests/utilities.test-d.ts
@@ -1,4 +1,6 @@
 import { App, InteractiveButtonClick } from '../';
+import { expectType } from 'tsd';
+import { ChatPostMessageResponse } from '@slack/web-api';
 
 const app = new App({ token: 'TOKEN', signingSecret: 'Signing Secret' });
 
@@ -10,7 +12,8 @@ app.action<InteractiveButtonClick>('my_callback_id', async ({ respond, say }) =>
   await respond({ delete_original: true });
 
   // Expect say to work with text
-  await say({ text: 'Some more text' });
+  const response = await say({ text: 'Some more text' });
+  expectType<ChatPostMessageResponse>(response);
 
   // sicne web-api v6.2, this is not an error anymore
   // Expect an error when calling say without text


### PR DESCRIPTION
###  Summary

This pull request updates a few parts of this library to utilize the newly introduced more specific API response types. As all the new types inherit `WebAPICallResult` interface, these change are backward-compatible.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).