### PR TITLE
Fixes #1241 Replacing instances of console with logger

### DIFF
--- a/docs/_advanced/context.md
+++ b/docs/_advanced/context.md
@@ -25,7 +25,7 @@ async function addTimezoneContext({ payload, client, context, next }) {
   await next();
 }
 
-app.command('/request', addTimezoneContext, async ({ command, ack, client, context }) => {
+app.command('/request', addTimezoneContext, async ({ command, ack, client, context, logger }) => {
   // Acknowledge command request
   await ack();
   // Get local hour of request
@@ -50,7 +50,7 @@ app.command('/request', addTimezoneContext, async ({ command, ack, client, conte
       });
     }
     catch (error) {
-      console.error(error);
+      logger.error(error);
     }
   } else {
     try {
@@ -61,7 +61,7 @@ app.command('/request', addTimezoneContext, async ({ command, ack, client, conte
       });
     }
     catch (error) {
-      console.error(error);
+      logger.error(error);
     }
   }
 });

--- a/docs/_advanced/ja_context.md
+++ b/docs/_advanced/ja_context.md
@@ -25,7 +25,7 @@ async function addTimezoneContext({ payload, client, context, next }) {
   await next();
 }
 
-app.command('/request', addTimezoneContext, async ({ command, ack, client, context }) => {
+app.command('/request', addTimezoneContext, async ({ command, ack, client, context, logger }) => {
   // コマンドリクエストの確認
   await ack();
   // リクエスト時のローカル時間を取得
@@ -50,7 +50,7 @@ app.command('/request', addTimezoneContext, async ({ command, ack, client, conte
       });
     }
     catch (error) {
-      console.error(error);
+      logger.error(error);
     }
   } else {
     try {
@@ -61,7 +61,7 @@ app.command('/request', addTimezoneContext, async ({ command, ack, client, conte
       });
     }
     catch (error) {
-      console.error(error);
+      logger.error(error);
     }
   }
 });

--- a/docs/_advanced/ja_middleware_listener.md
+++ b/docs/_advanced/ja_middleware_listener.md
@@ -26,7 +26,7 @@ async function noBotMessages({ message, next }) {
 }
 
 // ボットではなく人間からのメッセージのみを受信するリスナー
-app.message(noBotMessages, async ({ message }) => console.log(
+app.message(noBotMessages, async ({ message, logger }) => logger.info(
   `(MSG) User: ${message.user}
    Message: ${message.text}`
 ));

--- a/docs/_advanced/middleware_listener.md
+++ b/docs/_advanced/middleware_listener.md
@@ -26,7 +26,7 @@ async function noBotMessages({ message, next }) {
 }
 
 // The listener only receives messages from humans
-app.message(noBotMessages, async ({ message }) => console.log(
+app.message(noBotMessages, async ({ message, logger }) => logger.info(
   `(MSG) User: ${message.user}
    Message: ${message.text}`
 ));

--- a/docs/_basic/ja_listening_actions.md
+++ b/docs/_basic/ja_listening_actions.md
@@ -35,7 +35,7 @@ app.action('approve_button', async ({ ack }) => {
 ```javascript
 // action_id が 'select_user' と一致し、block_id が 'assign_ticket' と一致する場合のみミドルウェアが呼び出される
 app.action({ action_id: 'select_user', block_id: 'assign_ticket' },
-  async ({ body, client, ack }) => {
+  async ({ body, client, ack, logger }) => {
     await ack();
     try {
       if (body.message) {
@@ -45,11 +45,11 @@ app.action({ action_id: 'select_user', block_id: 'assign_ticket' },
           channel: body.channel.id
         });
 
-        console.log(result);
+        logger.info(result);
       }
     }
     catch (error) {
-      console.error(error);
+      logger.error(error);
     }
   });
 ```

--- a/docs/_basic/ja_listening_events.md
+++ b/docs/_basic/ja_listening_events.md
@@ -19,7 +19,7 @@ app.event('team_join', async ({ event, client, logger }) => {
   try {
     const result = await client.chat.postMessage({
       channel: welcomeChannelId,
-      text: `Welcome to the team, <@${event.user}>! 🎉 You can introduce yourself in this channel.`
+      text: `Welcome to the team, <@${event.user.id}>! 🎉 You can introduce yourself in this channel.`
     });
     logger.info(result);
   }

--- a/docs/_basic/ja_listening_events.md
+++ b/docs/_basic/ja_listening_events.md
@@ -15,16 +15,16 @@ order: 3
 const welcomeChannelId = 'C12345';
 
 // 新しいユーザーがワークスペースに加入したタイミングで、指定のチャンネルにメッセージを送信して自己紹介を促す
-app.event('team_join', async ({ event, client }) => {
+app.event('team_join', async ({ event, client, logger }) => {
   try {
     const result = await client.chat.postMessage({
       channel: welcomeChannelId,
-      text: `Welcome to the team, <@${event.user.id}>! 🎉 You can introduce yourself in this channel.`
+      text: `Welcome to the team, <@${event.user}>! 🎉 You can introduce yourself in this channel.`
     });
-    console.log(result);
+    logger.info(result);
   }
   catch (error) {
-    console.error(error);
+    logger.error(error);
   }
 });
 ```
@@ -42,8 +42,8 @@ app.event('team_join', async ({ event, client }) => {
 
 ```javascript
 // bot からのメッセージ全てと一致
-app.message(subtype('bot_message'), ({ message }) => {
-  console.log(`The bot user ${message.user} said ${message.text}`);
+app.message(subtype('bot_message'), ({ message, logger }) => {
+  logger.info(`The bot user ${message.user} said ${message.text}`);
 });
 ```
 

--- a/docs/_basic/ja_listening_modals.md
+++ b/docs/_basic/ja_listening_modals.md
@@ -34,7 +34,7 @@ app.view('modal-callback-id', async ({ ack, body }) => {
 
 ```javascript
 // モーダルでのデータ送信リクエストを処理します
-app.view('view_b', async ({ ack, body, view, client }) => {
+app.view('view_b', async ({ ack, body, view, client, logger }) => {
   // モーダルでのデータ送信リクエストを確認
   await ack();
 
@@ -64,7 +64,7 @@ app.view('view_b', async ({ ack, body, view, client }) => {
     });
   }
   catch (error) {
-    console.error(error);
+    logger.error(error);
   }
 
 });

--- a/docs/_basic/ja_listening_responding_shortcuts.md
+++ b/docs/_basic/ja_listening_responding_shortcuts.md
@@ -22,7 +22,7 @@ order: 8
 
 ```javascript
 // open_modal というグローバルショートカットはシンプルなモーダルを開く
-app.shortcut('open_modal', async ({ shortcut, ack, context }) => {
+app.shortcut('open_modal', async ({ shortcut, ack, context, logger }) => {
   // グローバルショートカットリクエストの確認
   ack();
 
@@ -63,10 +63,10 @@ app.shortcut('open_modal', async ({ shortcut, ack, context }) => {
       }
     });
 
-    console.log(result);
+    logger.info(result);
   }
   catch (error) {
-    console.error(error);
+    logger.error(error);
   }
 });
 ```
@@ -83,7 +83,7 @@ app.shortcut('open_modal', async ({ shortcut, ack, context }) => {
 
   ```javascript
   // callback_id が 'open_modal' と一致し type が 'message_action' と一致する場合のみミドルウェアが呼び出される
-  app.shortcut({ callback_id: 'open_modal', type: 'message_action' }, async ({ shortcut, ack, context, client }) => {
+  app.shortcut({ callback_id: 'open_modal', type: 'message_action' }, async ({ shortcut, ack, context, client, logger }) => {
     try {
       // ショートカットリクエストの確認
       await ack();
@@ -124,10 +124,10 @@ app.shortcut('open_modal', async ({ shortcut, ack, context }) => {
         }
       });
 
-      console.log(result);
+      logger.info(result);
     }
     catch (error) {
-      console.error(error);
+      logger.error(error);
     }
   });
   ```

--- a/docs/_basic/ja_opening_modals.md
+++ b/docs/_basic/ja_opening_modals.md
@@ -16,7 +16,7 @@ order: 10
 
 ```javascript
 // コマンド起動をリッスン
-app.command('/ticket', async ({ ack, body, client }) => {
+app.command('/ticket', async ({ ack, body, client, logger }) => {
   // コマンドのリクエストを確認
   await ack();
 
@@ -69,10 +69,10 @@ app.command('/ticket', async ({ ack, body, client }) => {
         }
       }
     });
-    console.log(result);
+    logger.info(result);
   }
   catch (error) {
-    console.error(error);
+    logger.error(error);
   }
 });
 ```

--- a/docs/_basic/ja_publishing_views.md
+++ b/docs/_basic/ja_publishing_views.md
@@ -13,7 +13,7 @@ order: 13
 
 ```javascript
 // ユーザーが App Home にアクセスしたことを伝えるイベントをリッスン
-app.event('app_home_opened', async ({ event, client }) => {
+app.event('app_home_opened', async ({ event, client, logger }) => {
   try {
     // 組み込みの API クライアントを使って views.publish を呼び出す
     const result = await client.views.publish({
@@ -41,10 +41,10 @@ app.event('app_home_opened', async ({ event, client }) => {
       }
     });
 
-    console.log(result);
+    logger.info(result);
   }
   catch (error) {
-    console.error(error);
+    logger.error(error);
   }
 });
 ```

--- a/docs/_basic/ja_updating_pushing_modals.md
+++ b/docs/_basic/ja_updating_pushing_modals.md
@@ -20,7 +20,7 @@ order: 11
 ```javascript
 // action_id: button_abc のボタンを押すイベントをリッスン
 // （そのボタンはモーダルの中にあるという想定）
-app.action('button_abc', async ({ ack, body, client }) => {
+app.action('button_abc', async ({ ack, body, client, logger }) => {
   // ボタンを押したイベントを確認
   await ack();
 
@@ -55,10 +55,10 @@ app.action('button_abc', async ({ ack, body, client }) => {
         ]
       }
     });
-    console.log(result);
+    logger.info(result);
   }
   catch (error) {
-    console.error(error);
+    logger.error(error);
   }
 });
 ```

--- a/docs/_basic/ja_web_api.md
+++ b/docs/_basic/ja_web_api.md
@@ -19,7 +19,7 @@ Bolt アプリケーションは、トップレベルに `app.client` も持っ�
 // September 30, 2019 11:59:59 PM を Unix エポックタイムで表示
 const whenSeptemberEnds = '1569887999';
 
-app.message('wake me up', async ({ message, context }) => {
+app.message('wake me up', async ({ message, context, logger }) => {
   try {
     // トークンを用いて chat.scheduleMessage 関数を呼び出す
     const result = await app.client.chat.scheduleMessage({
@@ -31,7 +31,7 @@ app.message('wake me up', async ({ message, context }) => {
     });
   }
   catch (error) {
-    console.error(error);
+    logger.error(error);
   }
 });
 ```

--- a/docs/_basic/listening_actions.md
+++ b/docs/_basic/listening_actions.md
@@ -46,7 +46,7 @@ app.action({ action_id: 'select_user', block_id: 'assign_ticket' },
           channel: body.channel.id
         });
 
-        logger.log(result);
+        logger.info(result);
       }
     }
     catch (error) {

--- a/docs/_basic/listening_actions.md
+++ b/docs/_basic/listening_actions.md
@@ -35,7 +35,7 @@ You can use a constraints object to listen to `callback_id`s, `block_id`s, and `
 ```javascript
 // Your listener function will only be called when the action_id matches 'select_user' AND the block_id matches 'assign_ticket'
 app.action({ action_id: 'select_user', block_id: 'assign_ticket' },
-  async ({ body, client, ack }) => {
+  async ({ body, client, ack, logger }) => {
     await ack();
     try {
       // Make sure the action isn't from a view (modal or app home)
@@ -46,11 +46,11 @@ app.action({ action_id: 'select_user', block_id: 'assign_ticket' },
           channel: body.channel.id
         });
 
-        console.log(result);
+        logger.log(result);
       }
     }
     catch (error) {
-      console.error(error);
+      logger.error(error);
     }
   });
 ```

--- a/docs/_basic/listening_events.md
+++ b/docs/_basic/listening_events.md
@@ -15,17 +15,17 @@ The `event()` method requires an `eventType` of type string.
 const welcomeChannelId = 'C12345';
 
 // When a user joins the team, send a message in a predefined channel asking them to introduce themselves
-app.event('team_join', async ({ event, client }) => {
+app.event('team_join', async ({ event, client, logger }) => {
   try {
     // Call chat.postMessage with the built-in client
     const result = await client.chat.postMessage({
       channel: welcomeChannelId,
       text: `Welcome to the team, <@${event.user.id}>! 🎉 You can introduce yourself in this channel.`
     });
-    console.log(result);
+    logger.info(result);
   }
   catch (error) {
-    console.error(error);
+    logger.error(error);
   }
 });
 ```
@@ -43,8 +43,8 @@ You can filter on subtypes of events by using the built-in `subtype()` middlewar
 
 ```javascript
 // Matches all messages from bot users
-app.message(subtype('bot_message'), ({ message }) => {
-  console.log(`The bot user ${message.user} said ${message.text}`);
+app.message(subtype('bot_message'), ({ message, logger }) => {
+  logger.info(`The bot user ${message.user} said ${message.text}`);
 });
 ```
 

--- a/docs/_basic/listening_modals.md
+++ b/docs/_basic/listening_modals.md
@@ -55,7 +55,7 @@ app.view({ callback_id: 'view_b', type: 'view_closed' }, async ({ ack, body, vie
 
 ```javascript
 // Handle a view_submission request
-app.view('view_b', async ({ ack, body, view, client }) => {
+app.view('view_b', async ({ ack, body, view, client, logger }) => {
   // Acknowledge the view_submission request
   await ack();
 
@@ -85,7 +85,7 @@ app.view('view_b', async ({ ack, body, view, client }) => {
     });
   }
   catch (error) {
-    console.error(error);
+    logger.error(error);
   }
 
 });

--- a/docs/_basic/listening_responding_shortcuts.md
+++ b/docs/_basic/listening_responding_shortcuts.md
@@ -25,7 +25,7 @@ When configuring shortcuts within your app configuration, you'll continue to app
 
 ```javascript
 // The open_modal shortcut opens a plain old modal
-app.shortcut('open_modal', async ({ shortcut, ack, client }) => {
+app.shortcut('open_modal', async ({ shortcut, ack, client, logger }) => {
 
   try {
     // Acknowledge shortcut request
@@ -65,10 +65,10 @@ app.shortcut('open_modal', async ({ shortcut, ack, client }) => {
       }
     });
 
-    console.log(result);
+    logger.info(result);
   }
   catch (error) {
-    console.error(error);
+    logger.error(error);
   }
 });
 ```
@@ -84,7 +84,7 @@ app.shortcut('open_modal', async ({ shortcut, ack, client }) => {
 
   ```javascript
   // Your middleware will only be called when the callback_id matches 'open_modal' AND the type matches 'message_action'
-  app.shortcut({ callback_id: 'open_modal', type: 'message_action' }, async ({ shortcut, ack, client }) => {
+  app.shortcut({ callback_id: 'open_modal', type: 'message_action' }, async ({ shortcut, ack, client, logger }) => {
     try {
       // Acknowledge shortcut request
       await ack();
@@ -123,10 +123,10 @@ app.shortcut('open_modal', async ({ shortcut, ack, client }) => {
         }
       });
 
-      console.log(result);
+      logger.info(result);
     }
     catch (error) {
-      console.error(error);
+      logger.error(error);
     }
   });
   ```

--- a/docs/_basic/opening_modals.md
+++ b/docs/_basic/opening_modals.md
@@ -15,7 +15,7 @@ Read more about modal composition in the <a href="https://api.slack.com/surfaces
 
 ```javascript
 // Listen for a slash command invocation
-app.command('/ticket', async ({ ack, body, client }) => {
+app.command('/ticket', async ({ ack, body, client, logger }) => {
   // Acknowledge the command request
   await ack();
 
@@ -69,10 +69,10 @@ app.command('/ticket', async ({ ack, body, client }) => {
         }
       }
     });
-    console.log(result);
+    logger.info(result);
   }
   catch (error) {
-    console.error(error);
+    logger.error(error);
   }
 });
 ```

--- a/docs/_basic/publishing_views.md
+++ b/docs/_basic/publishing_views.md
@@ -13,7 +13,7 @@ You can subscribe to the <a href="https://api.slack.com/events/app_home_opened">
 
 ```javascript
 // Listen for users opening your App Home
-app.event('app_home_opened', async ({ event, client }) => {
+app.event('app_home_opened', async ({ event, client, logger }) => {
   try {
     // Call views.publish with the built-in client
     const result = await client.views.publish({
@@ -41,10 +41,10 @@ app.event('app_home_opened', async ({ event, client }) => {
       }
     });
 
-    console.log(result);
+    logger.info(result);
   }
   catch (error) {
-    console.error(error);
+    logger.error(error);
   }
 });
 ```

--- a/docs/_basic/updating_pushing_modals.md
+++ b/docs/_basic/updating_pushing_modals.md
@@ -19,7 +19,7 @@ Learn more about updating and pushing views in our <a href="https://api.slack.co
 
 ```javascript
 // Listen for a button invocation with action_id `button_abc` (assume it's inside of a modal)
-app.action('button_abc', async ({ ack, body, client }) => {
+app.action('button_abc', async ({ ack, body, client, logger }) => {
   // Acknowledge the button request
   await ack();
 
@@ -55,10 +55,10 @@ app.action('button_abc', async ({ ack, body, client }) => {
         ]
       }
     });
-    console.log(result);
+    logger.info(result);
   }
   catch (error) {
-    console.error(error);
+    logger.error(error);
   }
 });
 ```

--- a/docs/_basic/web_api.md
+++ b/docs/_basic/web_api.md
@@ -19,7 +19,7 @@ Since the introduction of [org wide app installations](https://api.slack.com/ent
 // Unix Epoch time for September 30, 2019 11:59:59 PM
 const whenSeptemberEnds = '1569887999';
 
-app.message('wake me up', async ({ message, client }) => {
+app.message('wake me up', async ({ message, client, logger }) => {
   try {
     // Call chat.scheduleMessage with the built-in client
     const result = await client.chat.scheduleMessage({
@@ -29,7 +29,7 @@ app.message('wake me up', async ({ message, client }) => {
     });
   }
   catch (error) {
-    console.error(error);
+    logger.error(error);
   }
 });
 ```

--- a/docs/_tutorials/hubot_migration.md
+++ b/docs/_tutorials/hubot_migration.md
@@ -115,7 +115,7 @@ In Hubot, you needed to import the `WebClient` package from `@slack/client`. Bol
 To use the built-in `WebClient`, you’ll need to pass the token used to instantiate your app or the token associated with the team your request is coming from. This is found on the `context` object passed in to your listener functions. For example, to add a reaction to a message, you’d use:
 
 ```javascript
-app.message('react', async ({ message, context, client }) => {
+app.message('react', async ({ message, context, client, logger }) => {
   try {
     const result = await client.reactions.add({
       token: context.botToken,
@@ -125,7 +125,7 @@ app.message('react', async ({ message, context, client }) => {
     });
   }
   catch (error) {
-    console.error(error);
+    logger.error(error);
   }
 });
 ```

--- a/docs/_tutorials/ja_hubot_migration.md
+++ b/docs/_tutorials/ja_hubot_migration.md
@@ -113,7 +113,7 @@ Hubot では、`@slack/client` から `WebClient` パッケージをインポー
 組み込みの `WebClient` を使用するには、アプリをインスタンス化するために使用されるトークン、またはリクエストの送信元のチームに関連付けられているトークンを渡す必要があります。これは、リスナー関数に渡された `context` オブジェクトにあります。たとえば、メッセージにリアクションを追加するには、次を使用します:
 
 ```javascript
-app.message('react', async ({ message, context }) => {
+app.message('react', async ({ message, context, logger }) => {
   try {
     const result = await app.client.reactions.add({
       token: context.botToken,
@@ -123,7 +123,7 @@ app.message('react', async ({ message, context }) => {
     });
   }
   catch (error) {
-    console.error(error);
+    logger.error(error);
   }
 });
 ```


### PR DESCRIPTION
###  Summary

#1241 Replace instances of `console.log` where you have access to the built-in Bolt logger

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).