### PR TITLE
ESLint Config Migration: Fixing lint errors for "no-use-before-define" rule.

### DIFF
--- a/src/App.spec.ts
+++ b/src/App.spec.ts
@@ -18,6 +18,27 @@ const noopMiddleware = async ({ next }: { next: NextFn }) => {
 };
 const noopAuthorize = () => Promise.resolve({});
 
+// Fakes
+class FakeReceiver implements Receiver {
+  private bolt: App | undefined;
+
+  public init = (bolt: App) => {
+    this.bolt = bolt;
+  };
+
+  public start = sinon.fake((...params: any[]): Promise<unknown> => {
+    return Promise.resolve([...params]);
+  });
+
+  public stop = sinon.fake((...params: any[]): Promise<unknown> => {
+    return Promise.resolve([...params]);
+  });
+
+  public async sendEvent(event: ReceiverEvent): Promise<void> {
+    return this.bolt?.processEvent(event);
+  }
+}
+
 // Dummies (values that have no real behavior but pass through the system opaquely)
 function createDummyReceiverEvent(type: string = 'dummy_event_type'): ReceiverEvent {
   // NOTE: this is a degenerate ReceiverEvent that would successfully pass through the App. it happens to look like a
@@ -2100,23 +2121,3 @@ function withConversationContext(spy: SinonSpy): Override {
   };
 }
 
-// Fakes
-class FakeReceiver implements Receiver {
-  private bolt: App | undefined;
-
-  public init = (bolt: App) => {
-    this.bolt = bolt;
-  };
-
-  public start = sinon.fake((...params: any[]): Promise<unknown> => {
-    return Promise.resolve([...params]);
-  });
-
-  public stop = sinon.fake((...params: any[]): Promise<unknown> => {
-    return Promise.resolve([...params]);
-  });
-
-  public async sendEvent(event: ReceiverEvent): Promise<void> {
-    return this.bolt?.processEvent(event);
-  }
-}

--- a/src/App.ts
+++ b/src/App.ts
@@ -54,6 +54,17 @@ import allSettled = require('promise.allsettled'); // eslint-disable-line @types
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const packageJson = require('../package.json'); // eslint-disable-line @typescript-eslint/no-var-requires
 
+// ----------------------------
+// For listener registration methods
+
+const validViewTypes = ['view_closed', 'view_submission'];
+
+// ----------------------------
+// For the constructor
+
+const tokenUsage = 'Apps used in one workspace should be initialized with a token. Apps used in many workspaces ' +
+  'should be initialized with oauth installer or authorize.';
+
 /** App initialization options */
 export interface AppOptions {
   signingSecret?: HTTPReceiverOptions['signingSecret'];
@@ -868,12 +879,6 @@ export default class App {
   }
 }
 
