### PR TITLE
updated incorrect apphome test

### DIFF
--- a/src/middleware/builtin.spec.ts
+++ b/src/middleware/builtin.spec.ts
@@ -820,8 +820,6 @@ const appHomeOpenedEvent: AppHomeOpenedEvent = {
   view: {
     type: 'home',
     blocks: [],
-    clear_on_close: false,
-    notify_on_close: false,
     external_id: '',
   },
   event_ts: '123.123',


### PR DESCRIPTION
###  Summary

With the change that landed in @slack/types@2.2.0, this test is now incorrect as these two properties do not exist on the HomeView. 

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).