### PR TITLE
ESLint Config Migration: Tweak the operator-linebreak lint rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -161,7 +161,11 @@ module.exports = {
         '@typescript-eslint/no-use-before-define': ['error', 'nofunc'],
         // Turn off no-inferrable-types. While it may be obvious what the type of something is by its default
         // value, being explicit is good, especially for newcomers.
-        '@typescript-eslint/no-inferrable-types': 'off'
+        '@typescript-eslint/no-inferrable-types': 'off',
+
+        'operator-linebreak': ['error', 'after', { overrides: {
+          '=': 'none'
+        }}],
       },
     },
     {

--- a/src/App.spec.ts
+++ b/src/App.spec.ts
@@ -502,17 +502,16 @@ describe('App', () => {
          * @param orderDown The order it should be called when processing middleware down the chain
          * @param orderUp The order it should be called when processing middleware up the chain
          */
-        const assertOrderMiddleware =
-          (orderDown: number, orderUp: number) => async ({ next }: { next?: NextFn }) => {
-            await delay(100);
-            middlewareCount += 1;
-            assert.equal(middlewareCount, orderDown);
-            if (next !== undefined) {
-              await next();
-            }
-            middlewareCount += 1;
-            assert.equal(middlewareCount, orderUp);
-          };
+        const assertOrderMiddleware = (orderDown: number, orderUp: number) => async ({ next }: { next?: NextFn }) => {
+          await delay(100);
+          middlewareCount += 1;
+          assert.equal(middlewareCount, orderDown);
+          if (next !== undefined) {
+            await next();
+          }
+          middlewareCount += 1;
+          assert.equal(middlewareCount, orderUp);
+        };
 
         app.use(assertOrderMiddleware(1, 8));
         app.message(message, assertOrderMiddleware(3, 6), assertOrderMiddleware(4, 5));

--- a/src/App.ts
+++ b/src/App.ts
@@ -530,10 +530,9 @@ export default class App {
     callbackIdOrConstraints: string | RegExp | Constraints,
     ...listeners: Middleware<SlackShortcutMiddlewareArgs<Extract<Shortcut, { type: Constraints['type'] }>>>[]
   ): void {
-    const constraints: ShortcutConstraints =
-      typeof callbackIdOrConstraints === 'string' || util.types.isRegExp(callbackIdOrConstraints)
-        ? { callback_id: callbackIdOrConstraints }
-        : callbackIdOrConstraints;
+    const constraints: ShortcutConstraints = typeof callbackIdOrConstraints === 'string' || util.types.isRegExp(callbackIdOrConstraints) ?
+      { callback_id: callbackIdOrConstraints } :
+      callbackIdOrConstraints;
 
     // Fail early if the constraints contain invalid keys
     const unknownConstraintKeys = Object.keys(constraints).filter((k) => k !== 'callback_id' && k !== 'type');
@@ -573,10 +572,9 @@ export default class App {
     ...listeners: Middleware<SlackActionMiddlewareArgs<Extract<Action, { type: Constraints['type'] }>>>[]
   ): void {
     // Normalize Constraints
-    const constraints: ActionConstraints =
-      typeof actionIdOrConstraints === 'string' || util.types.isRegExp(actionIdOrConstraints)
-        ? { action_id: actionIdOrConstraints }
-        : actionIdOrConstraints;
+    const constraints: ActionConstraints = typeof actionIdOrConstraints === 'string' || util.types.isRegExp(actionIdOrConstraints) ?
+      { action_id: actionIdOrConstraints } :
+      actionIdOrConstraints;
 
     // Fail early if the constraints contain invalid keys
     const unknownConstraintKeys = Object.keys(constraints).filter(
@@ -610,10 +608,9 @@ export default class App {
     actionIdOrConstraints: string | RegExp | ActionConstraints,
     ...listeners: Middleware<SlackOptionsMiddlewareArgs<Source>>[]
   ): void {
-    const constraints: ActionConstraints =
-      typeof actionIdOrConstraints === 'string' || util.types.isRegExp(actionIdOrConstraints)
-        ? { action_id: actionIdOrConstraints }
-        : actionIdOrConstraints;
+    const constraints: ActionConstraints = typeof actionIdOrConstraints === 'string' || util.types.isRegExp(actionIdOrConstraints) ?
+      { action_id: actionIdOrConstraints } :
+      actionIdOrConstraints;
 
     this.listeners.push([onlyOptions, matchConstraints(constraints), ...listeners] as Middleware<AnyMiddlewareArgs>[]);
   }
@@ -630,10 +627,9 @@ export default class App {
     callbackIdOrConstraints: string | RegExp | ViewConstraints,
     ...listeners: Middleware<SlackViewMiddlewareArgs<ViewActionType>>[]
   ): void {
-    const constraints: ViewConstraints =
-      typeof callbackIdOrConstraints === 'string' || util.types.isRegExp(callbackIdOrConstraints)
-        ? { callback_id: callbackIdOrConstraints, type: 'view_submission' }
-        : callbackIdOrConstraints;
+    const constraints: ViewConstraints = typeof callbackIdOrConstraints === 'string' || util.types.isRegExp(callbackIdOrConstraints) ?
+      { callback_id: callbackIdOrConstraints, type: 'view_submission' } :
+      callbackIdOrConstraints;
     // Fail early if the constraints contain invalid keys
     const unknownConstraintKeys = Object.keys(constraints).filter((k) => k !== 'callback_id' && k !== 'type');
     if (unknownConstraintKeys.length > 0) {
@@ -923,9 +919,9 @@ function runAuthTestForBotToken(
   authorization: Partial<AuthorizeResult> & { botToken: Required<AuthorizeResult>['botToken'] },
 ): Promise<{ botUserId: string; botId: string }> {
   // TODO: warn when something needed isn't found
-  return authorization.botUserId !== undefined && authorization.botId !== undefined
-    ? Promise.resolve({ botUserId: authorization.botUserId, botId: authorization.botId })
-    : client.auth.test({ token: authorization.botToken }).then((result) => ({
+  return authorization.botUserId !== undefined && authorization.botId !== undefined ?
+    Promise.resolve({ botUserId: authorization.botUserId, botId: authorization.botId }) :
+    client.auth.test({ token: authorization.botToken }).then((result) => ({
       botUserId: result.user_id as string,
       botId: result.bot_id as string,
     }));

--- a/src/receivers/AwsLambdaReceiver.spec.ts
+++ b/src/receivers/AwsLambdaReceiver.spec.ts
@@ -224,8 +224,7 @@ describe('AwsLambdaReceiver', function () {
       });
       const handler = awsReceiver.toHandler();
       const timestamp = Math.floor(Date.now() / 1000);
-      const body =
-        'payload=%7B%22type%22%3A%22shortcut%22%2C%22token%22%3A%22fixed-value%22%2C%22action_ts%22%3A%221612879511.716075%22%2C%22team%22%3A%7B%22id%22%3A%22T111%22%2C%22domain%22%3A%22domain-value%22%2C%22enterprise_id%22%3A%22E111%22%2C%22enterprise_name%22%3A%22Sandbox+Org%22%7D%2C%22user%22%3A%7B%22id%22%3A%22W111%22%2C%22username%22%3A%22primary-owner%22%2C%22team_id%22%3A%22T111%22%7D%2C%22is_enterprise_install%22%3Afalse%2C%22enterprise%22%3A%7B%22id%22%3A%22E111%22%2C%22name%22%3A%22Kaz+SDK+Sandbox+Org%22%7D%2C%22callback_id%22%3A%22bolt-js-aws-lambda-shortcut%22%2C%22trigger_id%22%3A%22111.222.xxx%22%7D';
+      const body = 'payload=%7B%22type%22%3A%22shortcut%22%2C%22token%22%3A%22fixed-value%22%2C%22action_ts%22%3A%221612879511.716075%22%2C%22team%22%3A%7B%22id%22%3A%22T111%22%2C%22domain%22%3A%22domain-value%22%2C%22enterprise_id%22%3A%22E111%22%2C%22enterprise_name%22%3A%22Sandbox+Org%22%7D%2C%22user%22%3A%7B%22id%22%3A%22W111%22%2C%22username%22%3A%22primary-owner%22%2C%22team_id%22%3A%22T111%22%7D%2C%22is_enterprise_install%22%3Afalse%2C%22enterprise%22%3A%7B%22id%22%3A%22E111%22%2C%22name%22%3A%22Kaz+SDK+Sandbox+Org%22%7D%2C%22callback_id%22%3A%22bolt-js-aws-lambda-shortcut%22%2C%22trigger_id%22%3A%22111.222.xxx%22%7D';
       const signature = crypto.createHmac('sha256', 'my-secret').update(`v0:${timestamp}:${body}`).digest('hex');
       const awsEvent = {
         resource: '/slack/events',
@@ -279,8 +278,7 @@ describe('AwsLambdaReceiver', function () {
       });
       const handler = awsReceiver.toHandler();
       const timestamp = Math.floor(Date.now() / 1000);
-      const body =
-        'token=fixed-value&team_id=T111&team_domain=domain-value&channel_id=C111&channel_name=random&user_id=W111&user_name=primary-owner&command=%2Fhello-bolt-js&text=&api_app_id=A111&is_enterprise_install=false&enterprise_id=E111&enterprise_name=Sandbox+Org&response_url=https%3A%2F%2Fhooks.slack.com%2Fcommands%2FT111%2F111%2Fxxx&trigger_id=111.222.xxx';
+      const body = 'token=fixed-value&team_id=T111&team_domain=domain-value&channel_id=C111&channel_name=random&user_id=W111&user_name=primary-owner&command=%2Fhello-bolt-js&text=&api_app_id=A111&is_enterprise_install=false&enterprise_id=E111&enterprise_name=Sandbox+Org&response_url=https%3A%2F%2Fhooks.slack.com%2Fcommands%2FT111%2F111%2Fxxx&trigger_id=111.222.xxx';
       const signature = crypto.createHmac('sha256', 'my-secret').update(`v0:${timestamp}:${body}`).digest('hex');
       const awsEvent = {
         resource: '/slack/events',

--- a/src/receivers/AwsLambdaReceiver.ts
+++ b/src/receivers/AwsLambdaReceiver.ts
@@ -59,8 +59,7 @@ export default class AwsLambdaReceiver implements Receiver {
   constructor({ signingSecret, logger = undefined, logLevel = LogLevel.INFO }: AwsLambdaReceiverOptions) {
     // Initialize instance variables, substituting defaults for each value
     this.signingSecret = signingSecret;
-    this.logger =
-      logger ??
+    this.logger = logger ??
       (() => {
         const defaultLogger = new ConsoleLogger();
         defaultLogger.setLevel(logLevel);

--- a/src/receivers/ExpressReceiver.spec.ts
+++ b/src/receivers/ExpressReceiver.spec.ts
@@ -381,8 +381,7 @@ describe('ExpressReceiver', function () {
     const signingSecret = '8f742231b10e8888abcd99yyyzzz85a5';
     const signature = 'v0=a2114d57b48eac39b9ad189dd8316235a7b4a8d21a10bd27519666489c69b503';
     const requestTimestamp = 1531420618;
-    const body =
-      'token=xyzz0WbapA4vBCDEFasx0q6G&team_id=T1DC2JH3J&team_domain=testteamnow&channel_id=G8PSS9T3V&channel_name=foobar&user_id=U2CERLKJA&user_name=roadrunner&command=%2Fwebhook-collect&text=&response_url=https%3A%2F%2Fhooks.slack.com%2Fcommands%2FT1DC2JH3J%2F397700885554%2F96rGlfmibIGlgcZRskXaIFfN&trigger_id=398738663015.47445629121.803a0bc887a14d10d2c447fce8b6703c';
+    const body = 'token=xyzz0WbapA4vBCDEFasx0q6G&team_id=T1DC2JH3J&team_domain=testteamnow&channel_id=G8PSS9T3V&channel_name=foobar&user_id=U2CERLKJA&user_name=roadrunner&command=%2Fwebhook-collect&text=&response_url=https%3A%2F%2Fhooks.slack.com%2Fcommands%2FT1DC2JH3J%2F397700885554%2F96rGlfmibIGlgcZRskXaIFfN&trigger_id=398738663015.47445629121.803a0bc887a14d10d2c447fce8b6703c';
 
     function buildExpressRequest(): Request {
       const reqAsStream = new Readable();

--- a/src/receivers/ExpressReceiver.ts
+++ b/src/receivers/ExpressReceiver.ts
@@ -184,8 +184,9 @@ export default class ExpressReceiver implements Receiver {
 
     // Add OAuth routes to receiver
     if (this.installer !== undefined) {
-      const redirectUriPath =
-        installerOptions.redirectUriPath === undefined ? '/slack/oauth_redirect' : installerOptions.redirectUriPath;
+      const redirectUriPath = installerOptions.redirectUriPath === undefined ?
+        '/slack/oauth_redirect' :
+        installerOptions.redirectUriPath;
       this.router.use(redirectUriPath, async (req, res) => {
         await this.installer!.handleCallback(req, res, installerOptions.callbackOptions);
       });
@@ -399,8 +400,9 @@ export function verifySignatureAndParseRawBody(
 }
 
 function logError(logger: Logger, message: string, error: any): void {
-  const logMessage =
-    'code' in error ? `${message} (code: ${error.code}, message: ${error.message})` : `${message} (error: ${error})`;
+  const logMessage = 'code' in error ?
+    `${message} (code: ${error.code}, message: ${error.message})` :
+    `${message} (error: ${error})`;
   logger.warn(logMessage);
 }
 

--- a/src/receivers/HTTPReceiver.ts
+++ b/src/receivers/HTTPReceiver.ts
@@ -123,8 +123,7 @@ export default class HTTPReceiver implements Receiver {
     // Initialize instance variables, substituting defaults for each value
     this.signingSecret = signingSecret;
     this.processBeforeResponse = processBeforeResponse;
-    this.logger =
-      logger ??
+    this.logger = logger ??
       (() => {
         const defaultLogger = new ConsoleLogger();
         defaultLogger.setLevel(logLevel);

--- a/src/receivers/SocketModeReceiver.ts
+++ b/src/receivers/SocketModeReceiver.ts
@@ -96,8 +96,7 @@ export default class SocketModeReceiver implements Receiver {
     // Add OAuth routes to receiver
     if (this.installer !== undefined) {
       // use default or passed in redirect path
-      const redirectUriPath =
-        installerOptions.redirectUriPath === undefined ? '/slack/oauth_redirect' : installerOptions.redirectUriPath;
+      const redirectUriPath = installerOptions.redirectUriPath === undefined ? '/slack/oauth_redirect' : installerOptions.redirectUriPath;
 
       // use default or passed in installPath
       const installPath = installerOptions.installPath === undefined ? '/slack/install' : installerOptions.installPath;


### PR DESCRIPTION
###  Summary

This is a PR that should be merged into #1024 and incrementally addresses #842.

This PR tweaks the [`operator-linebreak` rule](https://eslint.org/docs/rules/operator-linebreak) such that:

- forbid line breaks around the = operator
- require other operators to be at the end of the line

What do folks think?

### Impact

#### Before

```
✖ 362 problems (173 errors, 189 warnings)
  76 errors and 0 warnings potentially fixable with the `--fix` option.
```

#### After

```
✖ 306 problems (117 errors, 189 warnings)
  20 errors and 0 warnings potentially fixable with the `--fix` option.
```

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).