### PR TITLE
ESLint Config Migration: Add test-specific ruleset

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -115,9 +115,10 @@ module.exports = {
         // Require class properties and methods to explicitly use accessibility modifiers (public, private, protected)
         '@typescript-eslint/explicit-member-accessibility': 'error',
 
-        // Forbids an object literal to appear in a type assertion expression unless its used as a parameter. This
-        // allows the typechecker to perform validation on the value as an assignment, instead of allowing the type
-        // assertion to always win.
+        // Forbids an object literal to appear in a type assertion expression unless its used as a parameter (we violate
+        // this rule for test code, to allow for looser property matching for objects - more in the test-specific rules
+        // section below). This allows the typechecker to perform validation on the value as an assignment, instead of
+        // allowing the type assertion to always win.
         // Requires use of `as Type` instead of `<Type>` for type assertion. Consistency.
         '@typescript-eslint/consistent-type-assertions': ['error', {
           assertionStyle: 'as',
@@ -224,7 +225,7 @@ module.exports = {
           },
           {
             'selector': 'objectLiteralProperty',
-            format: ['camelCase', 'snake_case', 'PascalCase'] 
+            format: ['camelCase', 'snake_case', 'PascalCase'],
           },
           {
             selector: ['enumMember'],
@@ -254,6 +255,36 @@ module.exports = {
         // styles.
         'object-curly-newline': ['error', { multiline: true, consistent: true }],
 
+      },
+    },
+    {
+      files: ['src/**/*.spec.ts'],
+      rules: {
+        // Test-specific rules
+        // ---
+        // Rules that only apply to Typescript _test_ source files
+
+        // With Mocha as a test framework, it is sometimes helpful to assign
+        // shared state to Mocha's Context object, for example in setup and
+        // teardown test methods. Assigning stub/mock objects to the Context
+        // object via `this` is a common pattern in Mocha. As such, using
+        // `function` over the the arrow notation binds `this` appropriately and
+        // should be used in tests. So: we turn off the prefer-arrow-callback
+        // rule.
+        // See https://github.com/slackapi/bolt-js/pull/1012#pullrequestreview-711232738
+        // for a case of arrow-vs-function syntax coming up for the team
+        'prefer-arrow-callback': 'off',
+
+        // Unlike non-test-code, where we require use of `as Type` instead of `<Type>` for type assertion,
+        // in test code using the looser `as Type` syntax leads to easier test writing, since only required
+        // properties must be adhered to using the `as Type` syntax.
+        '@typescript-eslint/consistent-type-assertions': ['error', {
+          assertionStyle: 'as',
+          objectLiteralTypeAssertions: 'allow',
+        }],
+        // In tests, don't force constructing a Symbol with a descriptor, as
+        // it's probably just for tests
+        'symbol-description': 'off',
       },
     },
   ],


### PR DESCRIPTION
###  Summary

This is a PR that should be merged into #1024 and incrementally addresses #842.

This PR adds test-code-specific rules:

- Turns off the [`prefer-arrow-callback rule`](https://eslint.org/docs/rules/prefer-arrow-callback) - but only for test files (i.e. `**/*.spec.ts`). The use of `function` over arrow syntax actually came up when writing tests in one time in Mocha (see https://github.com/slackapi/bolt-js/pull/1012#pullrequestreview-711232738). As such, we shouldn't have the linter recommend to use only arrow functions in test files, as that may lead to the same situation as in #1012.
- Loosens up how we do type assertions in code (via the [`consistent-type-assertions`](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/consistent-type-assertions.md) rule), to allow for the `const x = { ... } as T` over the `const x: T = { ... }` syntax. The latter requires all properties of a type to be declared, whereas the former requires only the required properties to be defined. I believe the `as T` syntax is handy to have in test code.
- Turns off the [`symbol-descriptor`](https://eslint.org/docs/rules/symbol-description) rule and allows for creating `Symbol` objects without a descriptor.

### Impact

#### Before

```
✖ 362 problems (173 errors, 189 warnings)
  76 errors and 0 warnings potentially fixable with the `--fix` option.
```

#### After

```
✖ 330 problems (141 errors, 189 warnings)
  64 errors and 0 warnings potentially fixable with the `--fix` option.
```

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).