### PR TITLE
[WIP] ESLint Config Migration: Expand import/no-internal-modules allowlist

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -247,6 +247,9 @@ module.exports = {
           // Use the following option to set a list of allowable globs in this project.
           allow: [
             '**/middleware/*', // the src/middleware directory doesn't export a module, it's just a namespace.
+            '**/receivers/*', // the src/receivers directory doesn't export a module, it's just a namespace.
+            '**/types/**/*',
+            '**/types/*', // type heirarchies should be used however one wants
           ],
         }],
 


### PR DESCRIPTION
###  Summary

This is a PR that should be merged into #1024 and incrementally addresses #842.

This PR expands the list of source directories that one may reach into its subdirectories to import individual submodules (details about the [`import/no-internal-modules rule here](https://github.com/import-js/eslint-plugin-import/blob/master/docs/rules/no-internal-modules.md)).

The `src/receivers` directory has no single export - so I think it is safe to allow it there (similar structure to `src/middleware`). I am less sure of the `src/types` directory. What do you think @misscoded ?

### Impact

#### Before

```
✖ 362 problems (173 errors, 189 warnings)
  76 errors and 0 warnings potentially fixable with the `--fix` option.
```

#### After

```
✖ 350 problems (161 errors, 189 warnings)
  76 errors and 0 warnings potentially fixable with the `--fix` option.
```

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).