### PR TITLE
ESLint Config Migration: Enum members should use PascalCase

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -226,6 +226,10 @@ module.exports = {
             'selector': 'objectLiteralProperty',
             format: ['camelCase', 'snake_case', 'PascalCase'] 
           },
+          {
+            selector: ['enumMember'],
+            format: ['PascalCase'],
+          },
         ],
 
         // Allow cyclical imports. Turning this rule on is mainly a way to manage the performance concern for linting


### PR DESCRIPTION
###  Summary

This is a PR that should be merged into #1024 and incrementally addresses #842.

It enforces a naming convention around Enum Members to be PascalCase.

### Impact

#### Before

```
✖ 362 problems (173 errors, 189 warnings)
  76 errors and 0 warnings potentially fixable with the `--fix` option.
```

#### After

```
✖ 346 problems (157 errors, 189 warnings)
  76 errors and 0 warnings potentially fixable with the `--fix` option.
```

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).