### PR TITLE
ESLint Config Migration: Allow unused vars with leading underscores

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -190,21 +190,26 @@ module.exports = {
         // both purposes, and it works fine on non-TypeScript code.
         camelcase: 'off',
         'no-underscore-dangle': 'off',
+        '@typescript-eslint/no-unused-vars': [
+          'error',
+          {
+            varsIgnorePattern: '^_',
+            argsIgnorePattern: '^_'
+          }
+        ],
         '@typescript-eslint/naming-convention': [
           'error',
           {
             selector: 'default',
             format: ['camelCase'],
-            filter: {
-              regex: '^_',
-              match: false
-            },
+            leadingUnderscore: 'allow',
           },
           {
             selector: 'variable',
             // PascalCase for variables is added to allow exporting a singleton, function library, or bare object as in
             // section 23.8 of the AirBnB style guide
             format: ['camelCase', 'PascalCase', 'UPPER_CASE', 'snake_case'],
+            leadingUnderscore: 'allow',
           },
           {
             selector: 'parameter',
@@ -214,10 +219,7 @@ module.exports = {
           {
             selector: 'typeLike',
             format: ['PascalCase', 'camelCase'],
-            filter: {
-              regex: '^_',
-              match: false
-            },
+            leadingUnderscore: 'allow',
           },
           {
             selector: 'typeProperty',

--- a/src/WorkflowStep.spec.ts
+++ b/src/WorkflowStep.spec.ts
@@ -291,7 +291,7 @@ describe('WorkflowStep', () => {
 
   describe('processStepMiddleware', () => {
     it('should call each callback in user-provided middleware', async () => {
-      const { next, ...fakeArgs } = createFakeStepEditAction() as unknown as AllWorkflowStepMiddlewareArgs;
+      const { next: _next, ...fakeArgs } = createFakeStepEditAction() as unknown as AllWorkflowStepMiddlewareArgs;
       const { processStepMiddleware } = await importWorkflowStep();
 
       const fn1 = sinon.spy((async ({ next: continuation }) => {

--- a/src/WorkflowStep.ts
+++ b/src/WorkflowStep.ts
@@ -347,7 +347,7 @@ function createStepFail(args: AllWorkflowStepMiddlewareArgs<WorkflowStepExecuteM
  * */
 // TODO :: refactor to incorporate a generic parameter
 export function prepareStepArgs(args: any): AllWorkflowStepMiddlewareArgs {
-  const { next, ...stepArgs } = args;
+  const { next: _next, ...stepArgs } = args;
   const preparedArgs: any = { ...stepArgs };
 
   switch (preparedArgs.payload.type) {


### PR DESCRIPTION
###  Summary

This is a PR that should be merged into #1024 and incrementally addresses #842.

This PR turns extends the [`@typescript-eslint/no-unused-vars rule`](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-unused-vars.md) (for reference: [base ESLint `no-unused-vars` rule](https://eslint.org/docs/rules/no-unused-vars)).

Leading underscores are allowed for variable and argument names and is intended to signify "ignore this variable."

### Impact

#### Before

```
✖ 362 problems (173 errors, 189 warnings)
  76 errors and 0 warnings potentially fixable with the `--fix` option.
```

#### After

```
✖ 340 problems (151 errors, 189 warnings)
  76 errors and 0 warnings potentially fixable with the `--fix` option.
```

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).