### PR TITLE
Fix #1098 next() is optional in middleware in TypeScript

### DIFF
--- a/src/App.spec.ts
+++ b/src/App.spec.ts
@@ -483,8 +483,8 @@ describe('App', () => {
         // Arrange
         app.use(fakeFirstMiddleware);
         app.use(async ({ next }) => {
-          await next!();
-          await next!();
+          await next();
+          await next();
         });
         app.use(fakeSecondMiddleware);
         app.error(fakeErrorHandler);
@@ -503,7 +503,7 @@ describe('App', () => {
           await delay(100);
           changed = true;
 
-          await next!();
+          await next();
         });
 
         await fakeReceiver.sendEvent(dummyReceiverEvent);
@@ -517,7 +517,7 @@ describe('App', () => {
 
         app.use(async ({ next }) => {
           try {
-            await next!();
+            await next();
           } catch (err: any) {
             caughtError = err;
           }
@@ -1216,7 +1216,7 @@ describe('App', () => {
 
           app.use(async ({ next }) => {
             await ackFn();
-            await next!();
+            await next();
           });
           app.shortcut({ callback_id: 'message_action_callback_id' }, async () => {
             await shortcutFn();
@@ -1317,7 +1317,7 @@ describe('App', () => {
 
           app.use(async ({ next }) => {
             await ackFn();
-            await next!();
+            await next();
           });
           app.shortcut({ callback_id: 'message_action_callback_id' }, async () => {
             await shortcutFn();
@@ -1635,7 +1635,7 @@ describe('App', () => {
           });
           app.use(async ({ logger, body, next }) => {
             logger.info(body);
-            await next!();
+            await next();
           });
 
           app.event('app_home_opened', async ({ logger, event }) => {
@@ -1683,7 +1683,7 @@ describe('App', () => {
           });
           app.use(async ({ logger, body, next }) => {
             logger.info(body);
-            await next!();
+            await next();
           });
 
           app.event('app_home_opened', async ({ logger, event }) => {
@@ -1746,7 +1746,7 @@ describe('App', () => {
           });
           app.use(async ({ client, next }) => {
             await client.auth.test();
-            await next!();
+            await next();
           });
           const clients: WebClient[] = [];
           app.event('app_home_opened', async ({ client }) => {

--- a/src/App.ts
+++ b/src/App.ts
@@ -56,6 +56,7 @@ import {
 } from './types';
 import { IncomingEventType, getTypeAndConversation, assertNever } from './helpers';
 import { CodedError, asCodedError, AppInitializationError, MultipleListenerError, ErrorCode } from './errors';
+import { AllMiddlewareArgs } from './types/middleware';
 // eslint-disable-next-line import/order
 import allSettled = require('promise.allsettled'); // eslint-disable-line @typescript-eslint/no-require-imports
 // eslint-disable-next-line @typescript-eslint/no-require-imports, import/no-commonjs
@@ -891,13 +892,15 @@ export default class App {
               context,
               client,
               this.logger,
-              // When the listener middleware chain is done processing, call the listener without a next fn
+              // When all of the listener middleware are done processing,
+              // `listener` here will be called without a `next` execution
               async () => listener({
                 ...(listenerArgs as AnyMiddlewareArgs),
                 context,
                 client,
                 logger: this.logger,
-              }),
+                // `next` is already set in the outer processMiddleware
+              } as AnyMiddlewareArgs & AllMiddlewareArgs),
             );
           });
 

--- a/src/WorkflowStep.spec.ts
+++ b/src/WorkflowStep.spec.ts
@@ -291,12 +291,11 @@ describe('WorkflowStep', () => {
 
   describe('processStepMiddleware', () => {
     it('should call each callback in user-provided middleware', async () => {
-      const { next: _next, ...fakeArgs } = createFakeStepEditAction() as unknown as AllWorkflowStepMiddlewareArgs;
+      const { ...fakeArgs } = createFakeStepEditAction() as unknown as AllWorkflowStepMiddlewareArgs;
       const { processStepMiddleware } = await importWorkflowStep();
 
       const fn1 = sinon.spy((async ({ next: continuation }) => {
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        await continuation!();
+        await continuation();
       }) as Middleware<WorkflowStepEdit>);
       const fn2 = sinon.spy(async () => {});
       const fakeMiddleware = [fn1, fn2] as WorkflowStepMiddleware;
@@ -323,7 +322,6 @@ function createFakeStepEditAction() {
       workflow_step: {},
     },
     context: {},
-    next: sinon.fake(),
   };
 }
 
@@ -341,7 +339,6 @@ function createFakeStepSaveEvent() {
       callback_id: 'test_save_callback_id',
     },
     context: {},
-    next: sinon.fake(),
   };
 }
 
@@ -362,7 +359,6 @@ function createFakeStepExecuteEvent() {
       },
     },
     context: {},
-    next: sinon.fake(),
   };
 }
 
@@ -380,6 +376,5 @@ function createFakeViewEvent() {
       callback_id: 'test_view_callback_id',
     },
     context: {},
-    next: sinon.fake(),
   };
 }

--- a/src/WorkflowStep.ts
+++ b/src/WorkflowStep.ts
@@ -154,9 +154,7 @@ export class WorkflowStep {
       if (isStepEvent(args) && this.matchesConstraints(args)) {
         return this.processEvent(args);
       }
-      // `next` here exists for sure bu the typing on the MiddlwareArgs is not great enough
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      return args.next!();
+      return args.next();
     };
   }
 

--- a/src/conversation-store.ts
+++ b/src/conversation-store.ts
@@ -74,8 +74,6 @@ export function conversationContext<ConversationState = any>(
     } else {
       logger.debug('No conversation ID for incoming event');
     }
-    // TODO: remove the non-null assertion operator
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    await next!();
+    await next();
   };
 }

--- a/src/middleware/builtin.ts
+++ b/src/middleware/builtin.ts
@@ -39,9 +39,7 @@ export const onlyActions: Middleware<AnyMiddlewareArgs & { action?: SlackAction 
   }
 
   // It matches so we should continue down this middleware listener chain
-  // TODO: remove the non-null assertion operator
-  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-  await next!();
+  await next();
 };
 
 /**
@@ -57,9 +55,7 @@ export const onlyShortcuts: Middleware<AnyMiddlewareArgs & { shortcut?: SlackSho
   }
 
   // It matches so we should continue down this middleware listener chain
-  // TODO: remove the non-null assertion operator
-  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-  await next!();
+  await next();
 };
 
 /**
@@ -72,9 +68,7 @@ export const onlyCommands: Middleware<AnyMiddlewareArgs & { command?: SlashComma
   }
 
   // It matches so we should continue down this middleware listener chain
-  // TODO: remove the non-null assertion operator
-  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-  await next!();
+  await next();
 };
 
 /**
@@ -87,9 +81,7 @@ export const onlyOptions: Middleware<AnyMiddlewareArgs & { options?: SlackOption
   }
 
   // It matches so we should continue down this middleware listener chain
-  // TODO: remove the non-null assertion operator
-  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-  await next!();
+  await next();
 };
 
 /**
@@ -102,9 +94,7 @@ export const onlyEvents: Middleware<AnyMiddlewareArgs & { event?: SlackEvent }> 
   }
 
   // It matches so we should continue down this middleware listener chain
-  // TODO: remove the non-null assertion operator
-  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-  await next!();
+  await next();
 };
 
 /**
@@ -117,9 +107,7 @@ export const onlyViewActions: Middleware<AnyMiddlewareArgs & { view?: ViewOutput
   }
 
   // It matches so we should continue down this middleware listener chain
-  // TODO: remove the non-null assertion operator
-  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-  await next!();
+  await next();
 };
 
 /**
@@ -206,9 +194,7 @@ export function matchConstraints(
       if (body.type !== constraints.type) return;
     }
 
-    // TODO: remove the non-null assertion operator
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    await next!();
+    await next();
   };
 }
 
@@ -240,9 +226,7 @@ export function matchMessage(
       }
     }
 
-    // TODO: remove the non-null assertion operator
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    await next!();
+    await next();
   };
 }
 
@@ -256,9 +240,7 @@ export function matchCommandName(pattern: string | RegExp): Middleware<SlackComm
       return;
     }
 
-    // TODO: remove the non-null assertion operator
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    await next!();
+    await next();
   };
 }
 
@@ -294,9 +276,7 @@ export function matchEventType(pattern: EventTypePattern): Middleware<SlackEvent
       }
     }
 
-    // TODO: remove the non-null assertion operator
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    await next!();
+    await next();
   };
 }
 
@@ -329,18 +309,14 @@ export function ignoreSelf(): Middleware<AnyMiddlewareArgs> {
     }
 
     // If all the previous checks didn't skip this message, then its okay to resume to next
-    // TODO: remove the non-null assertion operator
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    await args.next!();
+    await args.next();
   };
 }
 
 export function subtype(subtype1: string): Middleware<SlackEventMiddlewareArgs<'message'>> {
   return async ({ message, next }) => {
     if (message.subtype === subtype1) {
-      // TODO: remove the non-null assertion operator
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      await next!();
+      await next();
     }
   };
 }
@@ -376,9 +352,7 @@ export function directMention(): Middleware<SlackEventMiddlewareArgs<'message'>>
       return;
     }
 
-    // TODO: remove the non-null assertion operator
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    await next!();
+    await next();
   };
 }
 

--- a/src/types/middleware.ts
+++ b/src/types/middleware.ts
@@ -21,8 +21,7 @@ export interface AllMiddlewareArgs {
   context: Context;
   logger: Logger;
   client: WebClient;
-  // TODO: figure out how to make next non-optional
-  next?: NextFn;
+  next: NextFn;
 }
 
 // NOTE: Args should extend AnyMiddlewareArgs, but because of contravariance for function types, including that as a


### PR DESCRIPTION
###  Summary

This pull request fixes #1098 by updating the type of `next` property in `AllMiddlewareArgs`. As we already have so many changes in v3.7, we can have this one in v3.8 or later.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).