### PR TITLE
Ignore query params when using customRoutes with SocketModeReceiver

### DIFF
--- a/src/receivers/HTTPReceiver.spec.ts
+++ b/src/receivers/HTTPReceiver.spec.ts
@@ -264,7 +264,6 @@ describe('HTTPReceiver', function () {
         receiver.installer = installProviderStub as unknown as InstallProvider;
         const fakeReq: IncomingMessage = sinon.createStubInstance(IncomingMessage) as IncomingMessage;
         fakeReq.url = '/hiya';
-        fakeReq.headers = { host: 'localhost' };
         fakeReq.method = 'GET';
         const fakeRes: ServerResponse = sinon.createStubInstance(ServerResponse) as unknown as ServerResponse;
         const writeHead = sinon.fake();
@@ -307,7 +306,6 @@ describe('HTTPReceiver', function () {
         receiver.installer = installProviderStub as unknown as InstallProvider;
         const fakeReq: IncomingMessage = sinon.createStubInstance(IncomingMessage) as IncomingMessage;
         fakeReq.url = '/hiya';
-        fakeReq.headers = { host: 'localhost' };
         fakeReq.method = 'GET';
         const fakeRes: ServerResponse = sinon.createStubInstance(ServerResponse) as unknown as ServerResponse;
         const writeHead = sinon.fake();
@@ -352,7 +350,6 @@ describe('HTTPReceiver', function () {
         receiver.installer = installProviderStub as unknown as InstallProvider;
         const fakeReq: IncomingMessage = sinon.createStubInstance(IncomingMessage) as IncomingMessage;
         fakeReq.url = '/hiya';
-        fakeReq.headers = { host: 'localhost' };
         fakeReq.method = 'GET';
         const fakeRes: ServerResponse = sinon.createStubInstance(ServerResponse) as unknown as ServerResponse;
         const writeHead = sinon.fake();
@@ -401,7 +398,6 @@ describe('HTTPReceiver', function () {
         receiver.installer = installProviderStub as unknown as InstallProvider;
         const fakeReq: IncomingMessage = sinon.createStubInstance(IncomingMessage) as IncomingMessage;
         fakeReq.url = '/heyo';
-        fakeReq.headers = { host: 'localhost' };
         fakeReq.method = 'GET';
         const fakeRes: ServerResponse = sinon.createStubInstance(ServerResponse) as unknown as ServerResponse;
         const writeHead = sinon.fake();
@@ -456,7 +452,6 @@ describe('HTTPReceiver', function () {
         receiver.installer = installProviderStub as unknown as InstallProvider;
         const fakeReq: IncomingMessage = sinon.createStubInstance(IncomingMessage) as IncomingMessage;
         fakeReq.url = '/heyo';
-        fakeReq.headers = { host: 'localhost' };
         fakeReq.method = 'GET';
         const fakeRes: ServerResponse = sinon.createStubInstance(ServerResponse) as unknown as ServerResponse;
         fakeRes.writeHead = sinon.fake();
@@ -481,7 +476,32 @@ describe('HTTPReceiver', function () {
         const fakeRes: ServerResponse = sinon.createStubInstance(ServerResponse) as unknown as ServerResponse;
 
         fakeReq.url = '/test';
-        fakeReq.headers = { host: 'localhost' };
+
+        fakeReq.method = 'GET';
+        receiver.requestListener(fakeReq, fakeRes);
+        assert(customRoutes[0].handler.calledWith(fakeReq, fakeRes));
+
+        fakeReq.method = 'POST';
+        receiver.requestListener(fakeReq, fakeRes);
+        assert(customRoutes[0].handler.calledWith(fakeReq, fakeRes));
+
+        fakeReq.method = 'UNHANDLED_METHOD';
+        assert.throws(() => receiver.requestListener(fakeReq, fakeRes), HTTPReceiverDeferredRequestError);
+      });
+
+      it('should call custom route handler only if request matches route path and method, ignoring query params', async function () {
+        const HTTPReceiver = await importHTTPReceiver();
+        const customRoutes = [{ path: '/test', method: ['get', 'POST'], handler: sinon.fake() }];
+        const receiver = new HTTPReceiver({
+          clientSecret: 'my-client-secret',
+          signingSecret: 'secret',
+          customRoutes,
+        });
+
+        const fakeReq: IncomingMessage = sinon.createStubInstance(IncomingMessage) as IncomingMessage;
+        const fakeRes: ServerResponse = sinon.createStubInstance(ServerResponse) as unknown as ServerResponse;
+
+        fakeReq.url = '/test?hello=world';
 
         fakeReq.method = 'GET';
         receiver.requestListener(fakeReq, fakeRes);
@@ -544,7 +564,6 @@ describe('HTTPReceiver', function () {
 
       const fakeReq: IncomingMessage = sinon.createStubInstance(IncomingMessage) as IncomingMessage;
       fakeReq.url = '/nope';
-      fakeReq.headers = { host: 'localhost' };
       fakeReq.method = 'GET';
 
       const fakeRes: ServerResponse = sinon.createStubInstance(ServerResponse) as unknown as ServerResponse;
@@ -559,7 +578,6 @@ describe('HTTPReceiver', function () {
     it('should have defaultDispatchErrorHandler', async function () {
       const fakeReq: IncomingMessage = sinon.createStubInstance(IncomingMessage) as IncomingMessage;
       fakeReq.url = '/nope';
-      fakeReq.headers = { host: 'localhost' };
       fakeReq.method = 'GET';
 
       const fakeRes: ServerResponse = sinon.createStubInstance(ServerResponse) as unknown as ServerResponse;
@@ -577,7 +595,6 @@ describe('HTTPReceiver', function () {
     it('should have defaultProcessEventErrorHandler', async function () {
       const fakeReq: IncomingMessage = sinon.createStubInstance(IncomingMessage) as IncomingMessage;
       fakeReq.url = '/nope';
-      fakeReq.headers = { host: 'localhost' };
       fakeReq.method = 'GET';
 
       const fakeRes: ServerResponse = sinon.createStubInstance(ServerResponse) as unknown as ServerResponse;
@@ -597,7 +614,6 @@ describe('HTTPReceiver', function () {
     it('should have defaultUnhandledRequestHandler', async function () {
       const fakeReq: IncomingMessage = sinon.createStubInstance(IncomingMessage) as IncomingMessage;
       fakeReq.url = '/nope';
-      fakeReq.headers = { host: 'localhost' };
       fakeReq.method = 'GET';
 
       const fakeRes: ServerResponse = sinon.createStubInstance(ServerResponse) as unknown as ServerResponse;

--- a/src/receivers/HTTPReceiver.ts
+++ b/src/receivers/HTTPReceiver.ts
@@ -431,9 +431,9 @@ export default class HTTPReceiver implements Receiver {
   private unboundRequestListener(req: IncomingMessage, res: ServerResponse) {
     // Route the request
 
-    // NOTE: the domain and scheme of the following URL object are not necessarily accurate. The URL object is only
-    // meant to be used to parse the path and query
-    const { pathname: path } = new URL(req.url as string, `http://${req.headers.host}`);
+    // NOTE: the domain and scheme are irrelevant here.
+    // The URL object is only used to safely obtain the path to match
+    const { pathname: path } = new URL(req.url as string, 'http://localhost');
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const method = req.method!.toUpperCase();
 

--- a/src/receivers/SocketModeReceiver.ts
+++ b/src/receivers/SocketModeReceiver.ts
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
+import { URL } from 'url';
 import { SocketModeClient } from '@slack/socket-mode';
 import { createServer, IncomingMessage, ServerResponse, Server } from 'http';
 import { Logger, ConsoleLogger, LogLevel } from '@slack/logger';
@@ -185,13 +186,15 @@ export default class SocketModeReceiver implements Receiver {
           }
         }
 
-        // Handle request for custom routes, only match against the path
+        // Handle request for custom routes
         if (customRoutes.length && req.url) {
-          const [url] = req.url.split('?');
-          const match = this.routes[url] && this.routes[url][method] !== undefined;
+          // NOTE: the domain and scheme are irrelevant here.
+          // The URL object is only used to safely obtain the path to match
+          const { pathname: path } = new URL(req.url as string, 'http://localhost');
+          const match = this.routes[path] && this.routes[path][method] !== undefined;
 
           if (match) {
-            this.routes[url][method](req, res);
+            this.routes[path][method](req, res);
             return;
           }
         }

--- a/src/receivers/SocketModeReceiver.ts
+++ b/src/receivers/SocketModeReceiver.ts
@@ -185,12 +185,13 @@ export default class SocketModeReceiver implements Receiver {
           }
         }
 
-        // Handle request for custom routes
+        // Handle request for custom routes, only match against the path
         if (customRoutes.length && req.url) {
-          const match = this.routes[req.url] && this.routes[req.url][method] !== undefined;
+          const [url] = req.url.split('?');
+          const match = this.routes[url] && this.routes[url][method] !== undefined;
 
           if (match) {
-            this.routes[req.url][method](req, res);
+            this.routes[url][method](req, res);
             return;
           }
         }


### PR DESCRIPTION
###  Summary

https://github.com/slackapi/bolt-js/issues/1206

Allows for using query params in custom routes. Currently it will attempt to match the whole url including the query params.
With this change, it will skip the query params when matching.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).