-// ----------------------------
-// For the constructor
-
-const tokenUsage =
-  'Apps used in one workspace should be initialized with a token. Apps used in many workspaces ' +
-  'should be initialized with oauth installer or authorize.';
 
 function defaultErrorHandler(logger: Logger): ErrorHandler {
   return (error) => {
@@ -1135,10 +1140,6 @@ function buildRespondFn(
   };
 }
 
-// ----------------------------
-// For listener registration methods
-
-const validViewTypes = ['view_closed', 'view_submission'];
 
 // ----------------------------
 // Instrumentation

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -34,6 +34,18 @@ export enum ErrorCode {
   WorkflowStepInitializationError = 'slack_bolt_workflow_step_initialization_error',
 }
 
+export class UnknownError extends Error implements CodedError {
+  public code = ErrorCode.UnknownError;
+
+  public original: Error;
+
+  constructor(original: Error) {
+    super(original.message);
+
+    this.original = original;
+  }
+}
+
 export function asCodedError(error: CodedError | Error): CodedError {
   if ((error as CodedError).code !== undefined) {
     return error as CodedError;
@@ -110,18 +122,6 @@ export class MultipleListenerError extends Error implements CodedError {
     );
 
     this.originals = originals;
-  }
-}
-
-export class UnknownError extends Error implements CodedError {
-  public code = ErrorCode.UnknownError;
-
-  public original: Error;
-
-  constructor(original: Error) {
-    super(original.message);
-
-    this.original = original;
   }
 }
 

--- a/src/middleware/builtin.spec.ts
+++ b/src/middleware/builtin.spec.ts
@@ -20,6 +20,63 @@ import { SlashCommand } from '../types/command';
 import { AppMentionEvent, AppHomeOpenedEvent } from '../types/events';
 import { GenericMessageEvent } from '../types/events/message-events';
 
+// Test fixtures
+const validCommandPayload: SlashCommand = {
+  token: 'token-value',
+  command: '/hi',
+  text: 'Steve!',
+  response_url: 'https://hooks.slack.com/foo/bar',
+  trigger_id: 'trigger-id-value',
+  user_id: 'U1234567',
+  user_name: 'steve',
+  team_id: 'T1234567',
+  team_domain: 'awesome-eng-team',
+  channel_id: 'C1234567',
+  channel_name: 'random',
+  api_app_id: 'A123456',
+};
+
+const appMentionEvent: AppMentionEvent = {
+  type: 'app_mention',
+  username: 'USERNAME',
+  user: 'U1234567',
+  text: 'this is my message',
+  ts: '123.123',
+  channel: 'C1234567',
+  event_ts: '123.123',
+  thread_ts: '123.123',
+};
+
+const appHomeOpenedEvent: AppHomeOpenedEvent = {
+  type: 'app_home_opened',
+  user: 'USERNAME',
+  channel: 'U1234567',
+  tab: 'home',
+  view: {
+    type: 'home',
+    blocks: [],
+    clear_on_close: false,
+    notify_on_close: false,
+    external_id: '',
+  },
+  event_ts: '123.123',
+};
+
+const botMessageEvent: MessageEvent = {
+  type: 'message',
+  subtype: 'bot_message',
+  channel: 'CHANNEL_ID',
+  event_ts: '123.123',
+  user: 'U1234567',
+  ts: '123.123',
+  text: 'this is my message',
+  bot_id: 'B1234567',
+  channel_type: 'channel',
+};
+
+const noop = () => Promise.resolve(undefined);
+const sayNoop = () => Promise.resolve({ ok: true });
+
 describe('matchMessage()', () => {
   function initializeTestCase(pattern: string | RegExp): Mocha.AsyncFunc {
     return async () => {
@@ -782,59 +839,3 @@ function createFakeAppMentionEvent(text: string = ''): AppMentionEvent {
   };
   return event as AppMentionEvent;
 }
-
-const validCommandPayload: SlashCommand = {
-  token: 'token-value',
-  command: '/hi',
-  text: 'Steve!',
-  response_url: 'https://hooks.slack.com/foo/bar',
-  trigger_id: 'trigger-id-value',
-  user_id: 'U1234567',
-  user_name: 'steve',
-  team_id: 'T1234567',
-  team_domain: 'awesome-eng-team',
-  channel_id: 'C1234567',
-  channel_name: 'random',
-  api_app_id: 'A123456',
-};
-
-const appMentionEvent: AppMentionEvent = {
-  type: 'app_mention',
-  username: 'USERNAME',
-  user: 'U1234567',
-  text: 'this is my message',
-  ts: '123.123',
-  channel: 'C1234567',
-  event_ts: '123.123',
-  thread_ts: '123.123',
-};
-
-const appHomeOpenedEvent: AppHomeOpenedEvent = {
-  type: 'app_home_opened',
-  user: 'USERNAME',
-  channel: 'U1234567',
-  tab: 'home',
-  view: {
-    type: 'home',
-    blocks: [],
-    clear_on_close: false,
-    notify_on_close: false,
-    external_id: '',
-  },
-  event_ts: '123.123',
-};
-
-const botMessageEvent: MessageEvent = {
-  type: 'message',
-  subtype: 'bot_message',
-  channel: 'CHANNEL_ID',
-  event_ts: '123.123',
-  user: 'U1234567',
-  ts: '123.123',
-  text: 'this is my message',
-  bot_id: 'B1234567',
-  channel_type: 'channel',
-};
-
-const noop = () => Promise.resolve(undefined);
-const sayNoop = () => Promise.resolve({ ok: true });

--- a/src/receivers/ExpressReceiver.spec.ts
+++ b/src/receivers/ExpressReceiver.spec.ts
@@ -17,6 +17,34 @@ import ExpressReceiver, {
   verifySignatureAndParseRawBody,
 } from './ExpressReceiver';
 
+// Fakes
+class FakeServer extends EventEmitter {
+  public on = sinon.fake();
+
+  public listen = sinon.fake((...args: any[]) => {
+    if (this.listeningFailure !== undefined) {
+      this.emit('error', this.listeningFailure);
+      return;
+    }
+    setImmediate(() => {
+      args[1]();
+    });
+  });
+
+  public close = sinon.fake((...args: any[]) => {
+    setImmediate(() => {
+      this.emit('close');
+      setImmediate(() => {
+        args[0]();
+      });
+    });
+  });
+
+  public constructor(private listeningFailure?: Error) {
+    super();
+  }
+}
+
 describe('ExpressReceiver', function () {
   beforeEach(function () {
     this.fakeServer = new FakeServer();
@@ -679,28 +707,3 @@ function withHttpsCreateServer(spy: SinonSpy): Override {
   };
 }
 
-// Fakes
-class FakeServer extends EventEmitter {
-  public on = sinon.fake();
-  public listen = sinon.fake((...args: any[]) => {
-    if (this.listeningFailure !== undefined) {
-      this.emit('error', this.listeningFailure);
-      return;
-    }
-    setImmediate(() => {
-      args[1]();
-    });
-  });
-  public close = sinon.fake((...args: any[]) => {
-    setImmediate(() => {
-      this.emit('close');
-      setImmediate(() => {
-        args[0]();
-      });
-    });
-  });
-
-  constructor(private listeningFailure?: Error) {
-    super();
-  }
-}

--- a/src/receivers/HTTPReceiver.ts
+++ b/src/receivers/HTTPReceiver.ts
@@ -17,6 +17,42 @@ import {
   ErrorCode,
 } from '../errors';
 
+// Option keys for tls.createServer() and tls.createSecureContext(), exclusive of those for http.createServer()
+const httpsOptionKeys = [
+  'ALPNProtocols',
+  'clientCertEngine',
+  'enableTrace',
+  'handshakeTimeout',
+  'rejectUnauthorized',
+  'requestCert',
+  'sessionTimeout',
+  'SNICallback',
+  'ticketKeys',
+  'pskCallback',
+  'pskIdentityHint',
+  'ca',
+  'cert',
+  'sigalgs',
+  'ciphers',
+  'clientCertEngine',
+  'crl',
+  'dhparam',
+  'ecdhCurve',
+  'honorCipherOrder',
+  'key',
+  'privateKeyEngine',
+  'privateKeyIdentifier',
+  'maxVersion',
+  'minVersion',
+  'passphrase',
+  'pfx',
+  'secureOptions',
+  'secureProtocol',
+  'sessionIdContext',
+];
+
+const missingServerErrorDescription = 'The receiver cannot be started because private state was mutated. Please report this to the maintainers.';
+
 export interface HTTPReceiverOptions {
   signingSecret: string;
   endpoints?: string | string[];
@@ -435,40 +471,3 @@ function parseBody(req: BufferedIncomingMessage) {
   return JSON.parse(bodyAsString);
 }
 
-// Option keys for tls.createServer() and tls.createSecureContext(), exclusive of those for http.createServer()
-const httpsOptionKeys = [
-  'ALPNProtocols',
-  'clientCertEngine',
-  'enableTrace',
-  'handshakeTimeout',
-  'rejectUnauthorized',
-  'requestCert',
-  'sessionTimeout',
-  'SNICallback',
-  'ticketKeys',
-  'pskCallback',
-  'pskIdentityHint',
-
-  'ca',
-  'cert',
-  'sigalgs',
-  'ciphers',
-  'clientCertEngine',
-  'crl',
-  'dhparam',
-  'ecdhCurve',
-  'honorCipherOrder',
-  'key',
-  'privateKeyEngine',
-  'privateKeyIdentifier',
-  'maxVersion',
-  'minVersion',
-  'passphrase',
-  'pfx',
-  'secureOptions',
-  'secureProtocol',
-  'sessionIdContext',
-];
-
-const missingServerErrorDescription =
-  'The receiver cannot be started because private state was mutated. Please report this to the maintainers.';

--- a/src/receivers/SocketModeReceiver.spec.ts
+++ b/src/receivers/SocketModeReceiver.spec.ts
@@ -11,6 +11,30 @@ import { InstallProvider } from '@slack/oauth';
 import { SocketModeClient } from '@slack/socket-mode';
 import { Override, mergeOverrides } from '../test-helpers';
 
+// Fakes
+class FakeServer extends EventEmitter {
+  public on = sinon.fake();
+
+  public listen = sinon.fake(() => {
+    if (this.listeningFailure !== undefined) {
+      this.emit('error', this.listeningFailure);
+    }
+  });
+
+  public close = sinon.fake((...args: any[]) => {
+    setImmediate(() => {
+      this.emit('close');
+      setImmediate(() => {
+        args[0]();
+      });
+    });
+  });
+
+  public constructor(private listeningFailure?: Error) {
+    super();
+  }
+}
+
 describe('SocketModeReceiver', function () {
   beforeEach(function () {
     this.listener = (_req: any, _res: any) => {};
@@ -307,25 +331,3 @@ function withHttpsCreateServer(spy: SinonSpy): Override {
   };
 }
 
-// Fakes
-class FakeServer extends EventEmitter {
-  public on = sinon.fake();
-  public listen = sinon.fake(() => {
-    if (this.listeningFailure !== undefined) {
-      this.emit('error', this.listeningFailure);
-      return;
-    }
-  });
-  public close = sinon.fake((...args: any[]) => {
-    setImmediate(() => {
-      this.emit('close');
-      setImmediate(() => {
-        args[0]();
-      });
-    });
-  });
-
-  constructor(private listeningFailure?: Error) {
-    super();
-  }
-}

--- a/src/receivers/verify-request.ts
+++ b/src/receivers/verify-request.ts
@@ -15,6 +15,8 @@ import tsscmp from 'tsscmp';
 import type { Logger } from '@slack/logger';
 import type { IncomingMessage, ServerResponse } from 'http';
 
+const verifyErrorPrefix = 'Failed to verify authenticity';
+
 export interface VerifyOptions {
   signingSecret: string;
   nowMs?: () => number;
@@ -112,5 +114,3 @@ function getHeader(req: IncomingMessage, header: string): string {
   }
   return value;
 }
-
-const verifyErrorPrefix = 'Failed to verify authenticity';


### PR DESCRIPTION
###  Summary

This is a PR that should be merged into #1024 and incrementally addresses #842.

No ESLint config changes here - just getting the [`no-use-before-define` rule](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-use-before-define.md) passing. 

### Impact

#### Before

```
✖ 838 problems (649 errors, 189 warnings)
  111 errors and 0 warnings potentially fixable with the `--fix` option.
```

#### After

```
✖ 775 problems (586 errors, 189 warnings)
  109 errors and 0 warnings potentially fixable with the `--fix` option.
```

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).