### PR TITLE
ESLint Config Migration: Turn off consistent-return from linting rules

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -6,7 +6,6 @@
 // the communities' recommended styles for the technologies used as we can. When, and only when, we have a stated need
 // to differentiate, we add more rules (or modify options). Therefore, the fewer rules directly defined in this file,
 // the better.
-//
 
 const jsDocPlugin = require('eslint-plugin-jsdoc');
 
@@ -159,6 +158,10 @@ module.exports = {
         // override section below because a distinct override is necessary in JavaScript files.
         'no-use-before-define': 'off',
         '@typescript-eslint/no-use-before-define': ['error', 'nofunc'],
+        
+        // In mixed async + Promise code, consistent-return can be a pain to
+        // adhere to
+        'consistent-return': 'off',
       },
     },
     {


### PR DESCRIPTION
###  Summary

This is a PR that should be merged into #1024 and incrementally addresses #842.

This PR turns off the [`consistent-return`](https://eslint.org/docs/rules/consistent-return) rule.

In mixed async + Promise code, it can be a pain to adhere to the rule. For an example, see the [`stop` method of `HTTPReceiver.ts`](https://github.com/slackapi/bolt-js/blob/tslint-to-eslint/src/receivers/HTTPReceiver.ts#L253-L267). Both the [outer `Promise`](https://github.com/slackapi/bolt-js/blob/tslint-to-eslint/src/receivers/HTTPReceiver.ts#L254) as well as the [inner `server.close`](https://github.com/slackapi/bolt-js/blob/tslint-to-eslint/src/receivers/HTTPReceiver.ts#L258) methods raise the following lint failure:

```
  254:42  error    Expected to return a value at the end of arrow function          consistent-return
  258:33  error    Expected to return a value at the end of arrow function          consistent-return
```

What does everyone think? Is there a better way to implement the `stop` method without violating this rule?

### Impact

#### Before

```
✖ 362 problems (173 errors, 189 warnings)
  76 errors and 0 warnings potentially fixable with the `--fix` option.
```

#### After

```
✖ 353 problems (164 errors, 189 warnings)
  76 errors and 0 warnings potentially fixable with the `--fix` option.
```

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).