### PR TITLE
Fix #1237 Updates to message subtypes doc

### DIFF
--- a/docs/_basic/ja_listening_events.md
+++ b/docs/_basic/ja_listening_events.md
@@ -37,7 +37,7 @@ app.event('team_join', async ({ event, client }) => {
 <div class="secondary-content" markdown="0">
 `message()` リスナーは `event('message')` と等価の機能を提供します。
 
-イベントのサブタイプをフィルタリングしたい場合、組み込みの `subtype()` ミドルウェアを使用できます。 `bot_message` や `message_changed` のような一般的なメッセージサブタイプの情報は、[メッセージイベントのドキュメント](https://api.slack.com/events/message#message_subtypes)を参照してください。
+イベントのサブタイプをフィルタリングしたい場合、組み込みの `subtype()` ミドルウェアを使用できます。 `message_changed` や `message_replied` のような一般的なメッセージサブタイプの情報は、[メッセージイベントのドキュメント](https://api.slack.com/events/message#message_subtypes)を参照してください。
 </div>
 
 ```javascript

--- a/docs/_basic/ja_listening_events.md
+++ b/docs/_basic/ja_listening_events.md
@@ -37,13 +37,16 @@ app.event('team_join', async ({ event, client }) => {
 <div class="secondary-content" markdown="0">
 `message()` リスナーは `event('message')` と等価の機能を提供します。
 
-イベントのサブタイプをフィルタリングしたい場合、組み込みの `subtype()` ミドルウェアを使用できます。 `bot_message` や `message_replied` のような一般的なメッセージサブタイプの情報は、[メッセージイベントのドキュメント](https://api.slack.com/events/message#message_subtypes)を参照してください。
+イベントのサブタイプをフィルタリングしたい場合、組み込みの `subtype()` ミドルウェアを使用できます。 `bot_message` や `message_changed` のような一般的なメッセージサブタイプの情報は、[メッセージイベントのドキュメント](https://api.slack.com/events/message#message_subtypes)を参照してください。
 </div>
 
 ```javascript
-// bot からのメッセージ全てと一致
-app.message(subtype('bot_message'), ({ message }) => {
-  console.log(`The bot user ${message.user} said ${message.text}`);
+// パッケージから subtype をインポート
+const { App, subtype } = require('@slack/bolt');
+
+// user からのメッセージの編集と一致
+app.message(subtype('message_changed'), ({ event }) => {
+    console.log(`The user ${event.message.user} changed their message from ${event.previous_message.text} to ${event.message.text}`);
 });
 ```
 

--- a/docs/_basic/ja_listening_events.md
+++ b/docs/_basic/ja_listening_events.md
@@ -46,7 +46,7 @@ const { App, subtype } = require('@slack/bolt');
 
 // user からのメッセージの編集と一致
 app.message(subtype('message_changed'), ({ event }) => {
-    console.log(`The user ${event.message.user} changed their message from ${event.previous_message.text} to ${event.message.text}`);
+  console.log(`The user ${event.message.user} changed their message from ${event.previous_message.text} to ${event.message.text}`);
 });
 ```
 

--- a/docs/_basic/listening_events.md
+++ b/docs/_basic/listening_events.md
@@ -38,13 +38,16 @@ app.event('team_join', async ({ event, client }) => {
 <div class="secondary-content" markdown="0">
 A `message()` listener is equivalent to `event('message')`
 
-You can filter on subtypes of events by using the built-in `subtype()` middleware. Common message subtypes like `bot_message` and `message_replied` can be found [on the message event page](https://api.slack.com/events/message#message_subtypes).
+You can filter on subtypes of events by using the built-in `subtype()` middleware. Common message subtypes like `bot_message` and `message_changed` can be found [on the message event page](https://api.slack.com/events/message#message_subtypes).
 </div>
 
 ```javascript
-// Matches all messages from bot users
-app.message(subtype('bot_message'), ({ message }) => {
-  console.log(`The bot user ${message.user} said ${message.text}`);
+// Import subtype from the package
+const { App, subtype } = require('@slack/bolt');
+
+// Matches all message changes from users
+app.message(subtype('message_changed'), ({ event }) => {
+    console.log(`The user ${event.message.user} changed their message from ${event.previous_message.text} to ${event.message.text}`);
 });
 ```
 

--- a/docs/_basic/listening_events.md
+++ b/docs/_basic/listening_events.md
@@ -47,7 +47,7 @@ const { App, subtype } = require('@slack/bolt');
 
 // Matches all message changes from users
 app.message(subtype('message_changed'), ({ event }) => {
-    console.log(`The user ${event.message.user} changed their message from ${event.previous_message.text} to ${event.message.text}`);
+  console.log(`The user ${event.message.user} changed their message from ${event.previous_message.text} to ${event.message.text}`);
 });
 ```
 

--- a/docs/_basic/listening_events.md
+++ b/docs/_basic/listening_events.md
@@ -38,7 +38,7 @@ app.event('team_join', async ({ event, client }) => {
 <div class="secondary-content" markdown="0">
 A `message()` listener is equivalent to `event('message')`
 
-You can filter on subtypes of events by using the built-in `subtype()` middleware. Common message subtypes like `bot_message` and `message_changed` can be found [on the message event page](https://api.slack.com/events/message#message_subtypes).
+You can filter on subtypes of events by using the built-in `subtype()` middleware. Common message subtypes like `message_changed` and `message_replied` can be found [on the message event page](https://api.slack.com/events/message#message_subtypes).
 </div>
 
 ```javascript


### PR DESCRIPTION
###  Summary

Fixes #1237 for both EN and JP docs.  Changes message subtype from `bot_message` to `message_changed` and makes it explicit to import `subtype` from the Bolt package.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).