### PR TITLE
Add a type test verifying #922 is resolved by #878

### DIFF
--- a/docs/_basic/ja_listening_responding_options.md
+++ b/docs/_basic/ja_listening_responding_options.md
@@ -22,7 +22,7 @@ app.options('external_action', async ({ options, ack }) => {
   if (results) {
     let options = [];
     // ack 応答 するために options 配列に情報をプッシュ
-    for (const result in results) {
+    for (const result of results) {
       options.push({
         "text": {
           "type": "plain_text",

--- a/docs/_basic/listening_responding_options.md
+++ b/docs/_basic/listening_responding_options.md
@@ -24,7 +24,7 @@ app.options('external_action', async ({ options, ack }) => {
   if (results) {
     let options = [];
     // Collect information in options array to send in Slack ack response
-    for (const result in results) {
+    for (const result of results) {
       options.push({
         "text": {
           "type": "plain_text",

--- a/types-tests/options.test-d.ts
+++ b/types-tests/options.test-d.ts
@@ -75,3 +75,38 @@ expectType<void>(
   }),
 );
 // FIXME: app.options({ type: 'dialog_suggestion', callback_id: 'a' } does not work
+
+const db = {
+  get: (_teamId: String) => { return [{ label: 'l', value: 'v' }]; },
+};
+
+expectType<void>(
+  // Take from https://slack.dev/bolt-js/concepts#options
+  // Example of responding to an external_select options request
+  app.options('external_action', async ({ options, ack }) => {
+    // Get information specific to a team or channel
+    // (modified to satisfy TS compiler)
+    const results = options.team != null ? await db.get(options.team.id) : [];
+
+    if (results) {
+      // (modified to satisfy TS compiler)
+      let options: Option[] = [];
+      // Collect information in options array to send in Slack ack response
+      for (const result of results) {
+        options.push({
+          "text": {
+            "type": "plain_text",
+            "text": result.label
+          },
+          "value": result.value
+        });
+      }
+
+      await ack({
+        "options": options
+      });
+    } else {
+      await ack();
+    }
+  })
+);

--- a/types-tests/options.test-d.ts
+++ b/types-tests/options.test-d.ts
@@ -81,7 +81,7 @@ const db = {
 };
 
 expectType<void>(
-  // Take from https://slack.dev/bolt-js/concepts#options
+  // Taken from https://slack.dev/bolt-js/concepts#options
   // Example of responding to an external_select options request
   app.options('external_action', async ({ options, ack }) => {
     // Get information specific to a team or channel


### PR DESCRIPTION
###  Summary

This pull request adds a type test verifying #922 is resolved by #878 pull request.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).