### PR TITLE
Fix #947 Enable to use app.client with passed token for single workspace apps

### DIFF
--- a/src/App.spec.ts
+++ b/src/App.spec.ts
@@ -54,6 +54,23 @@ describe('App', () => {
         // TODO: verify that the fake bot ID and fake bot user ID are retrieved
         assert.instanceOf(app, App);
       });
+      it('should pass the given token to app.client', async () => {
+        // Arrange
+        const fakeBotId = 'B_FAKE_BOT_ID';
+        const fakeBotUserId = 'U_FAKE_BOT_USER_ID';
+        const overrides = mergeOverrides(
+          withNoopAppMetadata(),
+          withSuccessfulBotUserFetchingWebClient(fakeBotId, fakeBotUserId),
+        );
+        const App = await importApp(overrides); // eslint-disable-line  @typescript-eslint/naming-convention, no-underscore-dangle, id-blacklist, id-match
+
+        // Act
+        const app = new App({ token: 'xoxb-foo-bar', signingSecret: '' });
+
+        // Assert
+        assert.isDefined(app.client);
+        assert.equal(app.client.token, 'xoxb-foo-bar');
+      });
     });
     it('should succeed with an authorize callback', async () => {
       // Arrange

--- a/src/App.ts
+++ b/src/App.ts
@@ -260,8 +260,9 @@ export default class App {
       // Since v3.4, WebClient starts sharing loggger with App
       this.clientOptions.logger = this.logger;
     }
-    // the public WebClient instance (app.client) - this one doesn't have a token
-    this.client = new WebClient(undefined, this.clientOptions);
+    // The public WebClient instance (app.client)
+    // Since v3.4, it can have the passed token in the case of single workspace installation.
+    this.client = new WebClient(token, this.clientOptions);
 
     this.axios = axios.create({
       httpAgent: agent,


### PR DESCRIPTION
###  Summary

Refer to #947  for details. If we need to have some discussion about this, let's use the issue, not this PR. 

For the comments about the changes in this PR, please feel free to join as a reviewer!

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).