### PR TITLE
Fix #1181 Add port property to installerOptions in the HTTPReceiver

### DIFF
--- a/src/App.spec.ts
+++ b/src/App.spec.ts
@@ -51,6 +51,82 @@ function createDummyReceiverEvent(type: string = 'dummy_event_type'): ReceiverEv
 
 describe('App', () => {
   describe('constructor', () => {
+    describe('with a custom port value in HTTP Mode', () => {
+      const fakeBotId = 'B_FAKE_BOT_ID';
+      const fakeBotUserId = 'U_FAKE_BOT_USER_ID';
+      const overrides = mergeOverrides(
+        withNoopAppMetadata(),
+        withSuccessfulBotUserFetchingWebClient(fakeBotId, fakeBotUserId),
+      );
+      it('should accept a port value at the top-level', async () => {
+        // Arrange
+        const MockApp = await importApp(overrides);
+        // Act
+        const app = new MockApp({ token: '', signingSecret: '', port: 9999 });
+        // Assert
+        assert.equal((app as any).receiver.port, 9999);
+      });
+      it('should accept a port value under installerOptions', async () => {
+        // Arrange
+        const MockApp = await importApp(overrides);
+        // Act
+        const app = new MockApp({ token: '', signingSecret: '', port: 7777, installerOptions: { port: 9999 } });
+        // Assert
+        assert.equal((app as any).receiver.port, 9999);
+      });
+    });
+
+    describe('with a custom port value in Socket Mode', () => {
+      const fakeBotId = 'B_FAKE_BOT_ID';
+      const fakeBotUserId = 'U_FAKE_BOT_USER_ID';
+      const installationStore = {
+        storeInstallation: async () => { },
+        fetchInstallation: async () => { throw new Error('Failed fetching installation'); },
+        deleteInstallation: async () => { },
+      };
+      const overrides = mergeOverrides(
+        withNoopAppMetadata(),
+        withSuccessfulBotUserFetchingWebClient(fakeBotId, fakeBotUserId),
+      );
+      it('should accept a port value at the top-level', async () => {
+        // Arrange
+        const MockApp = await importApp(overrides);
+        // Act
+        const app = new MockApp({
+          socketMode: true,
+          appToken: '',
+          port: 9999,
+          clientId: '',
+          clientSecret: '',
+          stateSecret: '',
+          installerOptions: {
+          },
+          installationStore,
+        });
+        // Assert
+        assert.equal((app as any).receiver.httpServerPort, 9999);
+      });
+      it('should accept a port value under installerOptions', async () => {
+        // Arrange
+        const MockApp = await importApp(overrides);
+        // Act
+        const app = new MockApp({
+          socketMode: true,
+          appToken: '',
+          port: 7777,
+          clientId: '',
+          clientSecret: '',
+          stateSecret: '',
+          installerOptions: {
+            port: 9999,
+          },
+          installationStore,
+        });
+        // Assert
+        assert.equal((app as any).receiver.httpServerPort, 9999);
+      });
+    });
+
     // TODO: test when the single team authorization results fail. that should still succeed but warn. it also means
     // that the `ignoreSelf` middleware will fail (or maybe just warn) a bunch.
     describe('with successful single team authorization results', () => {

--- a/src/App.ts
+++ b/src/App.ts
@@ -78,6 +78,7 @@ const tokenUsage = 'Apps used in one workspace should be initialized with a toke
 export interface AppOptions {
   signingSecret?: HTTPReceiverOptions['signingSecret'];
   endpoints?: HTTPReceiverOptions['endpoints'];
+  port?: HTTPReceiverOptions['port'];
   customRoutes?: HTTPReceiverOptions['customRoutes'];
   processBeforeResponse?: HTTPReceiverOptions['processBeforeResponse'];
   signatureVerification?: HTTPReceiverOptions['signatureVerification'];
@@ -240,6 +241,7 @@ export default class App {
   public constructor({
     signingSecret = undefined,
     endpoints = undefined,
+    port = undefined,
     customRoutes = undefined,
     agent = undefined,
     clientTls = undefined,
@@ -337,6 +339,11 @@ export default class App {
       clientOptions: this.clientOptions,
       ...installerOptions,
     };
+    if (socketMode && port !== undefined && this.installerOptions.port === undefined) {
+      // As SocketModeReceiver uses a custom port number to listen on only for the OAuth flow,
+      // only installerOptions.port is available in the constructor arguments.
+      this.installerOptions.port = port;
+    }
 
     if (
       this.developerMode &&
@@ -394,6 +401,7 @@ export default class App {
       this.receiver = new HTTPReceiver({
         signingSecret: signingSecret || '',
         endpoints,
+        port,
         customRoutes,
         processBeforeResponse,
         signatureVerification,

--- a/src/receivers/HTTPReceiver.spec.ts
+++ b/src/receivers/HTTPReceiver.spec.ts
@@ -119,6 +119,38 @@ describe('HTTPReceiver', function () {
       assert.isNotNull(receiver);
     });
 
+    it('should accept a custom port', async function () {
+      // Arrange
+      const overrides = mergeOverrides(
+        withHttpCreateServer(this.fakeCreateServer),
+        withHttpsCreateServer(sinon.fake.throws('Should not be used.')),
+      );
+      const HTTPReceiver = await importHTTPReceiver(overrides);
+
+      const defaultPort = new HTTPReceiver({
+        signingSecret: 'secret',
+      });
+      assert.isNotNull(defaultPort);
+      assert.equal((defaultPort as any).port, 3000);
+
+      const customPort = new HTTPReceiver({
+        port: 9999,
+        signingSecret: 'secret',
+      });
+      assert.isNotNull(customPort);
+      assert.equal((customPort as any).port, 9999);
+
+      const customPort2 = new HTTPReceiver({
+        port: 7777,
+        signingSecret: 'secret',
+        installerOptions: {
+          port: 9999,
+        },
+      });
+      assert.isNotNull(customPort2);
+      assert.equal((customPort2 as any).port, 9999);
+    });
+
     it('should throw an error if redirect uri options supplied invalid or incomplete', async function () {
       const HTTPReceiver = await importHTTPReceiver();
       const clientId = 'my-clientId';

--- a/src/receivers/SocketModeReceiver.spec.ts
+++ b/src/receivers/SocketModeReceiver.spec.ts
@@ -93,7 +93,8 @@ describe('SocketModeReceiver', function () {
         },
       });
       assert.isNotNull(receiver);
-      assert.isOk(this.fakeServer.listen.calledWith(3000));
+      // since v3.8, the constructor does not start the server
+      // assert.isNotOk(this.fakeServer.listen.calledWith(3000));
     });
     it('should allow for customizing port the socket listens on', async function () {
       // Arrange
@@ -118,7 +119,8 @@ describe('SocketModeReceiver', function () {
         },
       });
       assert.isNotNull(receiver);
-      assert.isOk(this.fakeServer.listen.calledWith(customPort));
+      // since v3.8, the constructor does not start the server
+      // assert.isOk(this.fakeServer.listen.calledWith(customPort));
     });
     it('should allow for extracting additional values from Socket Mode messages', async function () {
       // Arrange


### PR DESCRIPTION
###  Summary

This pull request resolves #1181 by adding custom port option in the App/HTTPReceiver constructors. Also, while working on this, the SocketModeReceiver starts its underlying HTTP server for the OAuth flow (before `start()` method call). As I believe that the timing to start the HTTP server should be consistent with other receivers, I've changed the behavior too.

Fixes #1181 
Fixes #1179 

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).