### PR TITLE
Fix build:watch command in examples/getting-started-typescript

### DIFF
--- a/examples/getting-started-typescript/package.json
+++ b/examples/getting-started-typescript/package.json
@@ -5,7 +5,7 @@
   "main": "dist/app.js",
   "scripts": {
     "build": "tsc -p .",
-    "build:watch": "tsc -w -p ./src",
+    "build:watch": "tsc -w -p .",
     "start": "npm run build && node dist/app.js"
   },
   "license": "MIT",


### PR DESCRIPTION
###  Summary
(In examples/getting-started-typescript/package.json)
The path `./src` passed to the p option of `tsc` command is wrong.
Therefore, the following error occurs when using `build:watch` comamnd.

```
$ tsc -w -p ./src
error TS5057: Cannot find a tsconfig.json file at the specified directory: './src'.
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

So I changed it to the correct path where `tsconfig.json` exists.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).