### PR TITLE
Updated `ReactionRemovedEvent` type

### DIFF
--- a/src/types/events/base-events.ts
+++ b/src/types/events/base-events.ts
@@ -546,9 +546,7 @@ export interface ReactionRemovedEvent {
   user: string;
   reaction: string;
   item_user: string;
-  // TODO: incomplete, should be message | file | file comment (deprecated)
-  // https://api.slack.com/events/reaction_removed
-  item: {};
+  item: ReactionMessageItem | ReactionFileItem | ReactionFileCommentItem;
   event_ts: string;
 }
 

--- a/types-tests/event.test-d.ts
+++ b/types-tests/event.test-d.ts
@@ -1,5 +1,5 @@
 import { expectNotType, expectType } from 'tsd';
-import { App, SlackEvent, AppMentionEvent, ReactionAddedEvent } from '..';
+import { App, SlackEvent, AppMentionEvent, ReactionAddedEvent, ReactionRemovedEvent } from '..';
 
 const app = new App({ token: 'TOKEN', signingSecret: 'Signing Secret' });
 
@@ -14,6 +14,14 @@ expectType<void>(
 expectType<void>(
   app.event('reaction_added', async ({ event }) => {
     expectType<ReactionAddedEvent>(event);
+    expectNotType<SlackEvent>(event);
+    await Promise.resolve(event);
+  })
+);
+
+expectType<void>(
+  app.event('reaction_removed', async ({ event }) => {
+    expectType<ReactionRemovedEvent>(event);
     expectNotType<SlackEvent>(event);
     await Promise.resolve(event);
   })


### PR DESCRIPTION
###  Summary

Closes #917 

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).