### PR TITLE
Export MemoryInstallationStore and FileInstallationStore

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -39,6 +39,8 @@ export {
   InstallURLOptions,
   InstallationQuery,
   InstallationStore,
+  MemoryInstallationStore,
+  FileInstallationStore,
   StateStore,
   InstallProviderOptions,
 } from '@slack/oauth';


### PR DESCRIPTION
###  Summary

Fixes #941 

Exports the `MemoryInstallationStore` and `FileInstallationStore` classes from `@slack/oauth` to allow developers the ability to import and use them directly in their projects as the chosen `InstallationStore`.

**Dependent on `oauth@2.2`**

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).