### PR TITLE
Fix #951 TypeScript 4.3 typing for `KnownKeys<ChatPostMessageArguments>`

### DIFF
--- a/src/types/helpers.ts
+++ b/src/types/helpers.ts
@@ -4,13 +4,10 @@
 export type StringIndexed = Record<string, any>;
 
 /**
- * Type function which removes the index signature for the type `T`
+ * @deprecated No longer works in TypeScript 4.3
  */
-export type KnownKeys<T> = {
-  [K in keyof T]: string extends K ? never : number extends K ? never : K;
-} extends { [_ in keyof T]: infer U }
-  ? U
-  : never;
+// @ts-ignore -- ignore unused type parameter warning
+export type KnownKeys<T> = never;
 
 /**
  * Type function which allows either types `T` or `U`, but not both.

--- a/src/types/utilities.ts
+++ b/src/types/utilities.ts
@@ -1,9 +1,27 @@
 import { ChatPostMessageArguments, WebAPICallResult } from '@slack/web-api';
-import { KnownKeys } from './helpers';
+
+// (issue#951) KnownKeys<ChatPostMessageArguments> no longer works in TypeScript 4.3
+type ChatPostMessageArgumentsKnownKeys =
+  | 'token'
+  | 'channel'
+  | 'text'
+  | 'as_user'
+  | 'attachments'
+  | 'blocks'
+  | 'icon_emoji'
+  | 'icon_url'
+  | 'link_names'
+  | 'mrkdwn'
+  | 'parse'
+  | 'reply_broadcast'
+  | 'thread_ts'
+  | 'unfurl_links'
+  | 'unfurl_media'
+  | 'username';
 
 // The say() utility function binds the message to the same channel as the incoming message that triggered the
 // listener. Therefore, specifying the `channel` argument is not required.
-export type SayArguments = Pick<ChatPostMessageArguments, Exclude<KnownKeys<ChatPostMessageArguments>, 'channel'>> & {
+export type SayArguments = Pick<ChatPostMessageArguments, Exclude<ChatPostMessageArgumentsKnownKeys, 'channel'>> & {
   channel?: string;
 };
 
@@ -13,7 +31,7 @@ export interface SayFn {
 
 export type RespondArguments = Pick<
   ChatPostMessageArguments,
-  Exclude<KnownKeys<ChatPostMessageArguments>, 'channel' | 'text'>
+  Exclude<ChatPostMessageArgumentsKnownKeys, 'channel' | 'text'>
 > & {
   /** Response URLs can be used to send ephemeral messages or in-channel messages using this argument */
   response_type?: 'in_channel' | 'ephemeral';


### PR DESCRIPTION
###  Summary

This PR fixes the type `KnownKeys<ChatPostMessageArguments>` to work in TypeScript 4.3.  
Refer to #951 for details.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).