### PR TITLE
ESLint Config Migration: Remove no-inferrable-types rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -159,6 +159,9 @@ module.exports = {
         // override section below because a distinct override is necessary in JavaScript files.
         'no-use-before-define': 'off',
         '@typescript-eslint/no-use-before-define': ['error', 'nofunc'],
+        // Turn off no-inferrable-types. While it may be obvious what the type of something is by its default
+        // value, being explicit is good, especially for newcomers.
+        '@typescript-eslint/no-inferrable-types': 'off'
       },
     },
     {


### PR DESCRIPTION
###  Summary

This is a PR that should be merged into #1024 and incrementally addresses #842.

This PR turns off the [`no-inferrable-types` rule](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-inferrable-types.md). My thinking behind this is that, while extraneous, being specific about the type of a variable even when it can be inferred from its initialization value may be helpful to folks, especially those whom may be unfamiliar with TypeScript.

Example code that failed this rule previously:

```
export function delay(ms: number = 0): Promise<void> {
```

In the above, because the default value of `ms` is set to `0`, it can be inferred from the default value that the type of `ms` is `number`. Thus, the `no-inferrable-types` rule would fail.

What do folks think?

### Impact

#### Before

```
✖ 362 problems (173 errors, 189 warnings)
  76 errors and 0 warnings potentially fixable with the `--fix` option.
```

#### After

```
✖ 358 problems (169 errors, 189 warnings)
  72 errors and 0 warnings potentially fixable with the `--fix` option.
```


### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).