### PR TITLE
Cleanup Lambda example and docs around `proccessBeforeResponse`

### DIFF
--- a/docs/_deployments/aws-lambda.md
+++ b/docs/_deployments/aws-lambda.md
@@ -140,12 +140,7 @@ const awsLambdaReceiver = new AwsLambdaReceiver({
 // Initializes your app with your bot token and the AWS Lambda ready receiver
 const app = new App({
     token: process.env.SLACK_BOT_TOKEN,
-    receiver: awsLambdaReceiver,
-    // The `processBeforeResponse` option is required for all FaaS environments.
-    // It allows Bolt methods (e.g. `app.message`) to handle a Slack request
-    // before the Bolt framework responds to the request (e.g. `ack()`). This is
-    // important because FaaS immediately terminate handlers after the response.
-    processBeforeResponse: true
+    receiver: awsLambdaReceiver
 });
 ```
 

--- a/docs/_deployments/aws-lambda.md
+++ b/docs/_deployments/aws-lambda.md
@@ -140,7 +140,16 @@ const awsLambdaReceiver = new AwsLambdaReceiver({
 // Initializes your app with your bot token and the AWS Lambda ready receiver
 const app = new App({
     token: process.env.SLACK_BOT_TOKEN,
-    receiver: awsLambdaReceiver
+    receiver: awsLambdaReceiver,
+    
+    // When using the AwsLambdaReceiver, processBeforeResponse can be omitted.
+    // If you use other Receivers, such as ExpressReceiver for OAuth flow support
+    // then processBeforeResponse: true is required. This option will defer sending back
+    // the acknowledgement until after your handler has run to ensure your function
+    // isn't terminated early by responding to the HTTP request that triggered it.
+
+    // processBeforeResponse: true
+
 });
 ```
 

--- a/docs/_tutorials/reference.md
+++ b/docs/_tutorials/reference.md
@@ -98,7 +98,7 @@ Bolt includes a collection of initialization options to customize apps. There ar
 | `installerOptions` | Optional object that can be used to customize [the default OAuth support](/bolt-js/concepts#authenticating-oauth). Read more in the OAuth documentation. |
 
 ### App options
-App options are passed into the `App` constructor. When the `receiver` argument is `undefined` the `App` constructor also accepts the [above `Receiver` options](#receiver-options) to initialise either a `HttpReceiver` or a `SocketModeReceiver` depending on the value of the `socketMode` argument.
+App options are passed into the `App` constructor. When the `receiver` argument is `undefined` the `App` constructor also accepts the [above `Receiver` options](#receiver-options) to initialize either a `HttpReceiver` or a `SocketModeReceiver` depending on the value of the `socketMode` argument.
 
 | Option  | Description  |
 | :---: | :--- |

--- a/docs/_tutorials/reference.md
+++ b/docs/_tutorials/reference.md
@@ -98,7 +98,7 @@ Bolt includes a collection of initialization options to customize apps. There ar
 | `installerOptions` | Optional object that can be used to customize [the default OAuth support](/bolt-js/concepts#authenticating-oauth). Read more in the OAuth documentation. |
 
 ### App options
-App options are passed into the `App` constructor. The `App` constructor also accepts [`HttpReceiver`](#receiver-options) options and will use them to initialise a [Receiever](/bolt-js/concepts#receiver) when the `receiver` argument is `undefined` and are ignored otherwise.
+App options are passed into the `App` constructor. The `App` constructor also accepts [`HttpReceiver`](#receiver-options) options which will be used to initialise a [Receiever](/bolt-js/concepts#receiver) when the `receiver` argument is `undefined` and are ignored otherwise.
 
 | Option  | Description  |
 | :---: | :--- |

--- a/docs/_tutorials/reference.md
+++ b/docs/_tutorials/reference.md
@@ -89,7 +89,7 @@ Bolt includes a collection of initialization options to customize apps. There ar
 | :---: | :--- |
 | `signingSecret` | A `string` from your app's configuration (under "Basic Information") which verifies that incoming events are coming from Slack |
 | `endpoints` | A `string` or `object` that specifies the endpoint(s) that the receiver will listen for incoming requests from Slack. Currently, the only key for the object is `key`, the value of which is the customizable endpoint (ex: `/myapp/events`). **By default, all events are sent to the `/slack/events` endpoint** |
-| `processBeforeResponse` | `boolean` that determines whether events should be immediately acknowledged. This is primarily useful when running apps on FaaS to ensure events listeners don't unexpectedly terminate by setting it to `true`. Defaults to `false`.  |
+| `processBeforeResponse` | `boolean` that determines whether events should be immediately acknowledged. This is primarily useful when running apps on FaaS since listeners will terminate immediately once the request has completed. When set to `true` it will defer sending the acknowledgement until after your handlers run to prevent early termination. Defaults to `false`.  |
 | `clientId` | The client ID `string` from your app's configuration which is [required to configure OAuth](/bolt-js/concepts#authenticating-oauth). |
 | `clientSecret` | The client secret `string` from your app's configuration which is [required to configure OAuth](/bolt-js/concepts#authenticating-oauth). |
 | `stateSecret` | Recommended parameter (`string`) that's passed when [configuring OAuth](/bolt-js/concepts#authenticating-oauth) to prevent CSRF attacks |
@@ -98,7 +98,7 @@ Bolt includes a collection of initialization options to customize apps. There ar
 | `installerOptions` | Optional object that can be used to customize [the default OAuth support](/bolt-js/concepts#authenticating-oauth). Read more in the OAuth documentation. |
 
 ### App options
-App options are passed into the `App` constructor.
+App options are passed into the `App` constructor. The `App` constructor also accepts [`HttpReceiver`](#receiver-options) options and will use them to initialise a [Receiever](/bolt-js/concepts#receiver) when the `receiver` argument is `undefined` and are ignored otherwise.
 
 | Option  | Description  |
 | :---: | :--- |

--- a/docs/_tutorials/reference.md
+++ b/docs/_tutorials/reference.md
@@ -98,7 +98,7 @@ Bolt includes a collection of initialization options to customize apps. There ar
 | `installerOptions` | Optional object that can be used to customize [the default OAuth support](/bolt-js/concepts#authenticating-oauth). Read more in the OAuth documentation. |
 
 ### App options
-App options are passed into the `App` constructor. The `App` constructor also accepts [`HttpReceiver`](#receiver-options) options which will be used to initialise a [Receiever](/bolt-js/concepts#receiver) when the `receiver` argument is `undefined` and are ignored otherwise.
+App options are passed into the `App` constructor. When the `receiver` argument is `undefined` the `App` constructor also accepts the [above `Receiver` options](#receiver-options) to initialise either a `HttpReceiver` or a `SocketModeReceiver` depending on the value of the `socketMode` argument.
 
 | Option  | Description  |
 | :---: | :--- |

--- a/examples/deploy-aws-lambda/app.js
+++ b/examples/deploy-aws-lambda/app.js
@@ -9,11 +9,6 @@ const awsLambdaReceiver = new AwsLambdaReceiver({
 const app = new App({
   token: process.env.SLACK_BOT_TOKEN,
   receiver: awsLambdaReceiver,
-  // The `processBeforeResponse` option is required for all FaaS environments.
-  // It allows Bolt methods (e.g. `app.message`) to handle a Slack request
-  // before the Bolt framework responds to the request (e.g. `ack()`). This is
-  // important because FaaS immediately terminate handlers after the response.
-  processBeforeResponse: true
 });
 
 // Listens to incoming messages that contain "hello"
@@ -43,10 +38,9 @@ app.message('hello', async ({ message, say }) => {
 
 // Listens for an action from a button click
 app.action('button_click', async ({ body, ack, say }) => {
-  await say(`<@${body.user.id}> clicked the button`);
-
-  // Acknowledge the action after say() to exit the Lambda process
   await ack();
+  
+  await say(`<@${body.user.id}> clicked the button`);
 });
 
 // Listens to incoming messages that contain "goodbye"

--- a/examples/deploy-aws-lambda/app.js
+++ b/examples/deploy-aws-lambda/app.js
@@ -9,6 +9,14 @@ const awsLambdaReceiver = new AwsLambdaReceiver({
 const app = new App({
   token: process.env.SLACK_BOT_TOKEN,
   receiver: awsLambdaReceiver,
+
+  // When using the AwsLambdaReceiver, processBeforeResponse can be omitted.
+  // If you use other Receivers, such as ExpressReceiver for OAuth flow support
+  // then processBeforeResponse: true is required. This option will defer sending back
+  // the acknowledgement until after your handler has run to ensure your function
+  // isn't terminated early by responding to the HTTP request that triggered it.
+
+  // processBeforeResponse: true
 });
 
 // Listens to incoming messages that contain "hello"


### PR DESCRIPTION
###  Summary

The information supplied around `processBeforeResponse` was rather confusing and contradictory.

* The lambda example passes `processBeforeResponse` to the App constructor, but the AwsLambdaReciever class implements the correct behaviour & the argument isn't used in the constructor unless there isn't a receiver passed. Therefore I removed the argument and comment.
* The example listener calls `ack` at the end to respond to the request, but this contradicts other documentation that says to call it as early as possible, and the receiver will defer it until afterwards anyway. So I've moved `ack` to the top, otherwise I would've reworded the comment above it.
* I've reworded the reference documentation around `processBeforeResponse` to explain the behaviour more explicitly
* Because it's a reference document and people will jump directly to the section they're interested in, I've added some information about `HttpReceiver` arguments being passed to the `App` constructor under the `App options` header and explained how those arguments are used.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).