### PR TITLE
Fix #926 by adding more subtype ones to message event types

### DIFF
--- a/src/types/events/message-events.spec.ts
+++ b/src/types/events/message-events.spec.ts
@@ -1,0 +1,158 @@
+// tslint:disable:no-implicit-dependencies
+import { assert } from 'chai';
+import { BotMessageEvent, MessageEvent } from './message-events';
+
+describe('message event types', () => {
+  it('should be compatible with bot_message payload', () => {
+    const payload: BotMessageEvent = {
+      type: 'message',
+      subtype: 'bot_message',
+      bot_id: '',
+      username: '',
+      icons: {},
+      channel: '',
+      text: '',
+      blocks: [],
+      thread_ts: '',
+      ts: '',
+      event_ts: '',
+      channel_type: 'channel',
+    };
+    assert.isNotEmpty(payload);
+  });
+
+  it('should be compatible with channel_archive payload', () => {
+    const payload: MessageEvent = {
+      type: 'message',
+      subtype: 'channel_archive',
+      team: '',
+      user: '',
+      channel: '',
+      channel_type: 'channel',
+      text: '',
+      ts: '',
+      event_ts: '',
+    };
+    assert.isNotEmpty(payload);
+  });
+  it('should be compatible with channel_join payload', () => {
+    const payload: MessageEvent = {
+      type: 'message',
+      subtype: 'channel_join',
+      team: '',
+      user: '',
+      inviter: '',
+      channel: '',
+      channel_type: 'channel',
+      text: '',
+      ts: '',
+      event_ts: '',
+    };
+    assert.isNotEmpty(payload);
+  });
+  it('should be compatible with channel_leave payload', () => {
+    const payload: MessageEvent = {
+      type: 'message',
+      subtype: 'channel_leave',
+      team: '',
+      user: '',
+      channel: '',
+      channel_type: 'channel',
+      text: '',
+      ts: '',
+      event_ts: '',
+    };
+    assert.isNotEmpty(payload);
+  });
+  it('should be compatible with channel_name payload', () => {
+    const payload: MessageEvent = {
+      type: 'message',
+      subtype: 'channel_name',
+      team: '',
+      user: '',
+      name: '',
+      old_name: '',
+      channel: '',
+      channel_type: 'channel',
+      text: '',
+      ts: '',
+      event_ts: '',
+    };
+    assert.isNotEmpty(payload);
+  });
+  it('should be compatible with channel_posting_permissions payload', () => {
+    const payload: MessageEvent = {
+      type: 'message',
+      subtype: 'channel_posting_permissions',
+      user: '',
+      channel: '',
+      channel_type: 'channel',
+      text: '',
+      ts: '',
+      event_ts: '',
+    };
+    assert.isNotEmpty(payload);
+  });
+  it('should be compatible with channel_purpose payload', () => {
+    const payload: MessageEvent = {
+      type: 'message',
+      subtype: 'channel_purpose',
+      user: '',
+      channel: '',
+      channel_type: 'channel',
+      text: '',
+      purpose: '',
+      ts: '',
+      event_ts: '',
+    };
+    assert.isNotEmpty(payload);
+  });
+  it('should be compatible with channel_topic payload', () => {
+    const payload: MessageEvent = {
+      type: 'message',
+      subtype: 'channel_topic',
+      user: '',
+      channel: '',
+      channel_type: 'channel',
+      text: '',
+      topic: '',
+      ts: '',
+      event_ts: '',
+    };
+    assert.isNotEmpty(payload);
+  });
+  it('should be compatible with channel_unarchive payload', () => {
+    const payload: MessageEvent = {
+      type: 'message',
+      subtype: 'channel_unarchive',
+      team: '',
+      user: '',
+      channel: '',
+      channel_type: 'channel',
+      text: '',
+      ts: '',
+      event_ts: '',
+    };
+    assert.isNotEmpty(payload);
+  });
+  it('should be compatible with file_share payload', () => {
+    const payload: MessageEvent = {
+      type: 'message',
+      subtype: 'file_share',
+      user: '',
+      channel: '',
+      channel_type: 'channel',
+      blocks: [],
+      attachments: [],
+      files: [],
+      upload: false,
+      display_as_bot: false,
+      parent_user_id: '',
+      text: '',
+      ts: '',
+      thread_ts: '',
+      event_ts: '',
+    };
+    assert.isNotEmpty(payload);
+  });
+});

--- a/src/types/events/message-events.ts
+++ b/src/types/events/message-events.ts
@@ -3,7 +3,16 @@ import { MessageAttachment, KnownBlock, Block } from '@slack/types';
 export type MessageEvent =
   | GenericMessageEvent
   | BotMessageEvent
+  | ChannelArchiveMessageEvent
+  | ChannelJoinMessageEvent
+  | ChannelLeaveMessageEvent
+  | ChannelNameMessageEvent
+  | ChannelPostingPermissionsMessageEvent
+  | ChannelPurposeMessageEvent
+  | ChannelTopicMessageEvent
+  | ChannelUnarchiveMessageEvent
   | EKMAccessDeniedMessageEvent
+  | FileShareMessageEvent
   | MeMessageEvent
   | MessageChangedEvent
   | MessageDeletedEvent
@@ -67,6 +76,104 @@ export interface BotMessageEvent {
   thread_ts?: string;
 }
 
