### PR TITLE
Add option to disable state verification, fix redirect uri bug

### DIFF
--- a/docs/_basic/authenticating_oauth.md
+++ b/docs/_basic/authenticating_oauth.md
@@ -96,7 +96,7 @@ const app = new App({
       authVersion: 'v1', // default  is 'v2', 'v1' is used for classic slack apps
       metadata: 'some session data',
       installPath: '/slack/installApp',
-      redirectUriPath: 'http://example.com/slack/redirect',
+      redirectUriPath: '/slack/redirect',
       callbackOptions: {
         success: (installation, installOptions, req, res) => {
           // Do custom success logic here

--- a/docs/_basic/authenticating_oauth.md
+++ b/docs/_basic/authenticating_oauth.md
@@ -96,7 +96,7 @@ const app = new App({
       authVersion: 'v1', // default  is 'v2', 'v1' is used for classic slack apps
       metadata: 'some session data',
       installPath: '/slack/installApp',
-      redirectUriPath: '/slack/redirect',
+      redirectUriPath: 'http://example.com/slack/redirect',
       callbackOptions: {
         success: (installation, installOptions, req, res) => {
           // Do custom success logic here

--- a/docs/_basic/ja_authenticating_oauth.md
+++ b/docs/_basic/ja_authenticating_oauth.md
@@ -94,7 +94,7 @@ const app = new App({
       authVersion: 'v1', // デフォルトは 'v2' (クラシック Slack アプリは 'v1')
       metadata: 'some session data',
       installPath: '/slack/installApp',
-      redirectUriPath: 'http://example.com/slack/redirect',
+      redirectUriPath: '/slack/redirect',
       callbackOptions: {
         success: (installation, installOptions, req, res) => {
           // ここで成功時のカスタムロジックを実装

--- a/docs/_basic/ja_authenticating_oauth.md
+++ b/docs/_basic/ja_authenticating_oauth.md
@@ -94,7 +94,7 @@ const app = new App({
       authVersion: 'v1', // デフォルトは 'v2' (クラシック Slack アプリは 'v1')
       metadata: 'some session data',
       installPath: '/slack/installApp',
-      redirectUriPath: '/slack/redirect',
+      redirectUriPath: 'http://example.com/slack/redirect',
       callbackOptions: {
         success: (installation, installOptions, req, res) => {
           // ここで成功時のカスタムロジックを実装

--- a/src/App.spec.ts
+++ b/src/App.spec.ts
@@ -255,20 +255,7 @@ describe('App', () => {
         assert(fakeConversationContext.firstCall.calledWith(dummyConvoStore));
       });
     });
-    describe('with custom redirect supplied', () => {
-      it('should fail when missing redirectUri', async () => {
-        // Arrange
-        const MockApp = await importApp();
-
-        // Act
-        try {
-          new MockApp({ token: '', signingSecret: '', installerOptions: { redirectUriPath: '/redirect' } }); // eslint-disable-line no-new
-          assert.fail();
-        } catch (error: any) {
-          // Assert
-          assert.propertyVal(error, 'code', ErrorCode.AppInitializationError);
-        }
-      });
+    describe('with custom redirectUri supplied', () => {
       it('should fail when missing installerOptions', async () => {
         // Arrange
         const MockApp = await importApp();

--- a/src/App.spec.ts
+++ b/src/App.spec.ts
@@ -255,6 +255,47 @@ describe('App', () => {
         assert(fakeConversationContext.firstCall.calledWith(dummyConvoStore));
       });
     });
+    describe('with custom redirect supplied', () => {
+      it('should fail when missing redirectUri', async () => {
+        // Arrange
+        const MockApp = await importApp();
+
+        // Act
+        try {
+          new MockApp({ token: '', signingSecret: '', installerOptions: { redirectUriPath: '/redirect' } }); // eslint-disable-line no-new
+          assert.fail();
+        } catch (error: any) {
+          // Assert
+          assert.propertyVal(error, 'code', ErrorCode.AppInitializationError);
+        }
+      });
+      it('should fail when missing installerOptions', async () => {
+        // Arrange
+        const MockApp = await importApp();
+
+        // Act
+        try {
+          new MockApp({ token: '', signingSecret: '', redirectUri: 'http://example.com/redirect' }); // eslint-disable-line no-new
+          assert.fail();
+        } catch (error: any) {
+          // Assert
+          assert.propertyVal(error, 'code', ErrorCode.AppInitializationError);
+        }
+      });
+      it('should fail when missing installerOptions.redirectUriPath', async () => {
+        // Arrange
+        const MockApp = await importApp();
+
+        // Act
+        try {
+          new MockApp({ token: '', signingSecret: '', redirectUri: 'http://example.com/redirect', installerOptions: {} }); // eslint-disable-line no-new
+          assert.fail();
+        } catch (error: any) {
+          // Assert
+          assert.propertyVal(error, 'code', ErrorCode.AppInitializationError);
+        }
+      });
+    });
     it('with clientOptions', async () => {
       const fakeConstructor = sinon.fake();
       const overrides = mergeOverrides(withNoopAppMetadata(), {

--- a/src/App.ts
+++ b/src/App.ts
@@ -254,6 +254,7 @@ export default class App {
       this.logLevel = logLevel ?? LogLevel.INFO;
     }
 
+    // Set up logger
     if (typeof logger === 'undefined') {
       // Initialize with the default logger
       const consoleLogger = new ConsoleLogger();
@@ -267,6 +268,7 @@ export default class App {
     }
     this.errorHandler = defaultErrorHandler(this.logger);
 
+    // Set up client options
     this.clientOptions = clientOptions !== undefined ? clientOptions : {};
     if (agent !== undefined && this.clientOptions.agent === undefined) {
       this.clientOptions.agent = agent;
@@ -278,7 +280,7 @@ export default class App {
       // only logLevel is passed
       this.clientOptions.logLevel = logLevel;
     } else {
-      // Since v3.4, WebClient starts sharing loggger with App
+      // Since v3.4, WebClient starts sharing logger with App
       this.clientOptions.logger = this.logger;
     }
     // The public WebClient instance (app.client)
@@ -309,8 +311,8 @@ export default class App {
       this.developerMode &&
       this.installerOptions &&
       (typeof this.installerOptions.callbackOptions === 'undefined' ||
-        (typeof this.installerOptions.callbackOptions !== 'undefined' &&
-          typeof this.installerOptions.callbackOptions.failure === 'undefined'))
+      (typeof this.installerOptions.callbackOptions !== 'undefined' &&
+      typeof this.installerOptions.callbackOptions.failure === 'undefined'))
     ) {
       // add a custom failure callback for Developer Mode in case they are using OAuth
       this.logger.debug('adding Developer Mode custom OAuth failure handler');
@@ -323,11 +325,9 @@ export default class App {
       };
     }
 
-    // verify any redirect options supplied
-    this.verifyRedirectOpts(redirectUri);
-
-    // Check for required arguments of HTTPReceiver
+    // Initialize receiver
     if (receiver !== undefined) {
+      // Custom receiver
       if (this.socketMode) {
         throw new AppInitializationError('receiver cannot be passed when socketMode is set to true');
       }
@@ -434,26 +434,6 @@ export default class App {
 
     // Should be last to avoid exposing partially initialized app
     this.receiver.init(this);
-  }
-
-  /**
-   * Verifies redirect uri and redirect uri path exist if either supplied
-   */
-  private verifyRedirectOpts(redirectUri: HTTPReceiverOptions['redirectUri']) {
-    // if either redirectUri or redirectUriPath are supplied
-    // both must be supplied
-    const { installerOptions } = this;
-    if (
-      (redirectUri && !installerOptions) ||
-        (redirectUri && installerOptions && !installerOptions.redirectUriPath) ||
-          (!redirectUri && installerOptions && installerOptions.redirectUriPath)
-    ) {
-      throw new AppInitializationError(
-        'To set a custom install redirect path, you must provide both redirectUri' +
-        ' and installerOptions.redirectUriPath during app initialization.' +
-        ' These should be consistent, e.g. https://example.com/redirect and /redirect',
-      );
-    }
   }
 
   /**

--- a/src/App.ts
+++ b/src/App.ts
@@ -81,6 +81,7 @@ export interface AppOptions {
   clientId?: HTTPReceiverOptions['clientId'];
   clientSecret?: HTTPReceiverOptions['clientSecret'];
   stateSecret?: HTTPReceiverOptions['stateSecret']; // required when using default stateStore
+  redirectUri?: HTTPReceiverOptions['redirectUri']
   installationStore?: HTTPReceiverOptions['installationStore']; // default MemoryInstallationStore
   scopes?: HTTPReceiverOptions['scopes'];
   installerOptions?: HTTPReceiverOptions['installerOptions'];
@@ -229,6 +230,7 @@ export default class App {
     clientId = undefined,
     clientSecret = undefined,
     stateSecret = undefined,
+    redirectUri = undefined,
     installationStore = undefined,
     scopes = undefined,
     installerOptions = undefined,
@@ -319,6 +321,19 @@ export default class App {
       };
     }
 
+    // if either redirectUri or redirectUriPath are supplied
+    // both must be supplied
+    if (
+      (redirectUri && !this.installerOptions) ||
+        (redirectUri && !this.installerOptions.redirectUriPath) ||
+          (!redirectUri && this.installerOptions.redirectUriPath)
+    ) {
+      throw new AppInitializationError(
+        'To set a custom install redirect path, you must provide both redirectUri' +
+        ' and installerOptions#redirectUriPath during app initialization.' +
+        ' These should be consistent, e.g. https://example.com/redirect and /redirect',
+      );
+    }
     // Check for required arguments of HTTPReceiver
     if (receiver !== undefined) {
       if (this.socketMode) {
@@ -336,6 +351,7 @@ export default class App {
         clientId,
         clientSecret,
         stateSecret,
+        redirectUri,
         installationStore,
         scopes,
         logger,
@@ -359,6 +375,7 @@ export default class App {
         clientId,
         clientSecret,
         stateSecret,
+        redirectUri,
         installationStore,
         scopes,
         logger,

--- a/src/App.ts
+++ b/src/App.ts
@@ -321,19 +321,9 @@ export default class App {
       };
     }
 
-    // if either redirectUri or redirectUriPath are supplied
-    // both must be supplied
-    if (
-      (redirectUri && !this.installerOptions) ||
-        (redirectUri && !this.installerOptions.redirectUriPath) ||
-          (!redirectUri && this.installerOptions.redirectUriPath)
-    ) {
-      throw new AppInitializationError(
-        'To set a custom install redirect path, you must provide both redirectUri' +
-        ' and installerOptions#redirectUriPath during app initialization.' +
-        ' These should be consistent, e.g. https://example.com/redirect and /redirect',
-      );
-    }
+    // verify any redirect options supplied
+    this.verifyRedirectOpts(redirectUri);
+
     // Check for required arguments of HTTPReceiver
     if (receiver !== undefined) {
       if (this.socketMode) {
@@ -440,6 +430,26 @@ export default class App {
 
     // Should be last to avoid exposing partially initialized app
     this.receiver.init(this);
+  }
+
+  /**
+   * Verifies redirect uri and redirect uri path exist if either supplied
+   */
+  private verifyRedirectOpts(redirectUri: HTTPReceiverOptions['redirectUri']) {
+    // if either redirectUri or redirectUriPath are supplied
+    // both must be supplied
+    const { installerOptions } = this;
+    if (
+      (redirectUri && !installerOptions) ||
+        (redirectUri && installerOptions && !installerOptions.redirectUriPath) ||
+          (!redirectUri && installerOptions && installerOptions.redirectUriPath)
+    ) {
+      throw new AppInitializationError(
+        'To set a custom install redirect path, you must provide both redirectUri' +
+        ' and installerOptions.redirectUriPath during app initialization.' +
+        ' These should be consistent, e.g. https://example.com/redirect and /redirect',
+      );
+    }
   }
 
   /**

--- a/src/receivers/ExpressReceiver.ts
+++ b/src/receivers/ExpressReceiver.ts
@@ -228,7 +228,7 @@ export default class ExpressReceiver implements Receiver {
       this.router.get(installPath, async (_req, res, next) => {
         try {
           // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-          const url = await this.installer!.generateInstallUrl(installUrlOptions);
+          const url = await this.installer!.generateInstallUrl(installUrlOptions, stateVerification);
           if (installerOptions.directInstall) {
             // If a Slack app sets "Direct Install URL" in the Slack app configuration,
             // the installation flow of the app should start with the Slack authorize URL.

--- a/src/receivers/ExpressReceiver.ts
+++ b/src/receivers/ExpressReceiver.ts
@@ -181,7 +181,9 @@ export default class ExpressReceiver implements Receiver {
     if (
       clientId !== undefined &&
       clientSecret !== undefined &&
-      (stateSecret !== undefined || installerOptions.stateStore !== undefined)
+       (installerOptions.stateVerification === false || // state store not needed
+         stateSecret !== undefined ||
+          installerOptions.stateStore !== undefined) // user provided state store
     ) {
       this.installer = new InstallProvider({
         clientId,

--- a/src/receivers/HTTPReceiver.spec.ts
+++ b/src/receivers/HTTPReceiver.spec.ts
@@ -306,7 +306,7 @@ describe('HTTPReceiver', function () {
       });
     });
 
-    describe('handInstallRedirectRequest()', function () {
+    describe('handleInstallRedirectRequest()', function () {
       it('should invoke installer handler if a request comes into the redirect URI path', async function () {
         // Arrange
         const installProviderStub = sinon.createStubInstance(InstallProvider, {

--- a/src/receivers/HTTPReceiver.spec.ts
+++ b/src/receivers/HTTPReceiver.spec.ts
@@ -204,7 +204,7 @@ describe('HTTPReceiver', function () {
       assert.isTrue(writeHead.calledWith(200));
       assert.isTrue(end.calledWith('Hello world!'));
     });
-    it('should rediect installers if directInstall is true', async function () {
+    it('should redirect installers if directInstall is true', async function () {
       // Arrange
       const installProviderStub = sinon.createStubInstance(InstallProvider);
       const overrides = mergeOverrides(

--- a/src/receivers/HTTPReceiver.spec.ts
+++ b/src/receivers/HTTPReceiver.spec.ts
@@ -7,7 +7,7 @@ import { EventEmitter } from 'events';
 import { InstallProvider } from '@slack/oauth';
 import { IncomingMessage, ServerResponse } from 'http';
 import { Override, mergeOverrides } from '../test-helpers';
-import { CustomRouteInitializationError, HTTPReceiverDeferredRequestError } from '../errors';
+import { AppInitializationError, CustomRouteInitializationError, HTTPReceiverDeferredRequestError } from '../errors';
 
 /* Testing Harness */
 
@@ -117,217 +117,335 @@ describe('HTTPReceiver', function () {
       });
       assert.isNotNull(receiver);
     });
+
+    it('should throw an error if redirect uri options supplied invalid or incomplete', async function () {
+      const HTTPReceiver = await importHTTPReceiver();
+      const clientId = 'my-clientId';
+      const clientSecret = 'my-clientSecret';
+      const signingSecret = 'secret';
+      const stateSecret = 'my-stateSecret';
+      const scopes = ['chat:write'];
+      const redirectUri = 'http://example.com/heyo';
+      const installerOptions = {
+        redirectUriPath: '/heyo',
+      };
+      // correct format with redirect options supplied
+      const receiver = new HTTPReceiver({
+        clientId,
+        clientSecret,
+        signingSecret,
+        stateSecret,
+        scopes,
+        redirectUri,
+        installerOptions,
+      });
+      assert.isNotNull(receiver);
+      // redirectUri supplied, but missing redirectUriPath
+      assert.throws(() => new HTTPReceiver({
+        clientId,
+        clientSecret,
+        signingSecret,
+        stateSecret,
+        scopes,
+        redirectUri,
+      }), AppInitializationError);
+      // inconsistent redirectUriPath
+      assert.throws(() => new HTTPReceiver({
+        clientId: 'my-clientId',
+        clientSecret,
+        signingSecret,
+        stateSecret,
+        scopes,
+        redirectUri,
+        installerOptions: {
+          redirectUriPath: '/hiya',
+        },
+      }), AppInitializationError);
+      // inconsistent redirectUri
+      assert.throws(() => new HTTPReceiver({
+        clientId: 'my-clientId',
+        clientSecret,
+        signingSecret,
+        stateSecret,
+        scopes,
+        redirectUri: 'http://example.com/hiya',
+        installerOptions,
+      }), AppInitializationError);
+    });
   });
   describe('request handling', function () {
-    it('should invoke installer generateInstallUrl if a request comes into the install path', async function () {
-      // Arrange
-      const installProviderStub = sinon.createStubInstance(InstallProvider);
-      const overrides = mergeOverrides(
-        withHttpCreateServer(this.fakeCreateServer),
-        withHttpsCreateServer(sinon.fake.throws('Should not be used.')),
-      );
-      const HTTPReceiver = await importHTTPReceiver(overrides);
+    describe('handleInstallPathRequest()', function () {
+      it('should invoke installer generateInstallUrl if a request comes into the install path', async function () {
+        // Arrange
+        const installProviderStub = sinon.createStubInstance(InstallProvider);
+        const overrides = mergeOverrides(
+          withHttpCreateServer(this.fakeCreateServer),
+          withHttpsCreateServer(sinon.fake.throws('Should not be used.')),
+        );
+        const HTTPReceiver = await importHTTPReceiver(overrides);
 
-      const metadata = 'this is bat country';
-      const scopes = ['channels:read'];
-      const userScopes = ['chat:write'];
-      const receiver = new HTTPReceiver({
-        logger: noopLogger,
-        clientId: 'my-clientId',
-        clientSecret: 'my-client-secret',
-        signingSecret: 'secret',
-        stateSecret: 'state-secret',
-        scopes,
-        installerOptions: {
-          authVersion: 'v2',
-          installPath: '/hiya',
+        const metadata = 'this is bat country';
+        const scopes = ['channels:read'];
+        const userScopes = ['chat:write'];
+        const receiver = new HTTPReceiver({
+          logger: noopLogger,
+          clientId: 'my-clientId',
+          clientSecret: 'my-client-secret',
+          signingSecret: 'secret',
+          stateSecret: 'state-secret',
+          scopes,
+          installerOptions: {
+            authVersion: 'v2',
+            installPath: '/hiya',
+            metadata,
+            userScopes,
+          },
+        });
+        assert.isNotNull(receiver);
+        receiver.installer = installProviderStub as unknown as InstallProvider;
+        const fakeReq: IncomingMessage = sinon.createStubInstance(IncomingMessage) as IncomingMessage;
+        fakeReq.url = '/hiya';
+        fakeReq.headers = { host: 'localhost' };
+        fakeReq.method = 'GET';
+        const fakeRes: ServerResponse = sinon.createStubInstance(ServerResponse) as unknown as ServerResponse;
+        const writeHead = sinon.fake();
+        const end = sinon.fake();
+        fakeRes.writeHead = writeHead;
+        fakeRes.end = end;
+        await receiver.requestListener(fakeReq, fakeRes);
+        assert(installProviderStub.generateInstallUrl.calledWith(sinon.match({ metadata, scopes, userScopes })));
+        assert.isTrue(writeHead.calledWith(200));
+      });
+
+      it('should use a custom HTML renderer for the install path webpage', async function () {
+        // Arrange
+        const installProviderStub = sinon.createStubInstance(InstallProvider);
+        const overrides = mergeOverrides(
+          withHttpCreateServer(this.fakeCreateServer),
+          withHttpsCreateServer(sinon.fake.throws('Should not be used.')),
+        );
+        const HTTPReceiver = await importHTTPReceiver(overrides);
+
+        const metadata = 'this is bat country';
+        const scopes = ['channels:read'];
+        const userScopes = ['chat:write'];
+        const receiver = new HTTPReceiver({
+          logger: noopLogger,
+          clientId: 'my-clientId',
+          clientSecret: 'my-client-secret',
+          signingSecret: 'secret',
+          stateSecret: 'state-secret',
+          scopes,
+          installerOptions: {
+            authVersion: 'v2',
+            installPath: '/hiya',
+            renderHtmlForInstallPath: (_) => 'Hello world!',
+            metadata,
+            userScopes,
+          },
+        });
+        assert.isNotNull(receiver);
+        receiver.installer = installProviderStub as unknown as InstallProvider;
+        const fakeReq: IncomingMessage = sinon.createStubInstance(IncomingMessage) as IncomingMessage;
+        fakeReq.url = '/hiya';
+        fakeReq.headers = { host: 'localhost' };
+        fakeReq.method = 'GET';
+        const fakeRes: ServerResponse = sinon.createStubInstance(ServerResponse) as unknown as ServerResponse;
+        const writeHead = sinon.fake();
+        const end = sinon.fake();
+        fakeRes.writeHead = writeHead;
+        fakeRes.end = end;
+        /* eslint-disable-next-line @typescript-eslint/await-thenable */
+        await receiver.requestListener(fakeReq, fakeRes);
+        assert(installProviderStub.generateInstallUrl.calledWith(sinon.match({ metadata, scopes, userScopes })));
+        assert.isTrue(writeHead.calledWith(200));
+        assert.isTrue(end.calledWith('Hello world!'));
+      });
+
+      it('should redirect installers if directInstall is true', async function () {
+        // Arrange
+        const installProviderStub = sinon.createStubInstance(InstallProvider);
+        const overrides = mergeOverrides(
+          withHttpCreateServer(this.fakeCreateServer),
+          withHttpsCreateServer(sinon.fake.throws('Should not be used.')),
+        );
+        const HTTPReceiver = await importHTTPReceiver(overrides);
+
+        const metadata = 'this is bat country';
+        const scopes = ['channels:read'];
+        const userScopes = ['chat:write'];
+        const receiver = new HTTPReceiver({
+          logger: noopLogger,
+          clientId: 'my-clientId',
+          clientSecret: 'my-client-secret',
+          signingSecret: 'secret',
+          stateSecret: 'state-secret',
+          scopes,
+          installerOptions: {
+            authVersion: 'v2',
+            installPath: '/hiya',
+            directInstall: true,
+            metadata,
+            userScopes,
+          },
+        });
+        assert.isNotNull(receiver);
+        receiver.installer = installProviderStub as unknown as InstallProvider;
+        const fakeReq: IncomingMessage = sinon.createStubInstance(IncomingMessage) as IncomingMessage;
+        fakeReq.url = '/hiya';
+        fakeReq.headers = { host: 'localhost' };
+        fakeReq.method = 'GET';
+        const fakeRes: ServerResponse = sinon.createStubInstance(ServerResponse) as unknown as ServerResponse;
+        const writeHead = sinon.fake();
+        const end = sinon.fake();
+        fakeRes.writeHead = writeHead;
+        fakeRes.end = end;
+        await receiver.requestListener(fakeReq, fakeRes);
+        assert(installProviderStub.generateInstallUrl.calledWith(sinon.match({ metadata, scopes, userScopes })));
+        assert.isTrue(writeHead.calledWith(302, sinon.match.object));
+      });
+    });
+
+    describe('handInstallRedirectRequest()', function () {
+      it('should invoke installer handler if a request comes into the redirect URI path', async function () {
+        // Arrange
+        const installProviderStub = sinon.createStubInstance(InstallProvider, {
+          handleCallback: sinon.stub().resolves() as unknown as Promise<void>,
+        });
+        const overrides = mergeOverrides(
+          withHttpCreateServer(this.fakeCreateServer),
+          withHttpsCreateServer(sinon.fake.throws('Should not be used.')),
+        );
+        const HTTPReceiver = await importHTTPReceiver(overrides);
+
+        const metadata = 'this is bat country';
+        const scopes = ['channels:read'];
+        const userScopes = ['chat:write'];
+        const callbackOptions = {};
+        const receiver = new HTTPReceiver({
+          logger: noopLogger,
+          clientId: 'my-clientId',
+          clientSecret: 'my-client-secret',
+          signingSecret: 'secret',
+          stateSecret: 'state-secret',
+          scopes,
+          redirectUri: 'http://example.com/heyo',
+          installerOptions: {
+            authVersion: 'v2',
+            redirectUriPath: '/heyo',
+            callbackOptions,
+            metadata,
+            userScopes,
+          },
+        });
+        assert.isNotNull(receiver);
+        receiver.installer = installProviderStub as unknown as InstallProvider;
+        const fakeReq: IncomingMessage = sinon.createStubInstance(IncomingMessage) as IncomingMessage;
+        fakeReq.url = '/heyo';
+        fakeReq.headers = { host: 'localhost' };
+        fakeReq.method = 'GET';
+        const fakeRes: ServerResponse = sinon.createStubInstance(ServerResponse) as unknown as ServerResponse;
+        const writeHead = sinon.fake();
+        const end = sinon.fake();
+        fakeRes.writeHead = writeHead;
+        fakeRes.end = end;
+        /* eslint-disable-next-line @typescript-eslint/await-thenable */
+        await receiver.requestListener(fakeReq, fakeRes);
+        assert(installProviderStub.handleCallback.calledWith(fakeReq, fakeRes, callbackOptions));
+      });
+
+      it('should invoke installer handler with installURLoptions supplied if state verification is off', async function () {
+        // Arrange
+        const installProviderStub = sinon.createStubInstance(InstallProvider, {
+          handleCallback: sinon.stub().resolves() as unknown as Promise<void>,
+        });
+        const overrides = mergeOverrides(
+          withHttpCreateServer(this.fakeCreateServer),
+          withHttpsCreateServer(sinon.fake.throws('Should not be used.')),
+        );
+        const HTTPReceiver = await importHTTPReceiver(overrides);
+
+        const metadata = 'this is bat country';
+        const scopes = ['channels:read'];
+        const userScopes = ['chat:write'];
+        const redirectUri = 'http://example.com/heyo';
+        const callbackOptions = {};
+        const installUrlOptions = {
+          scopes,
           metadata,
           userScopes,
-        },
+          redirectUri,
+        };
+        const receiver = new HTTPReceiver({
+          logger: noopLogger,
+          clientId: 'my-clientId',
+          clientSecret: 'my-client-secret',
+          signingSecret: 'secret',
+          stateSecret: 'state-secret',
+          scopes,
+          redirectUri,
+          installerOptions: {
+            stateVerification: false,
+            authVersion: 'v2',
+            redirectUriPath: '/heyo',
+            callbackOptions,
+            metadata,
+            userScopes,
+          },
+        });
+        assert.isNotNull(receiver);
+        receiver.installer = installProviderStub as unknown as InstallProvider;
+        const fakeReq: IncomingMessage = sinon.createStubInstance(IncomingMessage) as IncomingMessage;
+        fakeReq.url = '/heyo';
+        fakeReq.headers = { host: 'localhost' };
+        fakeReq.method = 'GET';
+        const fakeRes: ServerResponse = sinon.createStubInstance(ServerResponse) as unknown as ServerResponse;
+        fakeRes.writeHead = sinon.fake();
+        fakeRes.end = sinon.fake();
+        await receiver.requestListener(fakeReq, fakeRes);
+        sinon.assert.calledWith(
+          installProviderStub.handleCallback, fakeReq, fakeRes, callbackOptions, installUrlOptions,
+        );
       });
-      assert.isNotNull(receiver);
-      receiver.installer = installProviderStub as unknown as InstallProvider;
-      const fakeReq: IncomingMessage = sinon.createStubInstance(IncomingMessage) as IncomingMessage;
-      fakeReq.url = '/hiya';
-      fakeReq.headers = { host: 'localhost' };
-      fakeReq.method = 'GET';
-      const fakeRes: ServerResponse = sinon.createStubInstance(ServerResponse) as unknown as ServerResponse;
-      const writeHead = sinon.fake();
-      const end = sinon.fake();
-      fakeRes.writeHead = writeHead;
-      fakeRes.end = end;
-      await receiver.requestListener(fakeReq, fakeRes);
-      assert(installProviderStub.generateInstallUrl.calledWith(sinon.match({ metadata, scopes, userScopes })));
-      assert.isTrue(writeHead.calledWith(200));
     });
-    it('should use a custom HTML renderer for the install path webpage', async function () {
-      // Arrange
-      const installProviderStub = sinon.createStubInstance(InstallProvider);
-      const overrides = mergeOverrides(
-        withHttpCreateServer(this.fakeCreateServer),
-        withHttpsCreateServer(sinon.fake.throws('Should not be used.')),
-      );
-      const HTTPReceiver = await importHTTPReceiver(overrides);
+    describe('custom route handling', async function () {
+      it('should call custom route handler only if request matches route path and method', async function () {
+        const HTTPReceiver = await importHTTPReceiver();
+        const customRoutes = [{ path: '/test', method: ['get', 'POST'], handler: sinon.fake() }];
+        const receiver = new HTTPReceiver({
+          clientSecret: 'my-client-secret',
+          signingSecret: 'secret',
+          customRoutes,
+        });
 
-      const metadata = 'this is bat country';
-      const scopes = ['channels:read'];
-      const userScopes = ['chat:write'];
-      const receiver = new HTTPReceiver({
-        logger: noopLogger,
-        clientId: 'my-clientId',
-        clientSecret: 'my-client-secret',
-        signingSecret: 'secret',
-        stateSecret: 'state-secret',
-        scopes,
-        installerOptions: {
-          authVersion: 'v2',
-          installPath: '/hiya',
-          renderHtmlForInstallPath: (_) => 'Hello world!',
-          metadata,
-          userScopes,
-        },
-      });
-      assert.isNotNull(receiver);
-      receiver.installer = installProviderStub as unknown as InstallProvider;
-      const fakeReq: IncomingMessage = sinon.createStubInstance(IncomingMessage) as IncomingMessage;
-      fakeReq.url = '/hiya';
-      fakeReq.headers = { host: 'localhost' };
-      fakeReq.method = 'GET';
-      const fakeRes: ServerResponse = sinon.createStubInstance(ServerResponse) as unknown as ServerResponse;
-      const writeHead = sinon.fake();
-      const end = sinon.fake();
-      fakeRes.writeHead = writeHead;
-      fakeRes.end = end;
-      /* eslint-disable-next-line @typescript-eslint/await-thenable */
-      await receiver.requestListener(fakeReq, fakeRes);
-      assert(installProviderStub.generateInstallUrl.calledWith(sinon.match({ metadata, scopes, userScopes })));
-      assert.isTrue(writeHead.calledWith(200));
-      assert.isTrue(end.calledWith('Hello world!'));
-    });
-    it('should redirect installers if directInstall is true', async function () {
-      // Arrange
-      const installProviderStub = sinon.createStubInstance(InstallProvider);
-      const overrides = mergeOverrides(
-        withHttpCreateServer(this.fakeCreateServer),
-        withHttpsCreateServer(sinon.fake.throws('Should not be used.')),
-      );
-      const HTTPReceiver = await importHTTPReceiver(overrides);
+        const fakeReq: IncomingMessage = sinon.createStubInstance(IncomingMessage) as IncomingMessage;
+        const fakeRes: ServerResponse = sinon.createStubInstance(ServerResponse) as unknown as ServerResponse;
 
-      const metadata = 'this is bat country';
-      const scopes = ['channels:read'];
-      const userScopes = ['chat:write'];
-      const receiver = new HTTPReceiver({
-        logger: noopLogger,
-        clientId: 'my-clientId',
-        clientSecret: 'my-client-secret',
-        signingSecret: 'secret',
-        stateSecret: 'state-secret',
-        scopes,
-        installerOptions: {
-          authVersion: 'v2',
-          installPath: '/hiya',
-          directInstall: true,
-          metadata,
-          userScopes,
-        },
-      });
-      assert.isNotNull(receiver);
-      receiver.installer = installProviderStub as unknown as InstallProvider;
-      const fakeReq: IncomingMessage = sinon.createStubInstance(IncomingMessage) as IncomingMessage;
-      fakeReq.url = '/hiya';
-      fakeReq.headers = { host: 'localhost' };
-      fakeReq.method = 'GET';
-      const fakeRes: ServerResponse = sinon.createStubInstance(ServerResponse) as unknown as ServerResponse;
-      const writeHead = sinon.fake();
-      const end = sinon.fake();
-      fakeRes.writeHead = writeHead;
-      fakeRes.end = end;
-      await receiver.requestListener(fakeReq, fakeRes);
-      assert(installProviderStub.generateInstallUrl.calledWith(sinon.match({ metadata, scopes, userScopes })));
-      assert.isTrue(writeHead.calledWith(302, sinon.match.object));
-    });
-    it('should invoke installer handler if a request comes into the redirect URI path', async function () {
-      // Arrange
-      const installProviderStub = sinon.createStubInstance(InstallProvider, {
-        handleCallback: sinon.stub().resolves() as unknown as Promise<void>,
-      });
-      const overrides = mergeOverrides(
-        withHttpCreateServer(this.fakeCreateServer),
-        withHttpsCreateServer(sinon.fake.throws('Should not be used.')),
-      );
-      const HTTPReceiver = await importHTTPReceiver(overrides);
+        fakeReq.url = '/test';
+        fakeReq.headers = { host: 'localhost' };
 
-      const metadata = 'this is bat country';
-      const scopes = ['channels:read'];
-      const userScopes = ['chat:write'];
-      const callbackOptions = {};
-      const receiver = new HTTPReceiver({
-        logger: noopLogger,
-        clientId: 'my-clientId',
-        clientSecret: 'my-client-secret',
-        signingSecret: 'secret',
-        stateSecret: 'state-secret',
-        scopes,
-        installerOptions: {
-          authVersion: 'v2',
-          redirectUriPath: '/heyo',
-          callbackOptions,
-          metadata,
-          userScopes,
-        },
-      });
-      assert.isNotNull(receiver);
-      receiver.installer = installProviderStub as unknown as InstallProvider;
-      const fakeReq: IncomingMessage = sinon.createStubInstance(IncomingMessage) as IncomingMessage;
-      fakeReq.url = '/heyo';
-      fakeReq.headers = { host: 'localhost' };
-      fakeReq.method = 'GET';
-      const fakeRes: ServerResponse = sinon.createStubInstance(ServerResponse) as unknown as ServerResponse;
-      const writeHead = sinon.fake();
-      const end = sinon.fake();
-      fakeRes.writeHead = writeHead;
-      fakeRes.end = end;
-      /* eslint-disable-next-line @typescript-eslint/await-thenable */
-      await receiver.requestListener(fakeReq, fakeRes);
-      assert(installProviderStub.handleCallback.calledWith(fakeReq, fakeRes, callbackOptions));
-    });
+        fakeReq.method = 'GET';
+        receiver.requestListener(fakeReq, fakeRes);
+        assert(customRoutes[0].handler.calledWith(fakeReq, fakeRes));
 
-    it('should call custom route handler only if request matches route path and method', async function () {
-      const HTTPReceiver = await importHTTPReceiver();
-      const customRoutes = [{ path: '/test', method: ['get', 'POST'], handler: sinon.fake() }];
-      const receiver = new HTTPReceiver({
-        clientSecret: 'my-client-secret',
-        signingSecret: 'secret',
-        customRoutes,
+        fakeReq.method = 'POST';
+        receiver.requestListener(fakeReq, fakeRes);
+        assert(customRoutes[0].handler.calledWith(fakeReq, fakeRes));
+
+        fakeReq.method = 'UNHANDLED_METHOD';
+        assert.throws(() => receiver.requestListener(fakeReq, fakeRes), HTTPReceiverDeferredRequestError);
       });
 
-      const fakeReq: IncomingMessage = sinon.createStubInstance(IncomingMessage) as IncomingMessage;
-      const fakeRes: ServerResponse = sinon.createStubInstance(ServerResponse) as unknown as ServerResponse;
+      it("should throw an error if customRoutes don't have the required keys", async function () {
+        const HTTPReceiver = await importHTTPReceiver();
+        const customRoutes = [{ path: '/test' }] as any;
 
-      fakeReq.url = '/test';
-      fakeReq.headers = { host: 'localhost' };
-
-      fakeReq.method = 'GET';
-      receiver.requestListener(fakeReq, fakeRes);
-      assert(customRoutes[0].handler.calledWith(fakeReq, fakeRes));
-
-      fakeReq.method = 'POST';
-      receiver.requestListener(fakeReq, fakeRes);
-      assert(customRoutes[0].handler.calledWith(fakeReq, fakeRes));
-
-      fakeReq.method = 'UNHANDLED_METHOD';
-      assert.throws(() => receiver.requestListener(fakeReq, fakeRes), HTTPReceiverDeferredRequestError);
-    });
-
-    it("should throw an error if customRoutes don't have the required keys", async function () {
-      const HTTPReceiver = await importHTTPReceiver();
-      const customRoutes = [{ path: '/test' }] as any;
-
-      assert.throws(() => new HTTPReceiver({
-        clientSecret: 'my-client-secret',
-        signingSecret: 'secret',
-        customRoutes,
-      }), CustomRouteInitializationError);
+        assert.throws(() => new HTTPReceiver({
+          clientSecret: 'my-client-secret',
+          signingSecret: 'secret',
+          customRoutes,
+        }), CustomRouteInitializationError);
+      });
     });
 
     it("should throw if request doesn't match install path, redirect URI path, or custom routes", async function () {
@@ -351,6 +469,7 @@ describe('HTTPReceiver', function () {
         signingSecret: 'secret',
         stateSecret: 'state-secret',
         scopes,
+        redirectUri: 'http://example.com/heyo',
         installerOptions: {
           authVersion: 'v2',
           installPath: '/hiya',

--- a/src/receivers/HTTPReceiver.ts
+++ b/src/receivers/HTTPReceiver.ts
@@ -76,6 +76,7 @@ export interface HTTPReceiverInstallerOptions {
   renderHtmlForInstallPath?: (url: string) => string;
   redirectUriPath?: string;
   stateStore?: InstallProviderOptions['stateStore']; // default ClearStateStore
+  stateValidation?: InstallProviderOptions['stateValidation']; // default true
   authVersion?: InstallProviderOptions['authVersion']; // default 'v2'
   clientOptions?: InstallProviderOptions['clientOptions'];
   authorizationUrl?: InstallProviderOptions['authorizationUrl'];

--- a/src/receivers/HTTPReceiver.ts
+++ b/src/receivers/HTTPReceiver.ts
@@ -86,6 +86,9 @@ export interface HTTPReceiverInstallerOptions {
   callbackOptions?: CallbackOptions;
 }
 
+/**
+ * Receives HTTP requests with Events, Slash Commands, and Actions
+ */
 export default class HTTPReceiver implements Receiver {
   private endpoints: string[];
 

--- a/src/receivers/HTTPReceiver.ts
+++ b/src/receivers/HTTPReceiver.ts
@@ -173,13 +173,13 @@ export default class HTTPReceiver implements Receiver {
       this.directInstall = installerOptions.directInstall !== undefined && installerOptions.directInstall;
       this.installRedirectUriPath = installerOptions.redirectUriPath ?? '/slack/oauth_redirect';
       this.stateVerification = installerOptions.stateVerification;
+      this.installCallbackOptions = installerOptions.callbackOptions ?? {};
       this.installUrlOptions = {
         scopes: scopes ?? [],
         userScopes: installerOptions.userScopes,
         metadata: installerOptions.metadata,
         redirectUri,
       };
-      this.installCallbackOptions = installerOptions.callbackOptions ?? {};
     }
     this.renderHtmlForInstallPath = installerOptions.renderHtmlForInstallPath !== undefined ?
       installerOptions.renderHtmlForInstallPath :
@@ -497,12 +497,13 @@ export default class HTTPReceiver implements Receiver {
   private handleInstallRedirectRequest(req: IncomingMessage, res: ServerResponse) {
     // This function is only called from within unboundRequestListener after checking that installer is defined, and
     // when installer is defined then installCallbackOptions is always defined too.
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    /* eslint-disable @typescript-eslint/no-non-null-assertion */
     const [installer, installCallbackOptions, installUrlOptions] = [
       this.installer!,
       this.installCallbackOptions!,
       this.installUrlOptions!,
     ];
+    /* eslint-disable @typescript-eslint/no-non-null-assertion */
     const errorHandler = (err: Error) => {
       this.logger.error(
         'HTTPReceiver encountered an unexpected error while handling the OAuth install redirect. Please report to the maintainers.',

--- a/src/receivers/HTTPReceiver.ts
+++ b/src/receivers/HTTPReceiver.ts
@@ -149,10 +149,13 @@ export default class HTTPReceiver implements Receiver {
       })();
     this.endpoints = Array.isArray(endpoints) ? endpoints : [endpoints];
     // Initialize InstallProvider when it's required options are provided
+    this.stateVerification = installerOptions.stateVerification;
     if (
       clientId !== undefined &&
       clientSecret !== undefined &&
-      (stateSecret !== undefined || installerOptions.stateStore !== undefined)
+       (this.stateVerification === false || // state store not needed
+         stateSecret !== undefined ||
+          installerOptions.stateStore !== undefined) // user provided state store
     ) {
       this.installer = new InstallProvider({
         clientId,
@@ -172,7 +175,6 @@ export default class HTTPReceiver implements Receiver {
       this.installPath = installerOptions.installPath ?? '/slack/install';
       this.directInstall = installerOptions.directInstall !== undefined && installerOptions.directInstall;
       this.installRedirectUriPath = installerOptions.redirectUriPath ?? '/slack/oauth_redirect';
-      this.stateVerification = installerOptions.stateVerification;
       this.installCallbackOptions = installerOptions.callbackOptions ?? {};
       this.installUrlOptions = {
         scopes: scopes ?? [],

--- a/src/receivers/HTTPReceiver.ts
+++ b/src/receivers/HTTPReceiver.ts
@@ -152,11 +152,8 @@ export default class HTTPReceiver implements Receiver {
         return defaultLogger;
       })();
     this.endpoints = Array.isArray(endpoints) ? endpoints : [endpoints];
-<<<<<<< HEAD
-=======
     this.routes = prepareRoutes(customRoutes);
 
->>>>>>> main
     // Initialize InstallProvider when it's required options are provided
     this.stateVerification = installerOptions.stateVerification;
     if (
@@ -319,11 +316,8 @@ export default class HTTPReceiver implements Receiver {
       // When installer is defined then installPath and installRedirectUriPath are always defined
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       const [installPath, installRedirectUriPath] = [this.installPath!, this.installRedirectUriPath!];
-<<<<<<< HEAD
-=======
 
       // Visiting the installation endpoint
->>>>>>> main
       if (path === installPath) {
         // Render installation path (containing Add to Slack button)
         return this.handleInstallPathRequest(res);

--- a/src/receivers/HTTPReceiver.ts
+++ b/src/receivers/HTTPReceiver.ts
@@ -525,7 +525,7 @@ export default class HTTPReceiver implements Receiver {
       this.installCallbackOptions!,
       this.installUrlOptions!,
     ];
-    /* eslint-disable @typescript-eslint/no-non-null-assertion */
+    /* eslint-enable @typescript-eslint/no-non-null-assertion */
     const errorHandler = (err: Error) => {
       this.logger.error(
         'HTTPReceiver encountered an unexpected error while handling the OAuth install redirect. Please report to the maintainers.',

--- a/src/receivers/HTTPReceiver.ts
+++ b/src/receivers/HTTPReceiver.ts
@@ -466,7 +466,7 @@ export default class HTTPReceiver implements Receiver {
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         const [installer, installUrlOptions] = [this.installer!, this.installUrlOptions!];
         // Generate the URL for the "Add to Slack" button.
-        const url = await installer.generateInstallUrl(installUrlOptions);
+        const url = await installer.generateInstallUrl(installUrlOptions, this.stateVerification);
 
         if (this.directInstall !== undefined && this.directInstall) {
           // If a Slack app sets "Direct Install URL" in the Slack app configruation,

--- a/src/receivers/HTTPReceiver.ts
+++ b/src/receivers/HTTPReceiver.ts
@@ -146,7 +146,6 @@ export default class HTTPReceiver implements Receiver {
         return defaultLogger;
       })();
     this.endpoints = Array.isArray(endpoints) ? endpoints : [endpoints];
-    this.logger.debug('===INSIDE HTTP RECEIVER====');
     // Initialize InstallProvider when it's required options are provided
     if (
       clientId !== undefined &&

--- a/src/receivers/SocketModeReceiver.spec.ts
+++ b/src/receivers/SocketModeReceiver.spec.ts
@@ -197,7 +197,9 @@ describe('SocketModeReceiver', function () {
         end: sinon.fake(),
       };
       await this.listener(fakeReq, fakeRes);
-      assert(installProviderStub.generateInstallUrl.calledWith(sinon.match({ metadata, scopes, userScopes })));
+      assert(installProviderStub.generateInstallUrl.calledWith(
+        sinon.match({ metadata, scopes, userScopes }),
+      ));
       assert(fakeRes.writeHead.calledWith(200, sinon.match.object));
       assert(fakeRes.end.called);
     });

--- a/src/receivers/SocketModeReceiver.spec.ts
+++ b/src/receivers/SocketModeReceiver.spec.ts
@@ -197,9 +197,7 @@ describe('SocketModeReceiver', function () {
         end: sinon.fake(),
       };
       await this.listener(fakeReq, fakeRes);
-      assert(installProviderStub.generateInstallUrl.calledWith(
-        sinon.match({ metadata, scopes, userScopes }),
-      ));
+      assert(installProviderStub.generateInstallUrl.calledWith(sinon.match({ metadata, scopes, userScopes })));
       assert(fakeRes.writeHead.calledWith(200, sinon.match.object));
       assert(fakeRes.end.called);
     });

--- a/src/receivers/SocketModeReceiver.ts
+++ b/src/receivers/SocketModeReceiver.ts
@@ -82,7 +82,9 @@ export default class SocketModeReceiver implements Receiver {
     if (
       clientId !== undefined &&
       clientSecret !== undefined &&
-      (stateSecret !== undefined || installerOptions.stateStore !== undefined)
+       (installerOptions.stateVerification === false || // state store not needed
+         stateSecret !== undefined ||
+          installerOptions.stateStore !== undefined) // user provided state store
     ) {
       this.installer = new InstallProvider({
         clientId,

--- a/src/receivers/SocketModeReceiver.ts
+++ b/src/receivers/SocketModeReceiver.ts
@@ -131,16 +131,17 @@ export default class SocketModeReceiver implements Receiver {
             await this.installer!.handleCallback(req, res, callbackOptions, installUrlOptions);
           }
         } else if (req.url !== undefined && req.url.startsWith(installPath)) {
+          const { stateVerification, renderHtmlForInstallPath } = installerOptions;
           try {
             // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-            const url = await this.installer!.generateInstallUrl(installUrlOptions);
+            const url = await this.installer!.generateInstallUrl(installUrlOptions, stateVerification);
             if (directInstallEnabled) {
               res.writeHead(302, { Location: url });
               res.end('');
             } else {
               res.writeHead(200, {});
-              const renderHtml = installerOptions.renderHtmlForInstallPath !== undefined ?
-                installerOptions.renderHtmlForInstallPath :
+              const renderHtml = renderHtmlForInstallPath !== undefined ?
+                renderHtmlForInstallPath :
                 defaultRenderHtmlForInstallPath;
               res.end(renderHtml(url));
             }

--- a/src/receivers/SocketModeReceiver.ts
+++ b/src/receivers/SocketModeReceiver.ts
@@ -116,16 +116,13 @@ export default class SocketModeReceiver implements Receiver {
         redirectUri,
       };
       const server = createServer(async (req, res) => {
-        this.logger.debug('+++ checking path +++', req.url, redirectUriPath);
         if (req.url !== undefined && req.url.startsWith(redirectUriPath)) {
           const { stateVerification, callbackOptions } = installerOptions;
           // call installer.handleCallback to wrap up the install flow
           if (stateVerification) {
-            this.logger.debug(' +++ state verification on +++');
             // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
             await this.installer!.handleCallback(req, res, callbackOptions);
           } else {
-            this.logger.debug(' +++ state verification off +++');
             // when stateVerification is disabled
             // make installation options directly available to installation handler
             // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
@@ -133,7 +130,6 @@ export default class SocketModeReceiver implements Receiver {
           }
         } else if (req.url !== undefined && req.url.startsWith(installPath)) {
           try {
-            this.logger.debug('+++ inside redirect path +++', req.url, redirectUriPath);
             // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
             const url = await this.installer!.generateInstallUrl(installUrlOptions);
             if (directInstallEnabled) {

--- a/src/receivers/SocketModeReceiver.ts
+++ b/src/receivers/SocketModeReceiver.ts
@@ -122,19 +122,19 @@ export default class SocketModeReceiver implements Receiver {
       const directInstallEnabled = installerOptions.directInstall !== undefined && installerOptions.directInstall;
       const port = installerOptions.port === undefined ? 3000 : installerOptions.port;
 
-      // create install url options
-      const installUrlOptions = {
-        metadata: installerOptions.metadata,
-        scopes: scopes ?? [],
-        userScopes: installerOptions.userScopes,
-        redirectUri,
-      };
       const server = createServer(async (req, res) => {
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         const method = req.method!.toUpperCase();
 
         // Handle OAuth-related requests
         if (this.installer) {
+          // create install url options
+          const installUrlOptions = {
+            metadata: installerOptions.metadata,
+            scopes: scopes ?? [],
+            userScopes: installerOptions.userScopes,
+            redirectUri,
+          };
           // Installation has been initiated
           if (req.url && req.url.startsWith(redirectUriPath)) {
             const { stateVerification, callbackOptions } = installerOptions;

--- a/src/receivers/verify-redirect-opts.ts
+++ b/src/receivers/verify-redirect-opts.ts
@@ -1,0 +1,29 @@
+/**
+ * Helper to verify redirect uri and redirect uri path exist and are consistent
+ * when supplied.
+*/
+import { AppInitializationError } from '../errors';
+import { HTTPReceiverOptions, HTTPReceiverInstallerOptions } from './HTTPReceiver';
+
+export interface RedirectOptions {
+  redirectUri?: HTTPReceiverOptions['redirectUri'],
+  redirectUriPath?: HTTPReceiverInstallerOptions['redirectUriPath'],
+}
+
+export function verifyRedirectOpts({ redirectUri, redirectUriPath }: RedirectOptions): void {
+  // if redirectUri is supplied, redirectUriPath is required
+  if ((redirectUri && !redirectUriPath)) {
+    throw new AppInitializationError(
+      ' You have set a redirectUri but not a matching redirectUriPath.' +
+      ' Please provide this via installerOptions.redirectUriPath' +
+      ' Note: These should be consistent, e.g. https://example.com/redirect and /redirect',
+    );
+  }
+  // if both redirectUri and redirectUri are supplied, they must be consistent
+  if (redirectUri && redirectUriPath && !redirectUri?.endsWith(redirectUriPath)) {
+    throw new AppInitializationError(
+      'redirectUri and installerOptions.redirectUriPath should be consistent' +
+      ' e.g. https://example.com/redirect and /redirect',
+    );
+  }
+}


### PR DESCRIPTION
###  Summary

Fixes #1101 
Fixes #1115 

See both for more context. 

It adds the option to disable state verification during OAuth flow via a `stateVerification` flag. By default this will be true. When state verification is disabled, `stateSecret` is no longer required, so this updates error messages associated with that previous hard requirement.

This PR also fixes an issue where the user supplied redirect_uri is not properly being passed as part of oauth/v2/authorize request params. It adds a separate top-level `redirectUri` parameter that contains the full url and includes some input validation. 


Todo 
- [x] Add tests for redirectUri configuration error states
- [x] Add test for stateVerification flow (needs new types pulled in)
- [x] Prep documentation PR to follow [here](https://github.com/slackapi/bolt-js/pull/1122)
- [x] [node-slack-sdk/pull/1329](https://github.com/slackapi/node-slack-sdk/pull/1329) should be released in node-slack-sdk. 


### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).