### PR TITLE
Add docs on updating views on submission with `response_action`

### DIFF
--- a/docs/_basic/listening_modals.md
+++ b/docs/_basic/listening_modals.md
@@ -6,11 +6,28 @@ order: 12
 ---
 
 <div class="section-content">
-If a <a href="https://api.slack.com/reference/block-kit/views">view payload</a> contains any input blocks, you must listen to <code>view_submission</code> requests to receive their values. To listen to <code>view_submission</code> requests, you can use the built-in <code>view()</code> method.
+If a <a href="https://api.slack.com/reference/block-kit/views">view payload</a> contains any input blocks, you must listen to `view_submission` requests to receive their values. To listen to `view_submission` requests, you can use the built-in `view()` method.
 
-<code>view()</code> requires a <code>callback_id</code> of type <code>string</code> or <code>RegExp</code>.
+`view()` requires a `callback_id` of type `string` or `RegExp`.
 
-You can access the value of the <code>input</code> blocks by accessing the <code>state</code> object. <code>state</code> contains a <code>values</code> object that uses the <code>block_id</code> and unique <code>action_id</code> to store the input values.
+You can access the value of the input blocks by accessing the `state` object. `state` contains a values object that uses the `block_id` and unique `action_id` to store the input values.
+
+---
+
+##### Update views on submission
+
+To update a view in response to a `view_submission` event, you may pass a `response_action` of type `update` with a newly composed `view` to display in your acknowledgement.
+
+```javascript
+// Update the view on submission 
+app.view('modal-callback-id', async ({ ack, body }) => {
+  await ack({
+    response_action: 'update',
+    view: buildNewModalView(body),
+  });
+});
+```
+Similarly, there are options for [displaying errors](https://api.slack.com/surfaces/modals/using#displaying_errors) in response to view submissions.
 
 Read more about view submissions in our <a href="https://api.slack.com/surfaces/modals/using#interactions">API documentation</a>.
 </div>


### PR DESCRIPTION
###  Summary

Fixes #1124. Can put in Python SDK docs changes after this is reviewed.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).