### PR TITLE
Update git stale action

### DIFF
--- a/.github/workflows/triage-issues.yml
+++ b/.github/workflows/triage-issues.yml
@@ -25,9 +25,9 @@ jobs:
           days-before-pr-close: -1
           stale-issue-label: auto-triage-stale
           stale-issue-message: 👋 It looks like this issue has been open for 30 days with no activity. We'll mark this as stale for now, and wait 10 days for an update or for further comment before closing this issue out.
-          close-issue-message: As this issue has been inactive for more than one month, we will be closing it. Thanks again for writing in!
+          close-issue-message: As this issue has been inactive for more than one month, we will be closing it. Thank you to all the participants! If you would like to raise a related issue, please create a new issue which includes your specific details and references this issue number.
           exempt-issue-labels: auto-triage-skip
           exempt-all-milestones: true
           remove-stale-when-updated: true
           enable-statistics: true
-          debug-only: true # TODO: remove after test run
+          operations-per-run: 60


### PR DESCRIPTION
###  Summary

This PR removes the no-op flag on our newly added stale action - I will trigger this manually for the week (and it will run going forward Sunday PST). 
 
I've also added a few language tweaks after team feedback and increased the limit of # operations to 60 / job.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).