### PR TITLE
updated default axios options

### DIFF
--- a/src/App.ts
+++ b/src/App.ts
@@ -267,6 +267,11 @@ export default class App {
     this.axios = axios.create({
       httpAgent: agent,
       httpsAgent: agent,
+      // disabling axios' automatic proxy support:
+      // axios would read from envvars to configure a proxy automatically, but it doesn't support TLS destinations.
+      // for compatibility with https://api.slack.com, and for a larger set of possible proxies (SOCKS or other
+      // protocols), users of this package should use the `agent` option to configure a proxy.
+      proxy: false,
       ...clientTls,
     });
 


### PR DESCRIPTION
###  Summary

Our axios instance in bolt-js won't work with some endpoints and server setups. This pr fixes this weird edgecase. We already have this fix in our web-api package. https://github.com/slackapi/node-slack-sdk/blob/main/packages/web-api/src/WebClient.ts#L138

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).