### PR TITLE
Fix #935 enterprise_id in InstallationQuery can be invalid for Slack Connect channel events

### DIFF
--- a/src/App.ts
+++ b/src/App.ts
@@ -991,12 +991,10 @@ function buildSource<IsEnterpriseInstall extends boolean>(
   const enterpriseId: string | undefined = (() => {
     if (type === IncomingEventType.Event) {
       const bodyAsEvent = body as SlackEventMiddlewareArgs['body'];
-      if (
-        Array.isArray(bodyAsEvent.authorizations) &&
-        bodyAsEvent.authorizations[0] !== undefined &&
-        bodyAsEvent.authorizations[0].enterprise_id !== null
-      ) {
-        return bodyAsEvent.authorizations[0].enterprise_id;
+      if (Array.isArray(bodyAsEvent.authorizations) && bodyAsEvent.authorizations[0] !== undefined) {
+        // The enteprise_id here can be null when the workspace is not in an Enterprise Grid
+        const theId = bodyAsEvent.authorizations[0].enterprise_id;
+        return theId !== null ? theId : undefined;
       }
       return bodyAsEvent.enterprise_id;
     }


### PR DESCRIPTION
###  Summary

Refer to #935 for details. This is a critical bug for the non-Enterprise Grid customers using Slack Connect channels.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).