### PR TITLE
Improve storeInstallation docs

### DIFF
--- a/docs/_basic/authenticating_oauth.md
+++ b/docs/_basic/authenticating_oauth.md
@@ -29,10 +29,11 @@ const app = new App({
   installationStore: {
     storeInstallation: async (installation) => {
       // change the line below so it saves to your database
-      if (installation.isEnterpriseInstall) {
+      if (installation.isEnterpriseInstall && installation.enterprise !== undefined) {
         // support for org wide app installation
         return await database.set(installation.enterprise.id, installation);
-      } else {
+      }
+      if (installation.team.id !== undefined) {
         // single team app installation
         return await database.set(installation.team.id, installation);
       }

--- a/docs/_basic/authenticating_oauth.md
+++ b/docs/_basic/authenticating_oauth.md
@@ -33,7 +33,7 @@ const app = new App({
         // support for org wide app installation
         return await database.set(installation.enterprise.id, installation);
       }
-      if (installation.team.id !== undefined) {
+      if (installation.team !== undefined) {
         // single team app installation
         return await database.set(installation.team.id, installation);
       }

--- a/docs/_basic/ja_authenticating_oauth.md
+++ b/docs/_basic/ja_authenticating_oauth.md
@@ -28,10 +28,11 @@ const app = new App({
   installationStore: {
     storeInstallation: async (installation) => {
       // 実際のデータベースに保存するために、ここのコードを変更
-      if (installation.isEnterpriseInstall) {
+      if (installation.isEnterpriseInstall && installation.enterprise !== undefined) {
         // OrG 全体へのインストールに対応する場合
         return await database.set(installation.enterprise.id, installation);
-      } else {
+      }
+      if (installation.team.id !== undefined) {
         // 単独のワークスペースへのインストールの場合
         return await database.set(installation.team.id, installation);
       }

--- a/docs/_basic/ja_authenticating_oauth.md
+++ b/docs/_basic/ja_authenticating_oauth.md
@@ -32,7 +32,7 @@ const app = new App({
         // OrG 全体へのインストールに対応する場合
         return await database.set(installation.enterprise.id, installation);
       }
-      if (installation.team.id !== undefined) {
+      if (installation.team !== undefined) {
         // 単独のワークスペースへのインストールの場合
         return await database.set(installation.team.id, installation);
       }

--- a/docs/_tutorials/ja_migration_v3.md
+++ b/docs/_tutorials/ja_migration_v3.md
@@ -54,7 +54,7 @@ installationStore: {
         // support for org wide app installation
         return await database.set(installation.enterprise.id, installation);
       }
-      if (installation.team.id !== undefined) {
+      if (installation.team !== undefined) {
         // single team app installation
         return await database.set(installation.team.id, installation);
       }

--- a/docs/_tutorials/ja_migration_v3.md
+++ b/docs/_tutorials/ja_migration_v3.md
@@ -50,10 +50,11 @@ installationStore: {
 ```javascript
 installationStore: {
     storeInstallation: async (installation) => {
-      if (installation.isEnterpriseInstall) {
+      if (installation.isEnterpriseInstall && installation.enterprise !== undefined) {
         // support for org wide app installation
         return await database.set(installation.enterprise.id, installation);
-      } else {
+      }
+      if (installation.team.id !== undefined) {
         // single team app installation
         return await database.set(installation.team.id, installation);
       }

--- a/docs/_tutorials/migration_v3.md
+++ b/docs/_tutorials/migration_v3.md
@@ -54,7 +54,7 @@ installationStore: {
         // support for org wide app installation
         return await database.set(installation.enterprise.id, installation);
       }
-      if (installation.team.id !== undefined) {
+      if (installation.team !== undefined) {
         // single team app installation
         return await database.set(installation.team.id, installation);
       }

--- a/docs/_tutorials/migration_v3.md
+++ b/docs/_tutorials/migration_v3.md
@@ -50,10 +50,11 @@ After:
 ```javascript
 installationStore: {
     storeInstallation: async (installation) => {
-      if (installation.isEnterpriseInstall) {
+      if (installation.isEnterpriseInstall && installation.enterprise !== undefined) {
         // support for org wide app installation
         return await database.set(installation.enterprise.id, installation);
-      } else {
+      }
+      if (installation.team.id !== undefined) {
         // single team app installation
         return await database.set(installation.team.id, installation);
       }


### PR DESCRIPTION
###  Summary

I'm trying to upgrade from v2 to v3 in my TypeScript project https://github.com/connorads/lockbot but if I follow [the docs](https://slack.dev/bolt-js/tutorial/migration-v3#org-wide-app-installation-changes-to-installationstore--orgauthorize) for `storeInstallation` the TypeScipt compiler complains, the `fetchInstallation` bit is ok.

![image](https://user-images.githubusercontent.com/10026538/120180283-78a98c80-c203-11eb-9eb2-045130cb899d.png)

1. TypeScript error: `installation.enterprise` or `installation.team` could be `undefined`

_I presume that there's meant to be some TypeScript magic™ going on in `node-slack-sdk` with [`IsEnterpriseInstall extends true ? EnterpriseInfo : (EnterpriseInfo | undefined);`](https://github.com/slackapi/node-slack-sdk/blob/main/packages/oauth/src/index.ts#L564) but it doesn't seem to be working. So I followed the example set by `fetchInstallation`. I might have a look later to see if any guarantees are offered at runtime which can be represented at compile time using TypeScript._

![image](https://user-images.githubusercontent.com/10026538/120075308-a6be8d80-c098-11eb-98bd-68dc61ea029f.png)
![image](https://user-images.githubusercontent.com/10026538/120075327-b8a03080-c098-11eb-9cb0-e80cac3ecf7c.png)

2. Also, the `throw` will never be reached in the current docs because of the `else` statement.

![image](https://user-images.githubusercontent.com/10026538/120075592-d3bf7000-c099-11eb-8f98-68f55bca967d.png)

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).