### PR TITLE
Update the documents to use respond over say in response to slash commands

### DIFF
--- a/docs/_advanced/context.md
+++ b/docs/_advanced/context.md
@@ -25,7 +25,7 @@ async function addTimezoneContext({ payload, client, context, next }) {
   await next();
 }
 
-app.command('request', addTimezoneContext, async ({ command, ack, client, context }) => {
+app.command('/request', addTimezoneContext, async ({ command, ack, client, context }) => {
   // Acknowledge command request
   await ack();
   // Get local hour of request

--- a/docs/_advanced/ja_context.md
+++ b/docs/_advanced/ja_context.md
@@ -25,7 +25,7 @@ async function addTimezoneContext({ payload, client, context, next }) {
   await next();
 }
 
-app.command('request', addTimezoneContext, async ({ command, ack, client, context }) => {
+app.command('/request', addTimezoneContext, async ({ command, ack, client, context }) => {
   // コマンドリクエストの確認
   await ack();
   // リクエスト時のローカル時間を取得

--- a/docs/_basic/ja_listening_responding_commands.md
+++ b/docs/_basic/ja_listening_responding_commands.md
@@ -19,10 +19,10 @@ Slack アプリの管理画面でスラッシュコマンドを設定すると�
 
 ```javascript
 // この echo コマンドは ただ、その引数を（やまびこのように）おうむ返しする
-app.command('/echo', async ({ command, ack, say }) => {
+app.command('/echo', async ({ command, ack, respond }) => {
   // コマンドリクエストを確認
   await ack();
 
-  await say(`${command.text}`);
+  await respond(`${command.text}`);
 });
 ```

--- a/docs/_basic/listening_responding_commands.md
+++ b/docs/_basic/listening_responding_commands.md
@@ -19,10 +19,10 @@ When configuring commands within your app configuration, you'll continue to appe
 
 ```javascript
 // The echo command simply echoes on command
-app.command('/echo', async ({ command, ack, say }) => {
+app.command('/echo', async ({ command, ack, respond }) => {
   // Acknowledge command request
   await ack();
 
-  await say(`${command.text}`);
+  await respond(`${command.text}`);
 });
 ```


### PR DESCRIPTION
###  Summary

This pull request updates some code snippets of slash command listeners to use `respond()` over `say()` method. The reason is t make the examples more robust. A slash command can be invoked anywhere. If the conversation where a user hit the command is the person's direct message, `say()` method does not work at all. But `respond()` works even for the use case.

see also: https://github.com/slackapi/bolt-js/issues/365#issuecomment-895778591

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).