### PR TITLE
Feature: Type safe custom context properties in TypeScript

### DIFF
--- a/src/App.ts
+++ b/src/App.ts
@@ -175,7 +175,7 @@ class WebClientPool {
 /**
  * A Slack App
  */
-export default class App<CustomContext extends StringIndexed = {}> {
+export default class App<CustomContext extends StringIndexed = StringIndexed> {
   /** Slack Web API client */
   public client: WebClient;
 
@@ -609,7 +609,10 @@ export default class App<CustomContext extends StringIndexed = {}> {
     this.listeners.push([onlyActions, matchConstraints(constraints), ...listeners] as Middleware<AnyMiddlewareArgs>[]);
   }
 
-  public command(commandName: string | RegExp, ...listeners: Middleware<SlackCommandMiddlewareArgs, CustomContext>[]): void {
+  public command(
+    commandName: string | RegExp,
+    ...listeners: Middleware<SlackCommandMiddlewareArgs, CustomContext>[]
+  ): void {
     this.listeners.push([onlyCommands, matchCommandName(commandName), ...listeners] as Middleware<AnyMiddlewareArgs>[]);
   }
 

--- a/src/types/middleware.ts
+++ b/src/types/middleware.ts
@@ -24,10 +24,12 @@ export interface AllMiddlewareArgs {
   next: NextFn;
 }
 
+export type ExtendContext<T extends {} = {}> = { context: T };
+
 // NOTE: Args should extend AnyMiddlewareArgs, but because of contravariance for function types, including that as a
 // constraint would mess up the interface of App#event(), App#message(), etc.
-export interface Middleware<Args> {
-  (args: Args & AllMiddlewareArgs): Promise<void>;
+export interface Middleware<Args, CustomContext = {}> {
+  (args: Args & AllMiddlewareArgs & ExtendContext<CustomContext>): Promise<void>;
 }
 
 /**

--- a/src/types/middleware.ts
+++ b/src/types/middleware.ts
@@ -24,11 +24,11 @@ export interface AllMiddlewareArgs {
   next: NextFn;
 }
 
-export type ExtendContext<T extends {} = {}> = { context: T };
+export interface ExtendContext<T extends StringIndexed = StringIndexed> { context: T };
 
 // NOTE: Args should extend AnyMiddlewareArgs, but because of contravariance for function types, including that as a
 // constraint would mess up the interface of App#event(), App#message(), etc.
-export interface Middleware<Args, CustomContext = {}> {
+export interface Middleware<Args, CustomContext = StringIndexed> {
   (args: Args & AllMiddlewareArgs & ExtendContext<CustomContext>): Promise<void>;
 }
 

--- a/src/types/middleware.ts
+++ b/src/types/middleware.ts
@@ -17,19 +17,17 @@ export type AnyMiddlewareArgs =
   | SlackViewMiddlewareArgs
   | SlackShortcutMiddlewareArgs;
 
-export interface AllMiddlewareArgs {
-  context: Context;
+export interface AllMiddlewareArgs<CustomContext = StringIndexed> {
+  context: Context & CustomContext;
   logger: Logger;
   client: WebClient;
   next: NextFn;
 }
 
-export interface ExtendContext<T extends StringIndexed = StringIndexed> { context: T }
-
 // NOTE: Args should extend AnyMiddlewareArgs, but because of contravariance for function types, including that as a
 // constraint would mess up the interface of App#event(), App#message(), etc.
 export interface Middleware<Args, CustomContext = StringIndexed> {
-  (args: Args & AllMiddlewareArgs & ExtendContext<CustomContext>): Promise<void>;
+  (args: Args & AllMiddlewareArgs<CustomContext>): Promise<void>;
 }
 
 /**

--- a/src/types/middleware.ts
+++ b/src/types/middleware.ts
@@ -24,7 +24,7 @@ export interface AllMiddlewareArgs {
   next: NextFn;
 }
 
-export interface ExtendContext<T extends StringIndexed = StringIndexed> { context: T };
+export interface ExtendContext<T extends StringIndexed = StringIndexed> { context: T }
 
 // NOTE: Args should extend AnyMiddlewareArgs, but because of contravariance for function types, including that as a
 // constraint would mess up the interface of App#event(), App#message(), etc.


### PR DESCRIPTION
###  Summary

This pull request enables developers to maintain type safety when adding custom properties to the `context` middleware arg.

### Description

This is partially related to #897. That issue was closed with a pull request which added built-in context fields to the type definitions, however it did not address the issue of using custom context properties.

Right now Bolt does not offer any way to add TypeScript typings to the context object. Consider this example:

```ts
const app = new App();

app.use(async ({ context, next }) => {
  context.foo = { bar: 'baz' };
  await next();
})

app.command('/test', async ({ ack, respond, context }) => {
  await ack();
  await respond(context.foo.bar);
})
```
This code would work, but there is no way to record type information about `context.foo`. The only workaround is something like this:

```ts
const app = new App<MyContext>();

interface MyContext {
  foo: { bar: string };
}

app.use(async ({ context, next }) => {
  const myContext = context as MyContext;
  myContext.foo = { bar: 'baz' };
  await next();
})

app.command('/show-user-id', async ({ ack, respond, context }) => {
  const myContext = context as MyContext;
  await ack();
  await respond(`Your custom user id is ${myContext.foo.bar}`);
})
```
This does work but is very clunky, verbose and overall causes the developer experience to suffer. Casting like this should be reserved for rare, special cases, not for something as basic as middleware.

### Background

How do other frameworks handle this? Koa takes a type parameter `ContextT` which is then added to the build-in context type definition in middleware listeners:
```ts
interface MyContext {
  foo: { bar: string }
}

const app = new Koa<any, MyContext>();

app.use(async (ctx) => {
  ctx.foo = { bar: 'baz' };
})
```

### Solution

My implementation is similar to Koa and works like this:

```ts
interface MyContext {
  foo: { bar: string };
}

const app = new App<MyContext>();

app.use(async ({ context, next }) => {
  context.foo = { bar: 'baz' };
  await next();
})

app.command('/show-user-id', async ({ ack, respond, context }) => {
  await ack();
  await respond(`Your custom user id is ${context.foo.bar}`);
})
```

This could be accomplished in a number of ways, I decided that the following is the cleanest option:

1. The `AllMiddlewareArgs` interface is the "root" of middleware args, so I added a `CustomContext` type parameter to it, constrained and defaulting to `StringIndexed`, and modified its type definition to define the `context` property as `Context & CustomContext`

```ts
export interface AllMiddlewareArgs<CustomContext = StringIndexed> {
  context: Context & CustomContext;
  logger: Logger;
  client: WebClient;
  next: NextFn;
}
```

2. The link between listener args and `AllMiddlewareArgs` is the `Middleware` interface, so I added a `CustomContext` type parameter to it as well, constrained and defaulting to `StringIndexed`, ​and modified its type definition to pass that type argument to  `AllMiddlewareArgs`.

```ts
export interface Middleware<Args, CustomContext = StringIndexed> {
  (args: Args & AllMiddlewareArgs<CustomContext>): Promise<void>;
}
```

3. Finally, I added a `CustomContext` type parameter to the `App` class, constrained and defaulting to `StringIndexed`, and modified its methods' type definitions to pass that type parameter to `Middleware`

```ts
export default class App<CustomContext extends StringIndexed = StringIndexed> {
  // ...
  public command(
    commandName: string | RegExp,
    ...listeners: Middleware<SlackCommandMiddlewareArgs, CustomContext>[]
  ): void {
    this.listeners.push([onlyCommands, matchCommandName(commandName), ...listeners] as Middleware<AnyMiddlewareArgs>[]);
  }
  // ...
}
```

Because all added type parameters default to `StringIndexed` and `Context` already extends `StringIndexed` they can still be used in other parts of the codebase without a type parameter or any changed to the typings. Other parts of the codebase don't need information about custom context properties because those are by definition added by the end developer and hence not needed in internal framework logic.

These changes do not modify any typings outside of this rather narrow scope, do not introduce any changes to the logic of the framework, and should work with any existing codebase.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).