### PR TITLE
ESLint Config Migration: Object property names enclosed with quotes require no naming convention

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -202,6 +202,16 @@ module.exports = {
             },
           },
           {
+            // When defining properties on an object...
+            selector: 'objectLiteralProperty',
+            // ... do not enforce any particular format...
+            format: null,
+            // ... when the property name is enclosed in quotes
+            modifiers: ['requiresQuotes'],
+            // The above is useful for things like quoting HTTP header names
+            // i.e. { 'Content-Type': 'application/json' }
+          },
+          {
             selector: 'variable',
             // PascalCase for variables is added to allow exporting a singleton, function library, or bare object as in
             // section 23.8 of the AirBnB style guide


### PR DESCRIPTION
###  Summary

This is a PR that should be merged into #1024 and incrementally addresses #842.

This PR tweaks the naming convention rule such that object properties enclosed in quotes do not need to adhere to specific naming conventions. This is useful for things like specifying HTTP header names as properties on an object, since HTTP header names typically use a kabob-case naming convention (usually capitalized, too).

### Impact

#### Before

```
✖ 765 problems (576 errors, 189 warnings)
  103 errors and 0 warnings potentially fixable with the `--fix` option.
```

#### After

```
✖ 761 problems (572 errors, 189 warnings)
  103 errors and 0 warnings potentially fixable with the `--fix` option.
```

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).