### PR TITLE
Export more message event types

### DIFF
--- a/src/types/events/index.ts
+++ b/src/types/events/index.ts
@@ -4,14 +4,23 @@ import { SayFn } from '../utilities';
 
 export * from './base-events';
 export {
-  BotMessageEvent,
   GenericMessageEvent,
-  MessageRepliedEvent,
-  MeMessageEvent,
-  MessageDeletedEvent,
-  ThreadBroadcastMessageEvent,
-  MessageChangedEvent,
+  BotMessageEvent,
+  ChannelArchiveMessageEvent,
+  ChannelJoinMessageEvent,
+  ChannelLeaveMessageEvent,
+  ChannelNameMessageEvent,
+  ChannelPostingPermissionsMessageEvent,
+  ChannelPurposeMessageEvent,
+  ChannelTopicMessageEvent,
+  ChannelUnarchiveMessageEvent,
   EKMAccessDeniedMessageEvent,
+  FileShareMessageEvent,
+  MeMessageEvent,
+  MessageChangedEvent,
+  MessageDeletedEvent,
+  MessageRepliedEvent,
+  ThreadBroadcastMessageEvent,
 } from './message-events';
 
 /**


### PR DESCRIPTION
###  Summary

This pull request adds a few missing message subtype events to exports.

See https://github.com/slackapi/bolt-js/pull/832#discussion_r773576824 for the context.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).