### PR TITLE
Fix #1068 Throw an error if both socketMode: boolean and receiver: Receiver arguments in App constructor

### DIFF
--- a/src/App.spec.ts
+++ b/src/App.spec.ts
@@ -170,6 +170,21 @@ describe('App', () => {
         assert.propertyVal(error, 'code', ErrorCode.AppInitializationError);
       }
     });
+    it('should fail when both socketMode and receiver are specified', async () => {
+      // Arrange
+      const fakeReceiver = new FakeReceiver();
+      const App = await importApp(); // eslint-disable-line  @typescript-eslint/naming-convention, no-underscore-dangle, id-blacklist, id-match
+
+      // Act
+      try {
+        // eslint-disable-line @typescript-eslint/no-unused-expressions
+        new App({ token: '', signingSecret: '', socketMode: true, receiver: fakeReceiver });
+        assert.fail();
+      } catch (error) {
+        // Assert
+        assert.propertyVal(error, 'code', ErrorCode.AppInitializationError);
+      }
+    });
     it('should initialize MemoryStore conversation store by default', async () => {
       // Arrange
       const fakeMemoryStore = sinon.fake();

--- a/src/App.ts
+++ b/src/App.ts
@@ -304,6 +304,9 @@ export default class App {
 
     // Check for required arguments of HTTPReceiver
     if (receiver !== undefined) {
+      if (this.socketMode) {
+        throw new AppInitializationError('You cannot pass receiver when socketMode is set to true');
+      }
       this.receiver = receiver;
     } else if (this.socketMode) {
       if (appToken === undefined) {


### PR DESCRIPTION
###  Summary

This pull request fixes #1068 . I'm feeling that the error message can be improved. Suggestions would be appreciated!

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).