### PR TITLE
Update docs to include the InstallationStore deleteInstallation method

### DIFF
--- a/docs/_basic/authenticating_oauth.md
+++ b/docs/_basic/authenticating_oauth.md
@@ -51,6 +51,18 @@ const app = new App({
       }
       throw new Error('Failed fetching installation');
     },
+    deleteInstallation: async (installQuery) => {
+      // change the line below so it deletes from your database
+      if (installQuery.isEnterpriseInstall && installQuery.enterpriseId !== undefined) {
+        // org wide app installation deletion
+        return await myDB.delete(installQuery.enterpriseId);
+      }
+      if (installQuery.teamId !== undefined) {
+        // single team app installation deletion
+        return await myDB.delete(installQuery.teamId);
+      }
+      throw new Error('Failed to delete installation');
+    },
   },
 });
 ```

--- a/docs/_basic/ja_authenticating_oauth.md
+++ b/docs/_basic/ja_authenticating_oauth.md
@@ -50,6 +50,18 @@ const app = new App({
       }
       throw new Error('Failed fetching installation');
     },
+    deleteInstallation: async (installQuery) => {
+      // change the line below so it deletes from your database
+      if (installQuery.isEnterpriseInstall && installQuery.enterpriseId !== undefined) {
+        // org wide app installation deletion
+        return await myDB.delete(installQuery.enterpriseId);
+      }
+      if (installQuery.teamId !== undefined) {
+        // single team app installation deletion
+        return await myDB.delete(installQuery.teamId);
+      }
+      throw new Error('Failed to delete installation');
+    },
   },
 });
 ```

--- a/docs/_tutorials/ja_reference.md
+++ b/docs/_tutorials/ja_reference.md
@@ -95,7 +95,7 @@ Bolt には、アプリをカスタマイズするためのさまざまな初期
 | `clientId` | アプリの設定で指定した、クライアントの ID を示す 文字列。[OAuth の設定を行うために必要です](/bolt-js/concepts#authenticating-oauth)。 |
 | `clientSecret` | アプリの設定で指定した、クライアントのシークレットキーを示す 文字列。[OAuth の設定を行うために必要です](/bolt-js/concepts#authenticating-oauth)。 |
 | `stateSecret` | CSRF 攻撃を防ぐために [OAuth の設定時](/bolt-js/concepts#authenticating-oauth)に渡すことができる、推奨のパラメーター（文字列）。 |
-| `installationStore` | [OAuth の設定時](/bolt-js/concepts#authenticating-oauth)に、インストールデータの保存と取得の手段を定義します。`fetchInstallation` と `storeInstallation` という 2 つのメソッドが含まれます。デフォルトの `installationStore` はインメモリストアです。 |
+| `installationStore` | [OAuth の設定時](/bolt-js/ja-jp/concepts#authenticating-oauth)に、インストールデータの保存・取得・削除の手段を定義します。`fetchInstallation` 、`storeInstallation`、`deleteInstallation` という 3 つのメソッドが含まれます。デフォルトの `installationStore` はインメモリストアです。 |
 | `scopes` | アプリが [OAuth のプロセスの中で](/bolt-js/concepts#authenticating-oauth)アクセス許可を求めるスコープのリスト。 |
 | `installerOptions` | [デフォルトの OAuth サポート](/bolt-js/concepts#authenticating-oauth)をカスタマイズする場合に指定するオブジェクト（必須ではない）。詳しくは、OAuth のドキュメントを参照してください。 |
 

--- a/docs/_tutorials/reference.md
+++ b/docs/_tutorials/reference.md
@@ -93,7 +93,7 @@ Bolt includes a collection of initialization options to customize apps. There ar
 | `clientId` | The client ID `string` from your app's configuration which is [required to configure OAuth](/bolt-js/concepts#authenticating-oauth). |
 | `clientSecret` | The client secret `string` from your app's configuration which is [required to configure OAuth](/bolt-js/concepts#authenticating-oauth). |
 | `stateSecret` | Recommended parameter (`string`) that's passed when [configuring OAuth](/bolt-js/concepts#authenticating-oauth) to prevent CSRF attacks |
-| `installationStore` | Defines how to save and fetch installation data when [configuring OAuth](/bolt-js/concepts#authenticating-oauth). Contains two methods: `fetchInstallation` and `storeInstallation`. The default `installationStore` is an in-memory store. |
+| `installationStore` | Defines how to save, fetch and delete installation data when [configuring OAuth](/bolt-js/concepts#authenticating-oauth). Contains three methods: `fetchInstallation`, `storeInstallation` and `deleteInstallation`. The default `installationStore` is an in-memory store. |
 | `scopes` | Array of scopes that your app will request [within the OAuth process](/bolt-js/concepts#authenticating-oauth). |
 | `installerOptions` | Optional object that can be used to customize [the default OAuth support](/bolt-js/concepts#authenticating-oauth). Read more in the OAuth documentation. |
 


### PR DESCRIPTION
###  Summary

Fixes #970

Update docs to include examples + references to recently added `deleteInstallation` method. 

**Relies on work included in `oauth@2.2`.**

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).