### PR TITLE
Bump web-api dependency to 6.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@slack/oauth": "^2.4.0",
     "@slack/socket-mode": "^1.2.0",
     "@slack/types": "^2.4.0",
-    "@slack/web-api": "^6.5.1",
+    "@slack/web-api": "^6.6.0",
     "@types/express": "^4.16.1",
     "@types/node": ">=12",
     "@types/promise.allsettled": "^1.0.3",


### PR DESCRIPTION
To ensure we get the latest security patches.
