### PR TITLE
Fix #985: Update "acknowledging events" code snippet

### DIFF
--- a/docs/_basic/acknowledging_requests.md
+++ b/docs/_basic/acknowledging_requests.md
@@ -15,7 +15,7 @@ We recommend calling `ack()` right away before sending a new message or fetching
 // Regex to determine if this is a valid email
 let isEmail = /^[\w-\.]+@([\w-]+\.)+[\w-]{2,4}$/
 // This uses a constraint object to listen for modal submissions with a callback_id of ticket_submit 
-app.view({ callback_id: 'ticket_submit' }, async ({ ack, view }) => {
+app.view('ticket_submit', async ({ ack, view }) => {
   // get the email value from the input block with `email_address` as the block_id
   const email = view.state.values['email_address']['input_a'].value;
 

--- a/docs/_basic/acknowledging_requests.md
+++ b/docs/_basic/acknowledging_requests.md
@@ -6,7 +6,7 @@ order: 7
 ---
 
 <div class="section-content">
-Actions, commands, and options events must **always** be acknowledged using the `ack()` function. This lets Slack know that the event was received and updates the Slack user interface accordingly. Depending on the type of event, your acknowledgement may be different. For example, when acknowledging a dialog submission you will call `ack()` with validation errors if the submission contains errors, or with no parameters if the submission is valid.
+Actions, commands, and options events must **always** be acknowledged using the `ack()` function. This lets Slack know that the event was received and updates the Slack user interface accordingly. Depending on the type of event, your acknowledgement may be different. For example, when acknowledging a modal submission you will call `ack()` with validation errors if the submission contains errors, or with no parameters if the submission is valid.
 
 We recommend calling `ack()` right away before sending a new message or fetching information from your database since you only have 3 seconds to respond.
 </div>
@@ -14,18 +14,21 @@ We recommend calling `ack()` right away before sending a new message or fetching
 ```javascript
 // Regex to determine if this is a valid email
 let isEmail = /^[\w-\.]+@([\w-]+\.)+[\w-]{2,4}$/
-// This uses a constraint object to listen for dialog submissions with a callback_id of ticket_submit 
-app.action({ callback_id: 'ticket_submit' }, async ({ action, ack }) => {
-  // it’s a valid email, accept the submission
-  if (isEmail.test(action.submission.email)) {
+// This uses a constraint object to listen for modal submissions with a callback_id of ticket_submit 
+app.view({ callback_id: 'ticket_submit' }, async ({ ack, view }) => {
+  // get the email value from the input block with `email_address` as the block_id
+  const email = view.state.values['email_address']['input_a'].value;
+
+  // if it’s a valid email, accept the submission
+  if (isEmail.test(email)) {
     await ack();
   } else {
     // if it isn’t a valid email, acknowledge with an error
     await ack({
-      errors: [{
-        "name": "email_address",
-        "error": "Sorry, this isn’t a valid email"
-      }]
+      "response_action": "errors",
+      errors: {
+        "email_address": "Sorry, this isn’t a valid email"
+      }
     });
   }
 });

--- a/docs/_basic/ja_acknowledging_requests.md
+++ b/docs/_basic/ja_acknowledging_requests.md
@@ -6,7 +6,7 @@ order: 7
 ---
 
 <div class="section-content">
-アクション（action）、コマンド（command）、およびオプション（options）イベントは、**必ず** `ack()` 関数を用いて確認する必要があります。これにより Slack 側にイベントが正常に受信されたことを知らせることができ、それに応じて Slack のユーザーインターフェイスが更新されます。イベントのタイプによっては、確認の通知方法が異なる場合があります。たとえば、ダイアログの送信を確認するとき、送信内容にエラーがあればバリデーションエラーとともに `ack()` を呼び出しますが、送信内容が問題なければ、そのようなパラメータなしで `ack()` を呼び出します。
+アクション（action）、コマンド（command）、およびオプション（options）イベントは、**必ず** `ack()` 関数を用いて確認する必要があります。これにより Slack 側にイベントが正常に受信されたことを知らせることができ、それに応じて Slack のユーザーインターフェイスが更新されます。イベントのタイプによっては、確認の通知方法が異なる場合があります。たとえば、モーダルの送信を確認するとき、送信内容にエラーがあればバリデーションエラーとともに `ack()` を呼び出しますが、送信内容が問題なければ、そのようなパラメータなしで `ack()` を呼び出します。
 
 この `ack()` による応答は 3 秒以内に行う必要があります。新しいメッセージの送信や、データベースからの情報の取得などを行う前に、リクエストを受けてすぐに `ack()` を呼び出して応答を返してしまうことをおすすめします。
 </div>
@@ -14,18 +14,21 @@ order: 7
 ```javascript
 // Regex でメールアドレスが有効かチェック
 let isEmail = /^[\w-\.]+@([\w-]+\.)+[\w-]{2,4}$/
-// 制約付きのオブジェクト を使用して ticket_submit という callback_id を持つダイアログ送信をリッスン
-app.action({ callback_id: 'ticket_submit' }, async ({ action, ack }) => {
-  // メールアドレスが有効。ダイアログを受信
-  if (isEmail.test(action.submission.email)) {
+// 制約付きのオブジェクト を使用して ticket_submit という callback_id を持つモーダル送信をリッスン
+app.view('ticket_submit', async ({ ack, view }) => {
+  // block_id が `email_address` の input ブロックからメールアドレスを取得
+  const email = view.state.values['email_address']['input_a'].value;
+
+  // メールアドレスが有効。モーダルを受信
+  if (isEmail.test(email)) {
     await ack();
   } else {
     // メールアドレスが無効。エラーを確認
     await ack({
-      errors: [{
-        "name": "email_address",
-        "error": "Sorry, this isn’t a valid email"
-      }]
+      "response_action": "errors",
+      errors: {
+        "email_address": "Sorry, this isn’t a valid email"
+      }
     });
   }
 });


### PR DESCRIPTION
###  Summary

This PR updates the code snippet in the "acknowledging events" document to use modals instead of dialogs (as dialogs are outmoded). Closes #985.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).