### PR TITLE
ESLint Config Migration: Use tsconfig's resolveJsonModule, replace require with import

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # node / npm stuff
 /node_modules
 /package-lock.json
+tsconfig.tsbuildinfo
 
 # build products
 /dist

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "scripts": {
     "prepare": "npm run build",
-    "build": "tsc",
+    "build": "npm run build:clean && tsc",
     "build:clean": "shx rm -rf ./dist ./coverage ./.nyc_output",
     "lint": "eslint --ext .ts src",
     "mocha": "TS_NODE_PROJECT=tsconfig.json nyc mocha --config .mocharc.json \"src/**/*.spec.ts\"",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,9 @@
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
-    "dist/**/*"
+    "dist/**/*.map",
+    "dist/**/*.js",
+    "dist/**/*.d.ts"
   ],
   "engines": {
     "node": ">=12.13.0",
@@ -26,12 +28,12 @@
   },
   "scripts": {
     "prepare": "npm run build",
-    "build": "npm run build:clean && tsc",
+    "build": "npm run build:clean && tsc --build src",
     "build:clean": "shx rm -rf ./dist ./coverage ./.nyc_output",
     "lint": "eslint --ext .ts src",
-    "mocha": "TS_NODE_PROJECT=tsconfig.json nyc mocha --config .mocharc.json \"src/**/*.spec.ts\"",
+    "mocha": "TS_NODE_PROJECT=src/tsconfig.json nyc mocha --config .mocharc.json \"src/**/*.spec.ts\"",
     "test": "npm run lint && npm run mocha && npm run test:types",
-    "test:types": "tsd",
+    "test:types": "tsd types-tests",
     "coverage": "codecov",
     "watch": "npx nodemon --watch 'src' --ext 'ts' --exec npm run build"
   },
@@ -81,8 +83,5 @@
     "ts-node": "^8.1.0",
     "tsd": "^0.13.1",
     "typescript": "^4.1.0"
-  },
-  "tsd": {
-    "directory": "types-tests"
   }
 }

--- a/src/App.ts
+++ b/src/App.ts
@@ -59,8 +59,7 @@ import { IncomingEventType, getTypeAndConversation, assertNever } from './helper
 import { CodedError, asCodedError, AppInitializationError, MultipleListenerError } from './errors';
 // eslint-disable-next-line import/order
 import allSettled = require('promise.allsettled'); // eslint-disable-line @typescript-eslint/no-require-imports
-// eslint-disable-next-line @typescript-eslint/no-require-imports
-const packageJson = require('../package.json'); // eslint-disable-line @typescript-eslint/no-var-requires
+import packageJson from '../package.json';
 
 // ----------------------------
 // For listener registration methods

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,5 @@
 import pleaseUpgradeNode from 'please-upgrade-node';
-// eslint-disable-next-line @typescript-eslint/no-require-imports
-const packageJson = require('../package.json'); // eslint-disable-line @typescript-eslint/no-var-requires
+import packageJson from '../package.json';
 
 pleaseUpgradeNode(packageJson);
 

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -12,7 +12,7 @@
     "declarationMap": true,                   /* Generates a sourcemap for each corresponding '.d.ts' file. */
     "sourceMap": true,                        /* Generates corresponding '.map' file. */
     // "outFile": "./",                       /* Concatenate and emit output to single file. */
-    "outDir": ".",                        /* Redirect output structure to the directory. */
+    "outDir": "../dist",                        /* Redirect output structure to the directory. */
     "rootDir": ".",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
     "composite": true,                     /* Enable project compilation */
     // "removeComments": true,                /* Do not emit comments to output. */
@@ -40,7 +40,7 @@
     "moduleResolution": "node",               /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
     "baseUrl": ".",                           /* Base directory to resolve non-absolute module names. */
     "paths": {                                /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
-      "*": ["./types/*"]
+      "*": ["../types/*"]
     },
     // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
     // "typeRoots": [],                       /* List of folders to include type definitions from. */
@@ -59,5 +59,15 @@
     // "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
     // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
   },
-  "files": ["package.json"],
+  "references": [
+    { "path": "../" },
+  ],
+  "include": [
+    "**/*",
+  ],
+  "exclude": [
+    "**/*.spec.ts",
+    "test-helpers.ts",
+    "**/tsconfig.tsbuildinfo",
+  ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     /* Basic Options */
     "target": "ES2018",                       /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */
     "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
-    // "resolveJsonModule": true,
+    "resolveJsonModule": true,
     // "lib": [],                             /* Specify library files to be included in the compilation. */
     // "allowJs": true,                       /* Allow javascript files to be compiled. */
     // "checkJs": true,                       /* Report errors in .js files. */

--- a/types-tests/package.json
+++ b/types-tests/package.json
@@ -1,0 +1,6 @@
+{
+    "types": "dummy.d.ts",
+    "tsd": {
+        "directory": "../src"
+    }
+}

--- a/types-tests/tsconfig.json
+++ b/types-tests/tsconfig.json
@@ -1,0 +1,32 @@
+{
+  "compilerOptions": {
+    /* Basic Options */
+    "target": "ES2018",                       /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */
+    "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
+    "resolveJsonModule": true,
+    "declaration": true,                      /* Generates corresponding '.d.ts' file. */
+    "declarationMap": true,                   /* Generates a sourcemap for each corresponding '.d.ts' file. */
+    "sourceMap": true,                        /* Generates corresponding '.map' file. */
+    "outDir": "../dist",                        /* Redirect output structure to the directory. */
+    "rootDir": "..",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
+    /* Strict Type-Checking Options */
+    "strict": true,                           /* Enable all strict type-checking options. */
+
+    /* Additional Checks */
+    "noUnusedLocals": true,                   /* Report errors on unused locals. */
+    "noUnusedParameters": true,               /* Report errors on unused parameters. */
+    "noImplicitReturns": true,                /* Report error when not all code paths in function return a value. */
+    "noFallthroughCasesInSwitch": true,       /* Report errors for fallthrough cases in switch statement. */
+
+    /* Module Resolution Options */
+    "moduleResolution": "node",               /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
+    "baseUrl": ".",                           /* Base directory to resolve non-absolute module names. */
+    "paths": {                                /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
+      "*": ["../types/*"]
+    },
+    "esModuleInterop": true                   /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
+  },
+  "include": [
+    "**/*",
+  ]
+}


### PR DESCRIPTION
###  Summary

This is a PR that should be merged into #1024 and incrementally addresses #842.

This PR sets [`resolveJsonModules`](https://www.typescriptlang.org/tsconfig#resolveJsonModule) to true in the `tsconfig.json`, allowing for use of `import` on .json files, and thus fixing the lint failures around use of `require`.

### Impact

#### Before

```
✖ 362 problems (173 errors, 189 warnings)
  76 errors and 0 warnings potentially fixable with the `--fix` option.
```

#### After

```
✖ 360 problems (171 errors, 189 warnings)
  76 errors and 0 warnings potentially fixable with the `--fix` option.
```

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).