### PR TITLE
Add token rotation section to docs

### DIFF
--- a/docs/_advanced/context.md
+++ b/docs/_advanced/context.md
@@ -2,7 +2,7 @@
 title: Adding context
 lang: en
 slug: context
-order: 6
+order: 7
 ---
 
 <div class="section-content">

--- a/docs/_advanced/conversation_store.md
+++ b/docs/_advanced/conversation_store.md
@@ -2,7 +2,7 @@
 title: Conversation stores
 lang: en
 slug: conversation-store
-order: 3
+order: 4
 ---
 
 <div class="section-content">

--- a/docs/_advanced/custom_routes.md
+++ b/docs/_advanced/custom_routes.md
@@ -2,7 +2,7 @@
 title: Adding Custom HTTP routes 
 lang: en
 slug: custom-routes
-order: 9
+order: 10
 ---
 
 <div class="section-content">

--- a/docs/_advanced/logging.md
+++ b/docs/_advanced/logging.md
@@ -2,7 +2,7 @@
 title: Logging
 lang: en
 slug: logging
-order: 7
+order: 8
 ---
 
 <div class="section-content">

--- a/docs/_advanced/middleware_global.md
+++ b/docs/_advanced/middleware_global.md
@@ -2,7 +2,7 @@
 title: Global middleware
 lang: en
 slug: global-middleware
-order: 4
+order: 5
 ---
 
 <div class="section-content">

--- a/docs/_advanced/middleware_listener.md
+++ b/docs/_advanced/middleware_listener.md
@@ -2,7 +2,7 @@
 title: Listener middleware
 lang: en
 slug: listener-middleware
-order: 5
+order: 6
 ---
 
 <div class="section-content">

--- a/docs/_advanced/receiver.md
+++ b/docs/_advanced/receiver.md
@@ -2,7 +2,7 @@
 title: Customizing a receiver
 lang: en
 slug: receiver
-order: 8
+order: 9
 ---
 
 <div class="section-content">

--- a/docs/_advanced/token_rotation.md
+++ b/docs/_advanced/token_rotation.md
@@ -6,7 +6,7 @@ order: 3
 ---
 
 <div class="section-content">
-Token rotation provides an extra layer of security for your access tokens and is defined by the [OAuth V2 RFC](https://datatracker.ietf.org/doc/html/rfc6749#section-10.4). 
+Supported in Bolt for JavaScript as of v3.5.0, token rotation provides an extra layer of security for your access tokens and is defined by the [OAuth V2 RFC](https://datatracker.ietf.org/doc/html/rfc6749#section-10.4). 
 
 Instead of an access token representing an existing installation of your Slack app indefinitely, with token rotation enabled, access tokens expire. A refresh token acts as a long-lived way to refresh your access tokens.
 

--- a/docs/_advanced/token_rotation.md
+++ b/docs/_advanced/token_rotation.md
@@ -10,7 +10,7 @@ Supported in Bolt for JavaScript as of v3.5.0, token rotation provides an extra 
 
 Instead of an access token representing an existing installation of your Slack app indefinitely, with token rotation enabled, access tokens expire. A refresh token acts as a long-lived way to refresh your access tokens.
 
-Bolt for JavaScript supports token rotation automatically once enabled in your app's configuration.
+Bolt for JavaScript supports and will handle token rotation automatically so long as the [built-in OAuth](https://slack.dev/node-slack-sdk/oauth) functionality is used.
 
 For more information about token rotation, please see the [documentation](https://api.slack.com/authentication/rotation).
 </div>

--- a/docs/_advanced/token_rotation.md
+++ b/docs/_advanced/token_rotation.md
@@ -10,7 +10,7 @@ Supported in Bolt for JavaScript as of v3.5.0, token rotation provides an extra 
 
 Instead of an access token representing an existing installation of your Slack app indefinitely, with token rotation enabled, access tokens expire. A refresh token acts as a long-lived way to refresh your access tokens.
 
-Bolt for JavaScript supports and will handle token rotation automatically so long as the [built-in OAuth](https://slack.dev/node-slack-sdk/oauth) functionality is used.
+Bolt for JavaScript supports and will handle token rotation automatically so long as the [built-in OAuth](https://slack.dev/bolt-js/concepts#authenticating-oauth) functionality is used.
 
 For more information about token rotation, please see the [documentation](https://api.slack.com/authentication/rotation).
 </div>

--- a/docs/_advanced/token_rotation.md
+++ b/docs/_advanced/token_rotation.md
@@ -1,0 +1,16 @@
+---
+title: Token rotation
+lang: en
+slug: token-rotation
+order: 3
+---
+
+<div class="section-content">
+Token rotation provides an extra layer of security for your access tokens and is defined by the [OAuth V2 RFC](https://datatracker.ietf.org/doc/html/rfc6749#section-10.4). 
+
+Instead of an access token representing an existing installation of your Slack app indefinitely, with token rotation enabled, access tokens expire. A refresh token acts as a long-lived way to refresh your access tokens.
+
+Bolt for JavaScript supports token rotation automatically once enabled in your app's configuration.
+
+For more information about token rotation, please see the [documentation](https://api.slack.com/authentication/rotation).
+</div>


### PR DESCRIPTION
###  Summary

Add section to documentation that outlines token rotation and links out to corresponding spec + API documentation.

![Screen Shot 2021-07-19 at 9 24 04 AM](https://user-images.githubusercontent.com/7788242/126193878-4bd5ace3-3437-49e9-bdc1-20122cafd7e8.png)

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
