### PR TITLE
Fix #1038 by making the AwsLambdaReceiver example TS compatible

### DIFF
--- a/examples/deploy-aws-lambda/app.js
+++ b/examples/deploy-aws-lambda/app.js
@@ -57,6 +57,6 @@ app.message('goodbye', async ({ message, say }) => {
 
 // Handle the Lambda function event
 module.exports.handler = async (event, context, callback) => {
-  const handler = await app.start();
+  const handler = await awsLambdaReceiver.start();
   return handler(event, context, callback);
 }

--- a/src/App.ts
+++ b/src/App.ts
@@ -433,6 +433,7 @@ export default class App {
   public start(
     ...args: Parameters<HTTPReceiver['start'] | SocketModeReceiver['start']>
   ): ReturnType<HTTPReceiver['start']> {
+    // TODO: HTTPReceiver['start'] should be the actual receiver's return type
     return this.receiver.start(...args) as ReturnType<HTTPReceiver['start']>;
   }
 

--- a/src/receivers/AwsLambdaReceiver.spec.ts
+++ b/src/receivers/AwsLambdaReceiver.spec.ts
@@ -8,6 +8,7 @@ import AwsLambdaReceiver from './AwsLambdaReceiver';
 import crypto from 'crypto';
 import rewiremock from 'rewiremock';
 import { WebClientOptions } from '@slack/web-api';
+import { AwsHandler } from './AwsLambdaReceiver';
 
 describe('AwsLambdaReceiver', function () {
   beforeEach(function () {});
@@ -48,7 +49,7 @@ describe('AwsLambdaReceiver', function () {
       const awsReceiver = new AwsLambdaReceiver({
         signingSecret: 'my-secret',
       });
-      const handler = await awsReceiver.start();
+      const handler: AwsHandler = await awsReceiver.start();
       assert.isNotNull(handler);
     });
 


### PR DESCRIPTION
###  Summary

This pull request fixes #1038

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).