### PR TITLE
ESLint Config Migration: Disable max-classes-per-file rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -92,6 +92,7 @@ module.exports = {
         // This level of this configuration contains rules which apply only to TypeScript. It also contains rules that
         // are meant to override options or disable rules in the base configurations (there are no more base
         // configurations in the subsequent overrides).
+        'max-classes-per-file': 'off',
 
         // Disallow invocations of require(). This will help make imports more consistent and ensures a smoother
         // transition to the best future syntax. And since this rule affects TypeScript, which is compiled, there's


### PR DESCRIPTION
### Summary

This is a PR that should be merged into #1024 and incrementally addresses #842.

This PR disables the [`max-classes-per-file` rule](https://eslint.org/docs/rules/max-classes-per-file). There are many situations you would want multiple classes per file, such as a generic [errors module](https://github.com/slackapi/bolt-js/blob/main/src/errors.ts) or test files that include helper mock classes. As such, I think it would be good to turn this rule off. Alternatively, we can customize the maximum number of classes to something higher.

What do folks think?

### Impact

#### Before

```
✖ 362 problems (173 errors, 189 warnings)
  76 errors and 0 warnings potentially fixable with the `--fix` option.
```

#### After

```
✖ 359 problems (170 errors, 189 warnings)
  76 errors and 0 warnings potentially fixable with the `--fix` option.
```

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).