### PR TITLE
Fix eslint warnings in getting-started-typescript app (ref #1095)

### DIFF
--- a/examples/getting-started-typescript/src/app.ts
+++ b/examples/getting-started-typescript/src/app.ts
@@ -1,11 +1,19 @@
-import "./utils/env";
+/* eslint-disable no-console */
+/* eslint-disable import/no-internal-modules */
+import './utils/env';
 import { App, LogLevel } from '@slack/bolt';
-import { isGenericMessageEvent } from './utils/helpers'
+import { isGenericMessageEvent } from './utils/helpers';
 
 const app = new App({
   token: process.env.SLACK_BOT_TOKEN,
   signingSecret: process.env.SLACK_SIGNING_SECRET,
-  logLevel: LogLevel.DEBUG
+  logLevel: LogLevel.DEBUG,
+});
+
+app.use(async ({ next }) => {
+  // TODO: This can be improved in future versions
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+  await next!();
 });
 
 // Listens to incoming messages that contain "hello"
@@ -13,27 +21,27 @@ app.message('hello', async ({ message, say }) => {
   // Filter out message events with subtypes (see https://api.slack.com/events/message)
   // Is there a way to do this in listener middleware with current type system?
   if (!isGenericMessageEvent(message)) return;
-  // say() sends a message to the channel where the event was triggered
 
+  // say() sends a message to the channel where the event was triggered
   await say({
     blocks: [
       {
         type: 'section',
         text: {
           type: 'mrkdwn',
-          text: `Hey there <@${message.user}>!`
+          text: `Hey there <@${message.user}>!`,
         },
         accessory: {
           type: 'button',
           text: {
             type: 'plain_text',
-            text: 'Click Me'
+            text: 'Click Me',
           },
-          action_id: 'button_click'
-        }
-      }
+          action_id: 'button_click',
+        },
+      },
     ],
-    text: `Hey there <@${message.user}>!`
+    text: `Hey there <@${message.user}>!`,
   });
 });
 
@@ -49,4 +57,3 @@ app.action('button_click', async ({ body, ack, say }) => {
 
   console.log('⚡️ Bolt app is running!');
 })();
-

--- a/examples/getting-started-typescript/src/utils/env.ts
+++ b/examples/getting-started-typescript/src/utils/env.ts
@@ -1,6 +1,6 @@
 // for details see https://github.com/motdotla/dotenv/blob/master/examples/typescript/
-import { resolve } from 'path'
-import { config } from 'dotenv'
+import { resolve } from 'path';
+import { config } from 'dotenv';
 
 const pathToConfig = '../../.env';
 config({ path: resolve(__dirname, pathToConfig) });

--- a/examples/getting-started-typescript/src/utils/helpers.ts
+++ b/examples/getting-started-typescript/src/utils/helpers.ts
@@ -2,14 +2,11 @@ import {
   GenericMessageEvent,
   MessageEvent,
   ReactionAddedEvent,
-  ReactionMessageItem
+  ReactionMessageItem,
 } from '@slack/bolt';
 
+export const isGenericMessageEvent = (msg: MessageEvent):
+  msg is GenericMessageEvent => (msg as GenericMessageEvent).subtype === undefined;
 
-export const isGenericMessageEvent = (msg: MessageEvent): msg is GenericMessageEvent => {
-  return (msg as GenericMessageEvent).subtype === undefined;
-}
-
-export const isMessageItem = (item: ReactionAddedEvent["item"]): item is ReactionMessageItem => {
-  return (item as ReactionMessageItem).type === 'message';
-}
+export const isMessageItem = (item: ReactionAddedEvent['item']):
+  item is ReactionMessageItem => (item as ReactionMessageItem).type === 'message';

--- a/examples/getting-started-typescript/tsconfig.eslint.json
+++ b/examples/getting-started-typescript/tsconfig.eslint.json
@@ -1,0 +1,13 @@
+// This config is only used to allow ESLint to use a different include / exclude setting than the actual build
+{
+  // extend the build config to share compilerOptions
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    // Setting "noEmit" prevents misuses of this config such as using it to produce a build
+    "noEmit": true
+  },
+  "include": [
+    // Since extending a config overwrites the entire value for "include", those value are copied here
+    "src/**/*",
+  ]
+}


### PR DESCRIPTION
###  Summary

This pull request resolves all the eslint warnings in getting-started-typescript example app project. This is an improvement in addition to #1095

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).