### PR TITLE
Fix #868 Add ability to use a custom express app and/or router to ExpressReceiver

### DIFF
--- a/src/receivers/ExpressReceiver.spec.ts
+++ b/src/receivers/ExpressReceiver.spec.ts
@@ -10,6 +10,7 @@ import { Request, Response } from 'express';
 import { Readable } from 'stream';
 import { EventEmitter } from 'events';
 import { ErrorCode, CodedError, ReceiverInconsistentStateError } from '../errors';
+import { Application, IRouter } from 'express';
 
 import ExpressReceiver, {
   respondToSslCheck,
@@ -78,6 +79,36 @@ describe('ExpressReceiver', function () {
         },
       });
       assert.isNotNull(receiver);
+    });
+    it('should accept custom Express app / router', async () => {
+      const app: Application = {
+        use: sinon.fake(),
+      } as unknown as Application;
+      const router: IRouter = {
+        get: sinon.fake(),
+        post: sinon.fake(),
+        use: sinon.fake(),
+      } as unknown as IRouter;
+      const receiver = new ExpressReceiver({
+        signingSecret: 'my-secret',
+        logger: noopLogger,
+        endpoints: { events: '/custom-endpoint' },
+        processBeforeResponse: true,
+        clientId: 'my-clientId',
+        clientSecret: 'my-client-secret',
+        stateSecret: 'state-secret',
+        scopes: ['channels:read'],
+        installerOptions: {
+          authVersion: 'v2',
+          userScopes: ['chat:write'],
+        },
+        app: app,
+        router: router,
+      });
+      assert.isNotNull(receiver);
+      assert((app.use as any).calledOnce);
+      assert((router.get as any).called);
+      assert((router.post as any).calledOnce);
     });
   });
 

--- a/src/receivers/ExpressReceiver.ts
+++ b/src/receivers/ExpressReceiver.ts
@@ -3,7 +3,7 @@
 import { createServer, Server, ServerOptions } from 'http';
 import { createServer as createHttpsServer, Server as HTTPSServer, ServerOptions as HTTPSServerOptions } from 'https';
 import { ListenOptions } from 'net';
-import express, { Request, Response, Application, RequestHandler, Router } from 'express';
+import express, { Request, Response, Application, RequestHandler, Router, IRouter } from 'express';
 import rawBody from 'raw-body';
 import querystring from 'querystring';
 import crypto from 'crypto';
@@ -33,6 +33,8 @@ export interface ExpressReceiverOptions {
   installationStore?: InstallProviderOptions['installationStore']; // default MemoryInstallationStore
   scopes?: InstallURLOptions['scopes'];
   installerOptions?: InstallerOptions;
+  app?: Application;
+  router?: IRouter;
 }
 
 // Additional Installer Options
@@ -63,7 +65,7 @@ export default class ExpressReceiver implements Receiver {
 
   private processBeforeResponse: boolean;
 
-  public router: Router;
+  public router: IRouter;
 
   public installer: InstallProvider | undefined = undefined;
 
@@ -79,8 +81,10 @@ export default class ExpressReceiver implements Receiver {
     installationStore = undefined,
     scopes = undefined,
     installerOptions = {},
+    app = undefined,
+    router = undefined,
   }: ExpressReceiverOptions) {
-    this.app = express();
+    this.app = app !== undefined ? app : express();
 
     if (typeof logger !== 'undefined') {
       this.logger = logger;
@@ -99,7 +103,7 @@ export default class ExpressReceiver implements Receiver {
     this.processBeforeResponse = processBeforeResponse;
 
     const endpointList = typeof endpoints === 'string' ? [endpoints] : Object.values(endpoints);
-    this.router = Router();
+    this.router = router !== undefined ? router : Router();
     endpointList.forEach((endpoint) => {
       this.router.post(endpoint, ...expressMiddleware);
     });


### PR DESCRIPTION
###  Summary

This pull request resolves #868. With this change, developers can easily embed Bolt app endpoints in existing Express applications.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).