### PR TITLE
Fix #956 Add bot_id / bot_profile to GenericMessageEvent

### DIFF
--- a/src/types/events/message-events.spec.ts
+++ b/src/types/events/message-events.spec.ts
@@ -1,6 +1,6 @@
 // tslint:disable:no-implicit-dependencies
 import { assert } from 'chai';
-import { BotMessageEvent, MessageEvent } from './message-events';
+import { BotMessageEvent, GenericMessageEvent, MessageEvent } from './message-events';
 
 describe('message event types', () => {
   it('should be compatible with bot_message payload', () => {
@@ -152,6 +152,34 @@ describe('message event types', () => {
       ts: '',
       thread_ts: '',
       event_ts: '',
+    };
+    assert.isNotEmpty(payload);
+  });
+  it('should be compatible with message with bot info', () => {
+    const payload: GenericMessageEvent = {
+      type: 'message',
+      subtype: undefined,
+      text: 'Hi there! Thanks for sharing the info!',
+      user: 'UB111',
+      ts: '1610261539.000900',
+      team: 'T111',
+      bot_id: 'B999',
+      bot_profile: {
+        id: 'B999',
+        deleted: false,
+        name: 'other-app',
+        updated: 1607307935,
+        app_id: 'A222',
+        icons: {
+          image_36: 'https://a.slack-edge.com/80588/img/plugins/app/bot_36.png',
+          image_48: 'https://a.slack-edge.com/80588/img/plugins/app/bot_48.png',
+          image_72: 'https://a.slack-edge.com/80588/img/plugins/app/service_72.png',
+        },
+        team_id: 'T111',
+      },
+      channel: 'C111',
+      event_ts: '1610261539.000900',
+      channel_type: 'channel',
     };
     assert.isNotEmpty(payload);
   });

--- a/src/types/events/message-events.ts
+++ b/src/types/events/message-events.ts
@@ -26,6 +26,8 @@ export interface GenericMessageEvent {
   team?: string;
   channel: string;
   user: string;
+  bot_id?: string;
+  bot_profile?: BotProfile;
   text?: string;
   ts: string;
   thread_ts?: string;
@@ -280,6 +282,18 @@ export interface ThreadBroadcastMessageEvent {
 }
 
 export type channelTypes = 'channel' | 'group' | 'im' | 'mpim' | 'app_home';
+
+interface BotProfile {
+  id: string;
+  name: string;
+  app_id: string;
+  team_id: string;
+  icons: {
+    [size: string]: string;
+  };
+  updated: number;
+  deleted: boolean;
+}
 
 interface File {
   id: string;


### PR DESCRIPTION
###  Summary

This pull request fixes #956. Refer to the issue for details.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).