### PR TITLE
Fix #925 by adding optional properties to CodedError interface

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -4,6 +4,11 @@ import type { BufferedIncomingMessage } from './receivers/verify-request';
 /* eslint-disable @typescript-eslint/explicit-member-accessibility */
 export interface CodedError extends Error {
   code: string; // This can be a value from ErrorCode, or WebClient's ErrorCode, or a NodeJS error code
+  original?: Error; // AuthorizationError, UnknownError
+  originals?: Error[]; // MultipleListenerError
+  missingProperty?: string; // ContextMissingPropertyError
+  req?: IncomingMessage | BufferedIncomingMessage; // HTTPReceiverDeferredRequestError
+  res?: ServerResponse; // HTTPReceiverDeferredRequestError
 }
 
 export enum ErrorCode {

--- a/types-tests/error.test-d.ts
+++ b/types-tests/error.test-d.ts
@@ -1,0 +1,43 @@
+import App from '../src/App';
+import { expectType } from 'tsd';
+import { CodedError } from '../src/errors';
+import { IncomingMessage, ServerResponse } from 'http';
+import { BufferedIncomingMessage } from '../src/receivers/verify-request';
+
+const app = new App({ token: 'TOKEN', signingSecret: 'Signing Secret' });
+
+// https://github.com/slackapi/bolt-js/issues/925
+// CodedError should have original and so on
+app.error(async (error) => {
+  expectType<CodedError>(error);
+
+  expectType<Error | undefined>(error.original);
+  if (error.original != undefined) {
+    expectType<Error>(error.original);
+    console.log(error.original.message);
+  }
+
+  expectType<Error[] | undefined>(error.originals);
+  if (error.originals != undefined) {
+    expectType<Error[]>(error.originals);
+    console.log(error.originals);
+  }
+
+  expectType<string | undefined>(error.missingProperty);
+  if (error.missingProperty != undefined) {
+    expectType<string>(error.missingProperty);
+    console.log(error.missingProperty);
+  }
+
+  expectType<IncomingMessage | BufferedIncomingMessage | undefined>(error.req);
+  if (error.req != undefined) {
+    expectType<IncomingMessage | BufferedIncomingMessage>(error.req);
+    console.log(error.req);
+  }
+
+  expectType<ServerResponse | undefined>(error.res);
+  if (error.res != undefined) {
+    expectType<ServerResponse>(error.res);
+    console.log(error.res);
+  }
+});


### PR DESCRIPTION
###  Summary

This pull request resolves #925 by updating the `CodedError` interface to have all the possible properties.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).