### PR TITLE
Update Custom HTTP Routes Documentation

### DIFF
--- a/docs/_advanced/custom_routes.md
+++ b/docs/_advanced/custom_routes.md
@@ -6,7 +6,7 @@ order: 10
 ---
 
 <div class="section-content">
-As of `v3.7.0`, custom HTTP routes can be easily added by passing in a collection of routes as `customRoutes` when initializing `App`. 
+As of `v3.7.0`, custom HTTP routes can be easily added by passing in an array of routes as `customRoutes` when initializing `App`. 
 
 Each `CustomRoute` object must contain three properties: `path`, `method`, and `handler`. `method`, which corresponds to the HTTP verb, can be either a string or an array of strings.
 </div>

--- a/docs/_advanced/custom_routes.md
+++ b/docs/_advanced/custom_routes.md
@@ -14,7 +14,7 @@ Each `CustomRoute` object must contain three properties: `path`, `method`, and `
 ```javascript
 const { App } = require('@slack/bolt');
 
-// Create the Bolt App, using the receiver
+// Initialize Bolt app, using the default HTTPReceiver
 const app = new App({
   token: process.env.SLACK_BOT_TOKEN,
   signingSecret: process.env.SLACK_SIGNING_SECRET,

--- a/docs/_advanced/custom_routes.md
+++ b/docs/_advanced/custom_routes.md
@@ -6,9 +6,43 @@ order: 10
 ---
 
 <div class="section-content">
+As of `v3.7.0`, custom HTTP routes can be easily added by passing in a collection of routes as `customRoutes` when initializing `App`. 
 
-Adding custom HTTP routes is quite straightforward when using Bolt's built-in `ExpressReceiver`. Since `v2.1.0`, `ExpressReceiver` added a `router` property, which exposes the Express [Router](http://expressjs.com/en/4x/api.html#router) on which more routes can be added.
+Each `CustomRoute` object must contain three properties: `path`, `method`, and `handler`. `method`, which corresponds to the HTTP verb, can be either a string or an array of strings.
+</div>
 
+```javascript
+const { App } = require('@slack/bolt');
+
+// Create the Bolt App, using the receiver
+const app = new App({
+  token: process.env.SLACK_BOT_TOKEN,
+  signingSecret: process.env.SLACK_SIGNING_SECRET,
+  customRoutes: [
+    {
+      path: '/health-check',
+      method: ['GET'],
+      handler: (req, res) => {
+        res.writeHead(200);
+        res.end('Health check information displayed here!');
+      },
+    },
+  ],
+});
+
+(async () => {
+  await app.start();
+  console.log('⚡️ Bolt app started');
+})();
+```
+
+<details class="secondary-wrapper">
+<summary class="section-head" markdown="0">
+<h4 class="section-head">Custom ExpressReceiver routes</h4>
+</summary>
+
+<div class="secondary-content" markdown="0">
+Adding custom HTTP routes is quite straightforward when using Bolt’s built-in ExpressReceiver. Since `v2.1.0`, `ExpressReceiver` added a `router` property, which exposes the Express [Router](http://expressjs.com/en/4x/api.html#router) on which additional routes can be added.
 </div>
 
 ```javascript
@@ -36,7 +70,8 @@ receiver.router.post('/secret-page', (req, res) => {
 });
 
 (async () => {
-  await app.start(8080);
-  console.log('app is running');
+  await app.start();
+  console.log('⚡️ Bolt app started');
 })();
 ```
+</details>


### PR DESCRIPTION
###  Summary

Update Custom HTTP Routes section of documentation to include the newly introduced way to add custom routes. Move `ExpressReceiver` approach to its own (accordion) section.

![Screen Shot 2021-09-28 at 3 32 01 PM](https://user-images.githubusercontent.com/7788242/135174653-124f12b2-2e61-45c0-bb3d-fca9ff5cd81a.png)

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).