### PR TITLE
Fix #648 Option to disable signature verification

### DIFF
--- a/src/App.ts
+++ b/src/App.ts
@@ -77,7 +77,7 @@ export interface AppOptions {
   signingSecret?: HTTPReceiverOptions['signingSecret'];
   endpoints?: HTTPReceiverOptions['endpoints'];
   processBeforeResponse?: HTTPReceiverOptions['processBeforeResponse'];
-  requestVerification?: HTTPReceiverOptions['requestVerification'];
+  signatureVerification?: HTTPReceiverOptions['signatureVerification'];
   clientId?: HTTPReceiverOptions['clientId'];
   clientSecret?: HTTPReceiverOptions['clientSecret'];
   stateSecret?: HTTPReceiverOptions['stateSecret']; // required when using default stateStore
@@ -222,7 +222,7 @@ export default class App {
     ignoreSelf = true,
     clientOptions = undefined,
     processBeforeResponse = false,
-    requestVerification = true,
+    signatureVerification = true,
     clientId = undefined,
     clientSecret = undefined,
     stateSecret = undefined,
@@ -339,7 +339,7 @@ export default class App {
         logLevel: this.logLevel,
         installerOptions: this.installerOptions,
       });
-    } else if (requestVerification && signingSecret === undefined) {
+    } else if (signatureVerification && signingSecret === undefined) {
       // No custom receiver
       throw new AppInitializationError(
         'Signing secret not found, so could not initialize the default receiver. Set a signing secret or use a ' +
@@ -352,7 +352,7 @@ export default class App {
         signingSecret: signingSecret || '',
         endpoints,
         processBeforeResponse,
-        requestVerification,
+        signatureVerification,
         clientId,
         clientSecret,
         stateSecret,

--- a/src/App.ts
+++ b/src/App.ts
@@ -77,6 +77,7 @@ export interface AppOptions {
   signingSecret?: HTTPReceiverOptions['signingSecret'];
   endpoints?: HTTPReceiverOptions['endpoints'];
   processBeforeResponse?: HTTPReceiverOptions['processBeforeResponse'];
+  requestVerification?: HTTPReceiverOptions['requestVerification'];
   clientId?: HTTPReceiverOptions['clientId'];
   clientSecret?: HTTPReceiverOptions['clientSecret'];
   stateSecret?: HTTPReceiverOptions['stateSecret']; // required when using default stateStore
@@ -221,6 +222,7 @@ export default class App {
     ignoreSelf = true,
     clientOptions = undefined,
     processBeforeResponse = false,
+    requestVerification = true,
     clientId = undefined,
     clientSecret = undefined,
     stateSecret = undefined,
@@ -337,7 +339,7 @@ export default class App {
         logLevel: this.logLevel,
         installerOptions: this.installerOptions,
       });
-    } else if (signingSecret === undefined) {
+    } else if (requestVerification && signingSecret === undefined) {
       // No custom receiver
       throw new AppInitializationError(
         'Signing secret not found, so could not initialize the default receiver. Set a signing secret or use a ' +
@@ -347,9 +349,10 @@ export default class App {
       this.logger.debug('Initializing HTTPReceiver');
       // Create default HTTPReceiver
       this.receiver = new HTTPReceiver({
-        signingSecret,
+        signingSecret: signingSecret || '',
         endpoints,
         processBeforeResponse,
+        requestVerification,
         clientId,
         clientSecret,
         stateSecret,

--- a/src/receivers/ExpressReceiver.ts
+++ b/src/receivers/ExpressReceiver.ts
@@ -78,11 +78,11 @@ export interface ExpressReceiverOptions {
   logger?: Logger;
   logLevel?: LogLevel;
   endpoints?:
-  | string
-  | {
-    [endpointType: string]: string;
-  };
-  requestVerification?: boolean;
+    | string
+    | {
+        [endpointType: string]: string;
+      };
+  signatureVerification?: boolean;
   processBeforeResponse?: boolean;
   clientId?: string;
   clientSecret?: string;
@@ -124,7 +124,7 @@ export default class ExpressReceiver implements Receiver {
 
   private processBeforeResponse: boolean;
 
-  private requestVerification: boolean;
+  private signatureVerification: boolean;
 
   public router: IRouter;
 
@@ -136,7 +136,7 @@ export default class ExpressReceiver implements Receiver {
     logLevel = LogLevel.INFO,
     endpoints = { events: '/slack/events' },
     processBeforeResponse = false,
-    requestVerification = true,
+    signatureVerification = true,
     clientId = undefined,
     clientSecret = undefined,
     stateSecret = undefined,
@@ -155,8 +155,8 @@ export default class ExpressReceiver implements Receiver {
       this.logger.setLevel(logLevel);
     }
 
-    this.requestVerification = requestVerification;
-    const bodyParser = this.requestVerification ?
+    this.signatureVerification = signatureVerification;
+    const bodyParser = this.signatureVerification ?
       buildVerificationBodyParserMiddleware(this.logger, signingSecret) :
       buildBodyParserMiddleware(this.logger);
     const expressMiddleware: RequestHandler[] = [

--- a/src/receivers/ExpressReceiver.ts
+++ b/src/receivers/ExpressReceiver.ts
@@ -78,10 +78,10 @@ export interface ExpressReceiverOptions {
   logger?: Logger;
   logLevel?: LogLevel;
   endpoints?:
-    | string
-    | {
-        [endpointType: string]: string;
-      };
+  | string
+  | {
+    [endpointType: string]: string;
+  };
   signatureVerification?: boolean;
   processBeforeResponse?: boolean;
   clientId?: string;

--- a/src/receivers/HTTPReceiver.ts
+++ b/src/receivers/HTTPReceiver.ts
@@ -60,7 +60,7 @@ export interface HTTPReceiverOptions {
   logger?: Logger;
   logLevel?: LogLevel;
   processBeforeResponse?: boolean;
-  requestVerification?: boolean;
+  signatureVerification?: boolean;
   clientId?: string;
   clientSecret?: string;
   stateSecret?: InstallProviderOptions['stateSecret']; // required when using default stateStore
@@ -93,7 +93,7 @@ export default class HTTPReceiver implements Receiver {
 
   private processBeforeResponse: boolean;
 
-  private requestVerification: boolean;
+  private signatureVerification: boolean;
 
   private app?: App;
 
@@ -123,7 +123,7 @@ export default class HTTPReceiver implements Receiver {
     logger = undefined,
     logLevel = LogLevel.INFO,
     processBeforeResponse = false,
-    requestVerification = true,
+    signatureVerification = true,
     clientId = undefined,
     clientSecret = undefined,
     stateSecret = undefined,
@@ -134,12 +134,14 @@ export default class HTTPReceiver implements Receiver {
     // Initialize instance variables, substituting defaults for each value
     this.signingSecret = signingSecret;
     this.processBeforeResponse = processBeforeResponse;
-    this.requestVerification = requestVerification;
-    this.logger = logger ?? (() => {
-      const defaultLogger = new ConsoleLogger();
-      defaultLogger.setLevel(logLevel);
-      return defaultLogger;
-    })();
+    this.signatureVerification = signatureVerification;
+    this.logger =
+      logger ??
+      (() => {
+        const defaultLogger = new ConsoleLogger();
+        defaultLogger.setLevel(logLevel);
+        return defaultLogger;
+      })();
     this.endpoints = Array.isArray(endpoints) ? endpoints : [endpoints];
 
     // Initialize InstallProvider when it's required options are provided
@@ -324,7 +326,7 @@ export default class HTTPReceiver implements Receiver {
         bufferedReq = await verifySlackAuthenticity(
           {
             // If enabled: false, this method returns bufferredReq without verification
-            enabled: this.requestVerification,
+            enabled: this.signatureVerification,
             signingSecret: this.signingSecret,
           },
           req,

--- a/src/receivers/HTTPReceiver.ts
+++ b/src/receivers/HTTPReceiver.ts
@@ -135,8 +135,7 @@ export default class HTTPReceiver implements Receiver {
     this.signingSecret = signingSecret;
     this.processBeforeResponse = processBeforeResponse;
     this.signatureVerification = signatureVerification;
-    this.logger =
-      logger ??
+    this.logger = logger ??
       (() => {
         const defaultLogger = new ConsoleLogger();
         defaultLogger.setLevel(logLevel);

--- a/src/receivers/verify-request.ts
+++ b/src/receivers/verify-request.ts
@@ -18,6 +18,7 @@ import type { IncomingMessage, ServerResponse } from 'http';
 const verifyErrorPrefix = 'Failed to verify authenticity';
 
 export interface VerifyOptions {
+  enabled?: boolean;
   signingSecret: string;
   nowMs?: () => number;
   logger?: Logger;
@@ -53,6 +54,11 @@ export async function verify(
 
   // Consume the readable stream (or use the previously consumed readable stream)
   const bufferedReq = await bufferIncomingMessage(req);
+
+  if (options.enabled !== undefined && !options.enabled) {
+    // As the validation is disabled, immediately return the bufferred reuest
+    return bufferedReq;
+  }
 
   // Find the relevant request headers
   const signature = getHeader(req, 'x-slack-signature');


### PR DESCRIPTION
###  Summary

This pull request resolves #648 by introducing a new option `signatureVerification: boolean` in `App`, `HTTPReceiver`, and `ExpressReceiver`. You can verify if the option works with the following example apps:

```js
const { App, ExpressReceiver } = require('@slack/bolt');

const app = new App({
  logLevel: 'debug',
  token: process.env.SLACK_BOT_TOKEN,
  signingSecret: 'xxx',
  signatureVerification: false,
});

const app = new App({
  logLevel: 'debug',
  token: process.env.SLACK_BOT_TOKEN,
  receiver: new ExpressReceiver({
    signingSecret: 'xxx',
    signatureVerification: false,
  }),
});
```

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).