### PR TITLE
Fix #1141 state is missing in the block_action payload type

### DIFF
--- a/src/types/actions/block-action.ts
+++ b/src/types/actions/block-action.ts
@@ -1,6 +1,6 @@
 import { PlainTextElement, Confirmation, Option } from '@slack/types';
 import { StringIndexed } from '../helpers';
-import { ViewOutput } from '../view';
+import { ViewOutput, ViewStateValue } from '../view';
 
 /**
  * All known actions from in Slack's interactive elements
@@ -234,6 +234,13 @@ export interface BlockAction<ElementAction extends BasicElementAction = BlockEle
     [key: string]: any;
   };
   view?: ViewOutput;
+  state?: {
+    values: {
+      [blockId: string]: {
+        [actionId: string]: ViewStateValue;
+      };
+    };
+  };
   token: string;
   response_url: string;
   trigger_id: string;


### PR DESCRIPTION
###  Summary

This pull request fixes #1141. Refer to the issue for more details.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).