### PR TITLE
Add the steps for safety in the release procedure

### DIFF
--- a/.github/maintainers_guide.md
+++ b/.github/maintainers_guide.md
@@ -65,6 +65,8 @@ Releasing can feel intimidating at first, but rest assured: if you make a mistak
     -  Push the new tag up to origin: `git push --tags origin`
 5. Distribute the release
     - To publish, you need to be a member of the `slack Org` on npm and set up 2-Factor Auth with your passsword generator of choice. Before you can publish with npm, you must run `npm login` from the command line.
+    - Before publishing a new version, run `rm -rf node_modules/ dist/` to clean your module dependencies in the project first (usually this is not required but in some cases, `npm publish` cannot include all the required files in a package) 
+    - Just in case, run `npm i && npm test && npm pack` and check if the list of the files that will be included in the package are correct
     - Run `npm publish . --otp YOUR_OTP_CODE`. To generate an OTP (One Time Password), use your password generator of choice (Duo, 1Password)
 6. Close Github Milestone
     - Close the relevant GitHub Milestone(s) for the release(s)

--- a/.github/maintainers_guide.md
+++ b/.github/maintainers_guide.md
@@ -66,7 +66,7 @@ Releasing can feel intimidating at first, but rest assured: if you make a mistak
 5. Distribute the release
     - To publish, you need to be a member of the `slack Org` on npm and set up 2-Factor Auth with your passsword generator of choice. Before you can publish with npm, you must run `npm login` from the command line.
     - Before publishing a new version, run `rm -rf node_modules/ dist/` to clean your module dependencies in the project first (usually this is not required but in some cases, `npm publish` cannot include all the required files in a package) 
-    - Just in case, run `npm i && npm test && npm pack` and check if the list of the files that will be included in the package are correct
+    - Just in case, run `npm i && npm test && npm pack` and check if the list of the files that will be included in the package contain, at a minimum: `package.json`, `README.md`, `LICENSE`, `CHANGELOG.md`, `dist/index.js`, `dist/App.js`
     - Run `npm publish . --otp YOUR_OTP_CODE`. To generate an OTP (One Time Password), use your password generator of choice (Duo, 1Password)
 6. Close Github Milestone
     - Close the relevant GitHub Milestone(s) for the release(s)

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 
 # build products
 /dist
+*.tgz
 
 # coverage
 /.nyc_output


### PR DESCRIPTION
###  Summary

This is related to https://github.com/slackapi/bolt-js/issues/1194 

As you may notice, version 3.8.0 did not go well. The published package file included only `package.json` and a few text files.

```
npm notice === Tarball Contents ===
npm notice 1.1kB LICENSE
npm notice 2.7kB dist/package.json
npm notice 2.4kB package.json
npm notice 258B  CHANGELOG.md
npm notice 8.3kB README.md
npm notice === Tarball Details ===
```

To deal with the situation, I went with the following actions:

* I've made sure if the situation can arise not only on RunKit but with my simple example app
* I've marked v3.8.0 as deprecated in npm package registry
* I ran `npm pack` in the local machine and found that the generated file is still invalid
* I checked the changes in `package.json` and build-related files since v3.7.0 but there are no related changes
* I saw the issue disappeared when I ran `npm pack` after deleting `dist` and `node_modules` directories
* I ran `npm publish` with a new patch version (3.8.1)
* I've installed `@slack/bolt@3.8.1` in an example app project and confirmed that the issue no longer exists

I am not yet 100% confident about the direct reason of this situation. That being said, I'm guessing that utilizing `npm link` for local development might affect the build process. If this is true, that explains why deleting directories helped.

Not to repeat this error in the future, I propose to add a few steps before `npm publish` command. Ideally, we may want to do releases from the CI runtime (at least, somewhere without any person's local environment). But, for now, we can make the current operation safer.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).