### PR TITLE
ESLint Config Migration: Remove strict-boolean-expressions rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -6,7 +6,6 @@
 // the communities' recommended styles for the technologies used as we can. When, and only when, we have a stated need
 // to differentiate, we add more rules (or modify options). Therefore, the fewer rules directly defined in this file,
 // the better.
-//
 
 const jsDocPlugin = require('eslint-plugin-jsdoc');
 
@@ -108,15 +107,6 @@ module.exports = {
         // NOTE: Consider contributing this to the `airbnb-typescript` config.
         'import/named': 'off',
         'node/no-missing-import': 'off',
-
-        // Prevent using non-boolean types as conditions. This ensures we're not relying on implicit type coercions in
-        // conditionals, which can lead to unintended behavior.
-        // NOTE: Consider contributing this to the `airbnb-typescript` config. https://github.com/airbnb/javascript#comparison--shortcuts
-        '@typescript-eslint/strict-boolean-expressions': ['error', {
-          allowString: false,
-          allowNumber: false,
-          allowNullableObject: false,
-        }],
 
         // Prefer an interface declaration over a type alias because interfaces can be extended, implemented, and merged
         '@typescript-eslint/consistent-type-definitions': ['error', 'interface'],


### PR DESCRIPTION
###  Summary

This is a PR that should be merged into #1024 and incrementally addresses #842.

This PR turns off the [`@typescript-eslint/strict-boolean-expressions`](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/strict-boolean-expressions.md) rule. While on the surface the intention of the rule makes sense ("prevent implicit casting to Boolean of conditional expressions"), in practice this rule gets in the way.

Consider the following real example from this code base, from [`ExpressReceiver.spec.ts`](https://github.com/slackapi/bolt-js/blob/main/src/receivers/ExpressReceiver.spec.ts#L398):

```
const verifier = verifySignatureAndParseRawBody(noopLogger, signingSecretFn || signingSecret);
```

The error raised by this line is:

```
  426:68   error    Unexpected value in conditional. A boolean expression is required  @typescript-eslint/strict-boolean-expressions
```

Essentially, any values taking part in a short-circuit logical operation (like `||` or `&&`) must be a boolean. Therefore, the common pattern seen in JS/TS of using `||` as a means of declaring default values would always be invalid.

My suggestions is to remove this rule, as it does not seem to allow for customization to avoid the above scenario, but what does everyone else think?

### Impact

#### Before

```
✖ 362 problems (173 errors, 189 warnings)
  76 errors and 0 warnings potentially fixable with the `--fix` option.
```

#### After

```
✖ 358 problems (169 errors, 189 warnings)
  75 errors and 0 warnings potentially fixable with the `--fix` option.
```

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).