### PR TITLE
Fix #960 by adding edited property to app_mention event payload

### DIFF
--- a/src/types/events/base-events.ts
+++ b/src/types/events/base-events.ts
@@ -154,6 +154,10 @@ export interface AppMentionEvent {
   text: string;
   attachments?: MessageAttachment[];
   blocks?: (KnownBlock | Block)[];
+  edited?: {
+    user: string;
+    ts: string;
+  };
   ts: string;
   channel: string;
   event_ts: string;


### PR DESCRIPTION
###  Summary

This pull request fixes #960 by adding `edited` property to `AppMentionEvent` interface. Refer to the issue for details.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).