+interface ChannelArchiveMessageEvent {
+  type: 'message';
+  subtype: 'channel_archive';
+  team: string;
+  user: string;
+  channel: string;
+  channel_type: channelTypes;
+  text: string;
+  ts: string;
+  event_ts: string;
+}
+
+interface ChannelJoinMessageEvent {
+  type: 'message';
+  subtype: 'channel_join';
+  team: string;
+  user: string;
+  inviter: string;
+  channel: string;
+  channel_type: channelTypes;
+  text: string;
+  ts: string;
+  event_ts: string;
+}
+
+interface ChannelLeaveMessageEvent {
+  type: 'message';
+  subtype: 'channel_leave';
+  team: string;
+  user: string;
+  channel: string;
+  channel_type: channelTypes;
+  text: string;
+  ts: string;
+  event_ts: string;
+}
+
+interface ChannelNameMessageEvent {
+  type: 'message';
+  subtype: 'channel_name';
+  team: string;
+  user: string;
+  name: string;
+  old_name: string;
+  channel: string;
+  channel_type: channelTypes;
+  text: string;
+  ts: string;
+  event_ts: string;
+}
+
+interface ChannelPostingPermissionsMessageEvent {
+  type: 'message';
+  subtype: 'channel_posting_permissions';
+  user: string;
+  channel: string;
+  channel_type: channelTypes;
+  text: string;
+  ts: string;
+  event_ts: string;
+}
+
+interface ChannelPurposeMessageEvent {
+  type: 'message';
+  subtype: 'channel_purpose';
+  user: string;
+  channel: string;
+  channel_type: channelTypes;
+  text: string;
+  purpose: string;
+  ts: string;
+  event_ts: string;
+}
+
+interface ChannelTopicMessageEvent {
+  type: 'message';
+  subtype: 'channel_topic';
+  user: string;
+  channel: string;
+  channel_type: channelTypes;
+  text: string;
+  topic: string;
+  ts: string;
+  event_ts: string;
+}
+
+interface ChannelUnarchiveMessageEvent {
+  type: 'message';
+  subtype: 'channel_unarchive';
+  team: string;
+  user: string;
+  channel: string;
+  channel_type: channelTypes;
+  text: string;
+  ts: string;
+  event_ts: string;
+}
+
 export interface EKMAccessDeniedMessageEvent {
   type: 'message';
   subtype: 'ekm_access_denied';
@@ -76,6 +183,25 @@ export interface EKMAccessDeniedMessageEvent {
   ts: string;
   text: string; // This will not have any meaningful content within
   user: 'UREVOKEDU';
+}
+
+interface FileShareMessageEvent {
+  type: 'message';
+  subtype: 'file_share';
+  text: string;
+  attachments?: MessageAttachment[];
+  blocks?: (KnownBlock | Block)[];
+  files?: File[];
+  upload?: boolean;
+  display_as_bot?: boolean;
+  x_files?: string[];
+  user: string;
+  parent_user_id?: string;
+  ts: string;
+  thread_ts?: string;
+  channel: string;
+  channel_type: channelTypes;
+  event_ts: string;
 }
 
 export interface MeMessageEvent {

--- a/src/types/events/message-events.ts
+++ b/src/types/events/message-events.ts
@@ -76,7 +76,7 @@ export interface BotMessageEvent {
   thread_ts?: string;
 }
 
-interface ChannelArchiveMessageEvent {
+export interface ChannelArchiveMessageEvent {
   type: 'message';
   subtype: 'channel_archive';
   team: string;
@@ -88,7 +88,7 @@ interface ChannelArchiveMessageEvent {
   event_ts: string;
 }
 
-interface ChannelJoinMessageEvent {
+export interface ChannelJoinMessageEvent {
   type: 'message';
   subtype: 'channel_join';
   team: string;
@@ -101,7 +101,7 @@ interface ChannelJoinMessageEvent {
   event_ts: string;
 }
 
-interface ChannelLeaveMessageEvent {
+export interface ChannelLeaveMessageEvent {
   type: 'message';
   subtype: 'channel_leave';
   team: string;
@@ -113,7 +113,7 @@ interface ChannelLeaveMessageEvent {
   event_ts: string;
 }
 
-interface ChannelNameMessageEvent {
+export interface ChannelNameMessageEvent {
   type: 'message';
   subtype: 'channel_name';
   team: string;
@@ -127,7 +127,7 @@ interface ChannelNameMessageEvent {
   event_ts: string;
 }
 
-interface ChannelPostingPermissionsMessageEvent {
+export interface ChannelPostingPermissionsMessageEvent {
   type: 'message';
   subtype: 'channel_posting_permissions';
   user: string;
@@ -138,7 +138,7 @@ interface ChannelPostingPermissionsMessageEvent {
   event_ts: string;
 }
 
-interface ChannelPurposeMessageEvent {
+export interface ChannelPurposeMessageEvent {
   type: 'message';
   subtype: 'channel_purpose';
   user: string;
@@ -150,7 +150,7 @@ interface ChannelPurposeMessageEvent {
   event_ts: string;
 }
 
-interface ChannelTopicMessageEvent {
+export interface ChannelTopicMessageEvent {
   type: 'message';
   subtype: 'channel_topic';
   user: string;
@@ -162,7 +162,7 @@ interface ChannelTopicMessageEvent {
   event_ts: string;
 }
 
-interface ChannelUnarchiveMessageEvent {
+export interface ChannelUnarchiveMessageEvent {
   type: 'message';
   subtype: 'channel_unarchive';
   team: string;
@@ -185,7 +185,7 @@ export interface EKMAccessDeniedMessageEvent {
   user: 'UREVOKEDU';
 }
 
-interface FileShareMessageEvent {
+export interface FileShareMessageEvent {
   type: 'message';
   subtype: 'file_share';
   text: string;


### PR DESCRIPTION
###  Summary

This pull request resolves #926

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).