### PR TITLE
ESLint Config Migration: Disable the only occurrences of no-nested-ternary rule violation

### DIFF
--- a/src/App.ts
+++ b/src/App.ts
@@ -719,7 +719,38 @@ export default class App {
       };
     };
 
-    // Set body and payload (this value will eventually conform to AnyMiddlewareArgs)
+    // Set body and payload
+    // TODO: this value should eventually conform to AnyMiddlewareArgs
+    let payload: any = {};
+    switch (type) {
+      case IncomingEventType.Event:
+        payload = (bodyArg as SlackEventMiddlewareArgs['body']).event;
+        break;
+      case IncomingEventType.ViewAction:
+        payload = (bodyArg as SlackViewMiddlewareArgs['body']).view;
+        break;
+      case IncomingEventType.Shortcut:
+        payload = (bodyArg as SlackShortcutMiddlewareArgs['body']);
+        break;
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore: Fallthrough case in switch
+      case IncomingEventType.Action:
+        if (isBlockActionOrInteractiveMessageBody(bodyArg as SlackActionMiddlewareArgs['body'])) {
+          const { actions } = (bodyArg as SlackActionMiddlewareArgs<BlockAction | InteractiveMessage>['body']);
+          [payload] = actions;
+          break;
+        }
+        // If above conditional does not hit, fall through to fallback payload in default block below
+      default:
+        payload = (bodyArg as (
+          | Exclude<
+          AnyMiddlewareArgs,
+          SlackEventMiddlewareArgs | SlackActionMiddlewareArgs | SlackViewMiddlewareArgs
+          >
+          | SlackActionMiddlewareArgs<Exclude<SlackAction, BlockAction | InteractiveMessage>>
+        )['body']);
+        break;
+    }
     // NOTE: the following doesn't work because... distributive?
     // const listenerArgs: Partial<AnyMiddlewareArgs> = {
     const listenerArgs: Pick<AnyMiddlewareArgs, 'body' | 'payload'> & {
@@ -731,23 +762,7 @@ export default class App {
       ack?: AckFn<any>;
     } = {
       body: bodyArg,
-      payload:
-        type === IncomingEventType.Event // eslint-disable-line no-nested-ternary
-          ? (bodyArg as SlackEventMiddlewareArgs['body']).event
-          : type === IncomingEventType.ViewAction // eslint-disable-line no-nested-ternary
-            ? (bodyArg as SlackViewMiddlewareArgs['body']).view
-            : type === IncomingEventType.Shortcut // eslint-disable-line no-nested-ternary
-              ? (bodyArg as SlackShortcutMiddlewareArgs['body'])
-              : type === IncomingEventType.Action &&
-                isBlockActionOrInteractiveMessageBody(bodyArg as SlackActionMiddlewareArgs['body'])
-                ? (bodyArg as SlackActionMiddlewareArgs<BlockAction | InteractiveMessage>['body']).actions[0]
-                : (bodyArg as (
-                  | Exclude<
-                  AnyMiddlewareArgs,
-                  SlackEventMiddlewareArgs | SlackActionMiddlewareArgs | SlackViewMiddlewareArgs
-                  >
-                  | SlackActionMiddlewareArgs<Exclude<SlackAction, BlockAction | InteractiveMessage>>
-                )['body']),
+      payload,
     };
 
     // Set aliases

--- a/src/App.ts
+++ b/src/App.ts
@@ -732,11 +732,11 @@ export default class App {
     } = {
       body: bodyArg,
       payload:
-        type === IncomingEventType.Event
+        type === IncomingEventType.Event // eslint-disable-line no-nested-ternary
           ? (bodyArg as SlackEventMiddlewareArgs['body']).event
-          : type === IncomingEventType.ViewAction
+          : type === IncomingEventType.ViewAction // eslint-disable-line no-nested-ternary
             ? (bodyArg as SlackViewMiddlewareArgs['body']).view
-            : type === IncomingEventType.Shortcut
+            : type === IncomingEventType.Shortcut // eslint-disable-line no-nested-ternary
               ? (bodyArg as SlackShortcutMiddlewareArgs['body'])
               : type === IncomingEventType.Action &&
                 isBlockActionOrInteractiveMessageBody(bodyArg as SlackActionMiddlewareArgs['body'])

--- a/src/App.ts
+++ b/src/App.ts
@@ -46,6 +46,14 @@ import {
   Receiver,
   ReceiverEvent,
   RespondArguments,
+  DialogSubmitAction,
+  BlockElementAction,
+  InteractiveAction,
+  ViewOutput,
+  KnownOptionsPayloadFromType,
+  KnownEventFromType,
+  SlashCommand,
+  WorkflowStepEdit,
 } from './types';
 import { IncomingEventType, getTypeAndConversation, assertNever } from './helpers';
 import { CodedError, asCodedError, AppInitializationError, MultipleListenerError } from './errors';
@@ -721,7 +729,8 @@ export default class App {
 
     // Set body and payload
     // TODO: this value should eventually conform to AnyMiddlewareArgs
-    let payload: any = {};
+    let payload: DialogSubmitAction | WorkflowStepEdit | SlackShortcut | KnownEventFromType<string> | SlashCommand
+    | KnownOptionsPayloadFromType<string> | BlockElementAction | ViewOutput | InteractiveAction;
     switch (type) {
       case IncomingEventType.Event:
         payload = (bodyArg as SlackEventMiddlewareArgs['body']).event;

--- a/src/types/events/index.ts
+++ b/src/types/events/index.ts
@@ -60,8 +60,10 @@ interface Authorization {
  * When the string matches known event(s) from the `SlackEvent` union, only those types are returned (also as a union).
  * Otherwise, the `BasicSlackEvent<T>` type is returned.
  */
-type EventFromType<T extends string> = KnownEventFromType<T> extends never ? BasicSlackEvent<T> : KnownEventFromType<T>;
-type KnownEventFromType<T extends string> = Extract<SlackEvent, { type: T }>;
+export type EventFromType<T extends string> = KnownEventFromType<T> extends never ?
+  BasicSlackEvent<T> :
+  KnownEventFromType<T>;
+export type KnownEventFromType<T extends string> = Extract<SlackEvent, { type: T }>;
 
 /**
  * Type function which tests whether or not the given `Event` contains a channel ID context for where the event

--- a/src/types/options/index.ts
+++ b/src/types/options/index.ts
@@ -25,11 +25,11 @@ export interface BasicOptionsPayload<Type extends string = string> {
   value: string;
 }
 
-type OptionsPayloadFromType<T extends string> = KnownOptionsPayloadFromType<T> extends never
+export type OptionsPayloadFromType<T extends string> = KnownOptionsPayloadFromType<T> extends never
   ? BasicOptionsPayload<T>
   : KnownOptionsPayloadFromType<T>;
 
-type KnownOptionsPayloadFromType<T extends string> = Extract<SlackOptions, { type: T }>;
+export type KnownOptionsPayloadFromType<T extends string> = Extract<SlackOptions, { type: T }>;
 
 /**
  * external data source in blocks


### PR DESCRIPTION
###  Summary

This is a PR that should be merged into #1024 and incrementally addresses #842.

This PR disables the [`no-nested-ternary`](https://eslint.org/docs/rules/no-nested-ternary) rule in the three occurrences that it happens - but is this the right approach? The section where the `eslint-disable` lines I added is particularly gnarly 😞 . I think the intention behind the `no-nested-ternary` rule is noble, case in point, the nested ternaries are super hard to read!

What do people think? Perhaps it is worth re-writing this section of the code, expanding it a little, so as to make it a bit more readable? Perhaps with a `switch` statement?

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).