### PR TITLE
Add Support for Custom HTTP Routes

### DIFF
--- a/docs/_advanced/custom_routes.md
+++ b/docs/_advanced/custom_routes.md
@@ -6,9 +6,42 @@ order: 10
 ---
 
 <div class="section-content">
+As of `v3.7.0`, custom HTTP routes can be easily added by passing in a collection of routes as `customRoutes` when initializing `App`. 
 
-Adding custom HTTP routes is quite straightforward when using Bolt's built-in `ExpressReceiver`. Since `v2.1.0`, `ExpressReceiver` added a `router` property, which exposes the Express [Router](http://expressjs.com/en/4x/api.html#router) on which more routes can be added.
+Each `CustomRoute` object must contain three properties: `path`, `method`, and `callback`. `method`, which corresponds to the HTTP verb, can be either a string or an array of strings.
+</div>
 
+```javascript
+const { App } = require('@slack/bolt');
+
+// Create the Bolt App, using the receiver
+const app = new App({
+  token: process.env.SLACK_BOT_TOKEN,
+  customRoutes: [
+    {
+      path: '/health-check',
+      method: ['GET'],
+      callback: (req, res) => {
+        res.writeHead(200);
+        res.end('Health check information displayed here!');
+      },
+    },
+  ],
+});
+
+(async () => {
+  await app.start();
+  console.log('⚡️ Bolt app started');
+})();
+```
+
+<details class="secondary-wrapper">
+<summary class="section-head" markdown="0">
+<h4 class="section-head">Custom ExpressReceiver routes</h4>
+</summary>
+
+<div class="secondary-content" markdown="0">
+Adding custom HTTP routes is quite straightforward when using Bolt’s built-in ExpressReceiver. Since `v2.1.0`, `ExpressReceiver` added a `router` property, which exposes the Express [Router](http://expressjs.com/en/4x/api.html#router) on which additional routes can be added.
 </div>
 
 ```javascript
@@ -36,7 +69,8 @@ receiver.router.post('/secret-page', (req, res) => {
 });
 
 (async () => {
-  await app.start(8080);
-  console.log('app is running');
+  await app.start();
+  console.log('⚡️ Bolt app started');
 })();
 ```
+</details>

--- a/docs/_advanced/custom_routes.md
+++ b/docs/_advanced/custom_routes.md
@@ -6,42 +6,9 @@ order: 10
 ---
 
 <div class="section-content">
-As of `v3.7.0`, custom HTTP routes can be easily added by passing in a collection of routes as `customRoutes` when initializing `App`. 
 
-Each `CustomRoute` object must contain three properties: `path`, `method`, and `callback`. `method`, which corresponds to the HTTP verb, can be either a string or an array of strings.
-</div>
+Adding custom HTTP routes is quite straightforward when using Bolt's built-in `ExpressReceiver`. Since `v2.1.0`, `ExpressReceiver` added a `router` property, which exposes the Express [Router](http://expressjs.com/en/4x/api.html#router) on which more routes can be added.
 
-```javascript
-const { App } = require('@slack/bolt');
-
-// Create the Bolt App, using the receiver
-const app = new App({
-  token: process.env.SLACK_BOT_TOKEN,
-  customRoutes: [
-    {
-      path: '/health-check',
-      method: ['GET'],
-      callback: (req, res) => {
-        res.writeHead(200);
-        res.end('Health check information displayed here!');
-      },
-    },
-  ],
-});
-
-(async () => {
-  await app.start();
-  console.log('⚡️ Bolt app started');
-})();
-```
-
-<details class="secondary-wrapper">
-<summary class="section-head" markdown="0">
-<h4 class="section-head">Custom ExpressReceiver routes</h4>
-</summary>
-
-<div class="secondary-content" markdown="0">
-Adding custom HTTP routes is quite straightforward when using Bolt’s built-in ExpressReceiver. Since `v2.1.0`, `ExpressReceiver` added a `router` property, which exposes the Express [Router](http://expressjs.com/en/4x/api.html#router) on which additional routes can be added.
 </div>
 
 ```javascript
@@ -69,8 +36,7 @@ receiver.router.post('/secret-page', (req, res) => {
 });
 
 (async () => {
-  await app.start();
-  console.log('⚡️ Bolt app started');
+  await app.start(8080);
+  console.log('app is running');
 })();
 ```
-</details>

--- a/src/App.ts
+++ b/src/App.ts
@@ -76,6 +76,7 @@ const tokenUsage = 'Apps used in one workspace should be initialized with a toke
 export interface AppOptions {
   signingSecret?: HTTPReceiverOptions['signingSecret'];
   endpoints?: HTTPReceiverOptions['endpoints'];
+  customRoutes?: HTTPReceiverOptions['customRoutes'];
   processBeforeResponse?: HTTPReceiverOptions['processBeforeResponse'];
   signatureVerification?: HTTPReceiverOptions['signatureVerification'];
   clientId?: HTTPReceiverOptions['clientId'];
@@ -211,6 +212,7 @@ export default class App {
   public constructor({
     signingSecret = undefined,
     endpoints = undefined,
+    customRoutes = undefined,
     agent = undefined,
     clientTls = undefined,
     receiver = undefined,
@@ -354,6 +356,7 @@ export default class App {
       this.receiver = new HTTPReceiver({
         signingSecret: signingSecret || '',
         endpoints,
+        customRoutes,
         processBeforeResponse,
         signatureVerification,
         clientId,

--- a/src/App.ts
+++ b/src/App.ts
@@ -343,6 +343,7 @@ export default class App {
         logger,
         logLevel: this.logLevel,
         installerOptions: this.installerOptions,
+        customRoutes,
       });
     } else if (signatureVerification && signingSecret === undefined) {
       // No custom receiver

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -16,6 +16,8 @@ export enum ErrorCode {
 
   ContextMissingPropertyError = 'slack_bolt_context_missing_property_error',
 
+  CustomRouteInitializationError = 'slack_bolt_custom_route_initialization_error',
+
   ReceiverMultipleAckError = 'slack_bolt_receiver_ack_multiple_error',
   ReceiverAuthenticityError = 'slack_bolt_receiver_authenticity_error',
   ReceiverInconsistentStateError = 'slack_bolt_receiver_inconsistent_state_error',
@@ -78,6 +80,10 @@ export class ContextMissingPropertyError extends Error implements CodedError {
     super(message);
     this.missingProperty = missingProperty;
   }
+}
+
+export class CustomRouteInitializationError extends Error implements CodedError {
+  public code = ErrorCode.CustomRouteInitializationError;
 }
 
 export class ReceiverMultipleAckError extends Error implements CodedError {

--- a/src/receivers/HTTPReceiver.spec.ts
+++ b/src/receivers/HTTPReceiver.spec.ts
@@ -294,7 +294,7 @@ describe('HTTPReceiver', function () {
 
     it('should call custom route callback only if request matches route path and method', async function () {
       const HTTPReceiver = await importHTTPReceiver();
-      const customRoutes = [{ path: '/test', method: ['GET', 'POST'], callback: sinon.fake() }];
+      const customRoutes = [{ path: '/test', method: ['get', 'POST'], callback: sinon.fake() }];
       const receiver = new HTTPReceiver({
         clientSecret: 'my-client-secret',
         signingSecret: 'secret',

--- a/src/receivers/SocketModeReceiver.spec.ts
+++ b/src/receivers/SocketModeReceiver.spec.ts
@@ -292,7 +292,7 @@ describe('SocketModeReceiver', function () {
       assert(fakeRes.end.called);
     });
 
-    it('should call custom route callback only if request matches route path and method', async function () {
+    it('should call custom route handler only if request matches route path and method', async function () {
       // Arrange
       const installProviderStub = sinon.createStubInstance(InstallProvider);
       const overrides = mergeOverrides(
@@ -300,7 +300,7 @@ describe('SocketModeReceiver', function () {
         withHttpsCreateServer(sinon.fake.throws('Should not be used.')),
       );
       const SocketModeReceiver = await importSocketModeReceiver(overrides);
-      const customRoutes = [{ path: '/test', method: ['get', 'POST'], callback: sinon.fake() }];
+      const customRoutes = [{ path: '/test', method: ['get', 'POST'], handler: sinon.fake() }];
 
       const receiver = new SocketModeReceiver({
         appToken: 'my-secret',
@@ -317,11 +317,11 @@ describe('SocketModeReceiver', function () {
 
       fakeReq.method = 'GET';
       await this.listener(fakeReq, fakeRes);
-      assert(customRoutes[0].callback.calledWith(fakeReq, fakeRes));
+      assert(customRoutes[0].handler.calledWith(fakeReq, fakeRes));
 
       fakeReq.method = 'POST';
       await this.listener(fakeReq, fakeRes);
-      assert(customRoutes[0].callback.calledWith(fakeReq, fakeRes));
+      assert(customRoutes[0].handler.calledWith(fakeReq, fakeRes));
 
       fakeReq.method = 'UNHANDLED_METHOD';
       await this.listener(fakeReq, fakeRes);
@@ -336,7 +336,7 @@ describe('SocketModeReceiver', function () {
         withHttpsCreateServer(sinon.fake.throws('Should not be used.')),
       );
       const SocketModeReceiver = await importSocketModeReceiver(overrides);
-      const customRoutes = [{ callback: sinon.fake() }] as any;
+      const customRoutes = [{ handler: sinon.fake() }] as any;
 
       assert.throws(() => new SocketModeReceiver({ appToken: 'my-secret', customRoutes }), CustomRouteInitializationError);
     });
@@ -353,7 +353,7 @@ describe('SocketModeReceiver', function () {
       const metadata = 'this is bat country';
       const scopes = ['channels:read'];
       const userScopes = ['chat:write'];
-      const customRoutes = [{ path: '/test', method: ['get', 'POST'], callback: sinon.fake() }];
+      const customRoutes = [{ path: '/test', method: ['get', 'POST'], handler: sinon.fake() }];
       const receiver = new SocketModeReceiver({
         appToken: 'my-secret',
         logger: noopLogger,

--- a/src/receivers/SocketModeReceiver.spec.ts
+++ b/src/receivers/SocketModeReceiver.spec.ts
@@ -8,6 +8,7 @@ import { IncomingMessage, ServerResponse } from 'http';
 import { InstallProvider } from '@slack/oauth';
 import { SocketModeClient } from '@slack/socket-mode';
 import { Override, mergeOverrides } from '../test-helpers';
+import { CustomRouteInitializationError } from '../errors';
 
 // Fakes
 class FakeServer extends EventEmitter {
@@ -150,6 +151,7 @@ describe('SocketModeReceiver', function () {
       receiver.installer = installProviderStub as unknown as InstallProvider;
       const fakeReq = {
         url: '/heyo',
+        method: 'GET',
       };
       const fakeRes = null;
       await this.listener(fakeReq, fakeRes);
@@ -191,6 +193,7 @@ describe('SocketModeReceiver', function () {
       receiver.installer = installProviderStub as unknown as InstallProvider;
       const fakeReq = {
         url: '/hiya',
+        method: 'GET',
       };
       const fakeRes = {
         writeHead: sinon.fake(),
@@ -232,6 +235,7 @@ describe('SocketModeReceiver', function () {
       receiver.installer = installProviderStub as unknown as InstallProvider;
       const fakeReq = {
         url: '/hiya',
+        method: 'GET',
       };
       const fakeRes = {
         writeHead: sinon.fake(),
@@ -275,6 +279,7 @@ describe('SocketModeReceiver', function () {
       receiver.installer = installProviderStub as unknown as InstallProvider;
       const fakeReq = {
         url: '/hiya',
+        method: 'GET',
       };
       const fakeRes = {
         writeHead: sinon.fake(),
@@ -286,7 +291,57 @@ describe('SocketModeReceiver', function () {
       assert(fakeRes.writeHead.calledWith(302, sinon.match.object));
       assert(fakeRes.end.called);
     });
-    it('should return a 404 if a request comes into neither the install path nor the redirect URI path', async function () {
+
+    it('should call custom route callback only if request matches route path and method', async function () {
+      // Arrange
+      const installProviderStub = sinon.createStubInstance(InstallProvider);
+      const overrides = mergeOverrides(
+        withHttpCreateServer(this.fakeCreateServer),
+        withHttpsCreateServer(sinon.fake.throws('Should not be used.')),
+      );
+      const SocketModeReceiver = await importSocketModeReceiver(overrides);
+      const customRoutes = [{ path: '/test', method: ['get', 'POST'], callback: sinon.fake() }];
+
+      const receiver = new SocketModeReceiver({
+        appToken: 'my-secret',
+        customRoutes,
+      });
+      assert.isNotNull(receiver);
+      receiver.installer = installProviderStub as unknown as InstallProvider;
+
+      const fakeReq: IncomingMessage = sinon.createStubInstance(IncomingMessage) as IncomingMessage;
+      const fakeRes = { writeHead: sinon.fake(), end: sinon.fake() };
+
+      fakeReq.url = '/test';
+      fakeReq.headers = { host: 'localhost' };
+
+      fakeReq.method = 'GET';
+      await this.listener(fakeReq, fakeRes);
+      assert(customRoutes[0].callback.calledWith(fakeReq, fakeRes));
+
+      fakeReq.method = 'POST';
+      await this.listener(fakeReq, fakeRes);
+      assert(customRoutes[0].callback.calledWith(fakeReq, fakeRes));
+
+      fakeReq.method = 'UNHANDLED_METHOD';
+      await this.listener(fakeReq, fakeRes);
+      assert(fakeRes.writeHead.calledWith(404, sinon.match.object));
+      assert(fakeRes.end.called);
+    });
+
+    it("should throw an error if customRoutes don't have the required keys", async function () {
+      // Arrange
+      const overrides = mergeOverrides(
+        withHttpCreateServer(this.fakeCreateServer),
+        withHttpsCreateServer(sinon.fake.throws('Should not be used.')),
+      );
+      const SocketModeReceiver = await importSocketModeReceiver(overrides);
+      const customRoutes = [{ callback: sinon.fake() }] as any;
+
+      assert.throws(() => new SocketModeReceiver({ appToken: 'my-secret', customRoutes }), CustomRouteInitializationError);
+    });
+
+    it('should return a 404 if a request passes the install path, redirect URI path and custom routes', async function () {
       // Arrange
       const installProviderStub = sinon.createStubInstance(InstallProvider);
       const overrides = mergeOverrides(
@@ -298,6 +353,7 @@ describe('SocketModeReceiver', function () {
       const metadata = 'this is bat country';
       const scopes = ['channels:read'];
       const userScopes = ['chat:write'];
+      const customRoutes = [{ path: '/test', method: ['get', 'POST'], callback: sinon.fake() }];
       const receiver = new SocketModeReceiver({
         appToken: 'my-secret',
         logger: noopLogger,
@@ -305,6 +361,7 @@ describe('SocketModeReceiver', function () {
         clientSecret: 'my-client-secret',
         stateSecret: 'state-secret',
         scopes,
+        customRoutes,
         installerOptions: {
           authVersion: 'v2',
           installPath: '/hiya',
@@ -317,6 +374,7 @@ describe('SocketModeReceiver', function () {
       receiver.installer = installProviderStub as unknown as InstallProvider;
       const fakeReq = {
         url: '/nope',
+        method: 'GET',
       };
       const fakeRes = {
         writeHead: sinon.fake(),
@@ -324,7 +382,7 @@ describe('SocketModeReceiver', function () {
       };
       await this.listener(fakeReq, fakeRes);
       assert(fakeRes.writeHead.calledWith(404, sinon.match.object));
-      assert(fakeRes.end.calledWith(sinon.match("route /nope doesn't exist!")));
+      assert(fakeRes.end.calledOnce);
     });
   });
   describe('#start()', function () {

--- a/src/receivers/SocketModeReceiver.ts
+++ b/src/receivers/SocketModeReceiver.ts
@@ -1,12 +1,13 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { SocketModeClient } from '@slack/socket-mode';
-import { createServer } from 'http';
+import { createServer, IncomingMessage, ServerResponse } from 'http';
 import { Logger, ConsoleLogger, LogLevel } from '@slack/logger';
 import { InstallProvider, CallbackOptions, InstallProviderOptions, InstallURLOptions } from '@slack/oauth';
 import { AppsConnectionsOpenResponse } from '@slack/web-api';
 import App from '../App';
 import { Receiver, ReceiverEvent } from '../types';
 import defaultRenderHtmlForInstallPath from './render-html-for-install-path';
+import { CustomRouteInitializationError } from '../errors';
 
 // TODO: we throw away the key names for endpoints, so maybe we should use this interface. is it better for migrations?
 // if that's the reason, let's document that with a comment.
@@ -20,6 +21,13 @@ export interface SocketModeReceiverOptions {
   scopes?: InstallURLOptions['scopes'];
   installerOptions?: InstallerOptions;
   appToken: string; // App Level Token
+  customRoutes?: CustomRoute[];
+}
+
+export interface CustomRoute {
+  path: string;
+  method: string | string[];
+  callback: (req: IncomingMessage, res: ServerResponse) => void;
 }
 
 // Additional Installer Options
@@ -51,6 +59,8 @@ export default class SocketModeReceiver implements Receiver {
 
   public installer: InstallProvider | undefined = undefined;
 
+  private customRoutes: CustomRoute[];
+
   public constructor({
     appToken,
     logger = undefined,
@@ -61,6 +71,7 @@ export default class SocketModeReceiver implements Receiver {
     installationStore = undefined,
     scopes = undefined,
     installerOptions = {},
+    customRoutes = [],
   }: SocketModeReceiverOptions) {
     this.client = new SocketModeClient({
       appToken,
@@ -69,18 +80,16 @@ export default class SocketModeReceiver implements Receiver {
       clientOptions: installerOptions.clientOptions,
     });
 
-    if (typeof logger !== 'undefined') {
-      this.logger = logger;
-    } else {
-      this.logger = new ConsoleLogger();
-      this.logger.setLevel(logLevel);
-    }
+    this.logger = logger ?? (() => {
+      const defaultLogger = new ConsoleLogger();
+      defaultLogger.setLevel(logLevel);
+      return defaultLogger;
+    })();
+    this.customRoutes = prepareCustomRoutes(customRoutes);
 
-    if (
-      clientId !== undefined &&
-      clientSecret !== undefined &&
-      (stateSecret !== undefined || installerOptions.stateStore !== undefined)
-    ) {
+    // Initialize InstallProvider
+    if (clientId !== undefined && clientSecret !== undefined &&
+      (stateSecret !== undefined || installerOptions.stateStore !== undefined)) {
       this.installer = new InstallProvider({
         clientId,
         clientSecret,
@@ -95,53 +104,81 @@ export default class SocketModeReceiver implements Receiver {
       });
     }
 
-    // Add OAuth routes to receiver
-    if (this.installer !== undefined) {
+    // Add OAuth and/or custom routes to receiver
+    if (this.installer !== undefined || this.customRoutes.length) {
       // use default or passed in redirect path
       const redirectUriPath = installerOptions.redirectUriPath === undefined ? '/slack/oauth_redirect' : installerOptions.redirectUriPath;
 
       // use default or passed in installPath
       const installPath = installerOptions.installPath === undefined ? '/slack/install' : installerOptions.installPath;
       const directInstallEnabled = installerOptions.directInstall !== undefined && installerOptions.directInstall;
+      const port = installerOptions.port === undefined ? 3000 : installerOptions.port;
 
       const server = createServer(async (req, res) => {
-        if (req.url !== undefined && req.url.startsWith(redirectUriPath)) {
-          // call installer.handleCallback to wrap up the install flow
-          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-          await this.installer!.handleCallback(req, res, installerOptions.callbackOptions);
-        } else if (req.url !== undefined && req.url.startsWith(installPath)) {
-          try {
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        const method = req.method!.toUpperCase();
+
+        // Handle OAuth-related requests
+        if (this.installer) {
+          // Installation has been initiated
+          if (req.url && req.url.startsWith(redirectUriPath)) {
             // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-            const url = await this.installer!.generateInstallUrl({
-              metadata: installerOptions.metadata,
-              scopes: scopes ?? [],
-              userScopes: installerOptions.userScopes,
-            });
-            if (directInstallEnabled) {
-              res.writeHead(302, { Location: url });
-              res.end('');
-            } else {
-              res.writeHead(200, {});
-              const renderHtml = installerOptions.renderHtmlForInstallPath !== undefined ?
-                installerOptions.renderHtmlForInstallPath :
-                defaultRenderHtmlForInstallPath;
-              res.end(renderHtml(url));
-            }
-          } catch (err) {
-            const e = err as any;
-            throw new Error(e);
+            await this.installer!.handleCallback(req, res, installerOptions.callbackOptions);
+            return;
           }
-        } else {
-          this.logger.error(`Tried to reach ${req.url} which isn't a valid route.`);
-          // Return 404 because we don't support route
-          res.writeHead(404, {});
-          res.end(`route ${req.url} doesn't exist!`);
+
+          // Visiting the installation endpoint
+          if (req.url && req.url.startsWith(installPath)) {
+            try {
+              // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+              const url = await this.installer!.generateInstallUrl({
+                metadata: installerOptions.metadata,
+                scopes: scopes ?? [],
+                userScopes: installerOptions.userScopes,
+              });
+              if (directInstallEnabled) {
+                res.writeHead(302, { Location: url });
+                res.end('');
+              } else {
+                res.writeHead(200, {});
+                const renderHtml = installerOptions.renderHtmlForInstallPath !== undefined ?
+                  installerOptions.renderHtmlForInstallPath :
+                  defaultRenderHtmlForInstallPath;
+                res.end(renderHtml(url));
+                return;
+              }
+            } catch (err) {
+              const e = err as any;
+              throw new Error(e);
+            }
+          }
         }
+
+        // Handle request for custom routes
+        if (this.customRoutes.length) {
+          const match = this.customRoutes.find((route) => {
+            const isMethodMatch = Array.isArray(route.method) ?
+              route.method.includes(method) : route.method === method;
+            return route.path === req.url && isMethodMatch;
+          });
+
+          if (match) {
+            match.callback(req, res);
+            return;
+          }
+        }
+
+        this.logger.info(`An unhandled HTTP request made to ${req.url} was ignored`);
+        res.writeHead(404, {});
+        res.end();
       });
 
-      const port = installerOptions.port === undefined ? 3000 : installerOptions.port;
-      this.logger.debug(`listening on port ${port} for OAuth`);
-      this.logger.debug(`Go to http://localhost:${port}${installPath} to initiate OAuth flow`);
+      this.logger.debug(`Listening for HTTP requests on port ${port}`);
+
+      if (this.installer) {
+        this.logger.debug(`Go to http://localhost:${port}${installPath} to initiate OAuth flow`);
+      }
+
       // use port 3000 by default
       server.listen(port);
     }
@@ -174,4 +211,32 @@ export default class SocketModeReceiver implements Receiver {
       }
     });
   }
+}
+
+function prepareCustomRoutes(customRoutes: CustomRoute[]): CustomRoute[] {
+  const requiredKeys: (keyof CustomRoute)[] = ['path', 'method', 'callback'];
+  const missingKeys: (keyof CustomRoute)[] = [];
+
+  // Check for missing required keys
+  customRoutes.forEach((route) => {
+    requiredKeys.forEach((key) => {
+      if (route[key] === undefined && !missingKeys.includes(key)) {
+        missingKeys.push(key);
+      }
+    });
+  });
+
+  if (missingKeys.length > 0) {
+    const errorMsg = `One or more members of customRoutes are missing required keys: ${missingKeys.join(', ')}`;
+    throw new CustomRouteInitializationError(errorMsg);
+  }
+
+  // Convert methods to uppercase for ease of request processing
+  const updatedRoutes = customRoutes.map((route) => {
+    const method = Array.isArray(route.method) ?
+      route.method.map((m) => m.toUpperCase()) : route.method.toUpperCase();
+    return { ...route, method };
+  });
+
+  return updatedRoutes;
 }

--- a/src/receivers/custom-routes.ts
+++ b/src/receivers/custom-routes.ts
@@ -42,7 +42,7 @@ function validateCustomRoutes(customRoutes: CustomRoute[]): void {
   });
 
   if (missingKeys.length > 0) {
-    const errorMsg = `One or more members of customRoutes are missing required keys: ${missingKeys.join(', ')}`;
+    const errorMsg = `One or more routes in customRoutes are missing required keys: ${missingKeys.join(', ')}`;
     throw new CustomRouteInitializationError(errorMsg);
   }
 }

--- a/src/receivers/custom-routes.ts
+++ b/src/receivers/custom-routes.ts
@@ -1,0 +1,48 @@
+import { IncomingMessage, ServerResponse } from 'http';
+import { CustomRouteInitializationError } from '../errors';
+
+export interface CustomRoute {
+  path: string;
+  method: string | string[];
+  handler: (req: IncomingMessage, res: ServerResponse) => void;
+}
+
+export interface ReceiverRoutes {
+  [key: string]: {
+    [key: string]: (req: IncomingMessage, res: ServerResponse) => void;
+  };
+}
+
+export function prepareRoutes(customRoutes: CustomRoute[]): ReceiverRoutes {
+  const routes: ReceiverRoutes = {};
+
+  validateCustomRoutes(customRoutes);
+
+  customRoutes.forEach((r) => {
+    const methodObj = Array.isArray(r.method) ?
+      r.method.reduce((o, key) => ({ ...o, [key.toUpperCase()]: r.handler }), {}) :
+      { [r.method.toUpperCase()]: r.handler };
+    routes[r.path] = routes[r.path] ? { ...routes[r.path], ...methodObj } : methodObj;
+  });
+
+  return routes;
+}
+
+function validateCustomRoutes(customRoutes: CustomRoute[]): void {
+  const requiredKeys: (keyof CustomRoute)[] = ['path', 'method', 'handler'];
+  const missingKeys: (keyof CustomRoute)[] = [];
+
+  // Check for missing required keys
+  customRoutes.forEach((route) => {
+    requiredKeys.forEach((key) => {
+      if (route[key] === undefined && !missingKeys.includes(key)) {
+        missingKeys.push(key);
+      }
+    });
+  });
+
+  if (missingKeys.length > 0) {
+    const errorMsg = `One or more members of customRoutes are missing required keys: ${missingKeys.join(', ')}`;
+    throw new CustomRouteInitializationError(errorMsg);
+  }
+}

--- a/src/receivers/custom-routes.ts
+++ b/src/receivers/custom-routes.ts
@@ -8,8 +8,8 @@ export interface CustomRoute {
 }
 
 export interface ReceiverRoutes {
-  [key: string]: {
-    [key: string]: (req: IncomingMessage, res: ServerResponse) => void;
+  [url: string]: {
+    [method: string]: (req: IncomingMessage, res: ServerResponse) => void;
   };
 }
 


### PR DESCRIPTION
###  Summary

Fixes #866, #834

This PR introduces support for adding custom HTTP routes to both `HTTPReceiver` and `SocketModeReceiver`.

Currently, `SocketModeReceiver` uses the `http` module to create routes if OAuth support is present. The changes introduced here expand upon that HTTP route creation and add additional routes if `customRoutes` is passed at the instantiation of `App`.

#### How to Add Custom HTTP Routes
When instantiating `App`, developers can now pass in the property `customRoutes` with a value set to a collection of `CustomRoute` objects. Each `CustomRoute` must include a `path`, `method` (which can be a `string` or `array`), and a `callback`, as seen below:

```
const app = new App({
  token: process.env.SLACK_BOT_TOKEN,
  customRoutes: [
    {
      path: '/health-check',
      method: ['GET'],
      handler: (req, res) => {
        res.writeHead(200);
        res.end('Health check information goes here!');
      },
    },
  ],
});
```


**As this was a highly requested feature, we would love any and all feedback from the community on this to ensure the solution addresses the use cases alluded to in past threads 🙂**

___ 
### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).