### PR TITLE
Bump axios version to 0.21.2 or higher for better security

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@types/node": ">=12",
     "@types/promise.allsettled": "^1.0.3",
     "@types/tsscmp": "^1.0.0",
-    "axios": "^0.21.1",
+    "axios": "^0.21.2",
     "express": "^4.16.4",
     "please-upgrade-node": "^3.2.0",
     "promise.allsettled": "^1.0.2",


### PR DESCRIPTION
Hi team,

NPM audit is throwing a high severity vulnerability in node-slack-sdk and with bolt-js dependency packages.

I hope it helps.