### PR TITLE
Explicitly set the content-type on HTTPReceiver responses to the /slack/install route

### DIFF
--- a/src/receivers/HTTPReceiver.spec.ts
+++ b/src/receivers/HTTPReceiver.spec.ts
@@ -291,11 +291,14 @@ describe('HTTPReceiver', function () {
         const fakeRes: ServerResponse = sinon.createStubInstance(ServerResponse) as unknown as ServerResponse;
         const writeHead = sinon.fake();
         const end = sinon.fake();
+        const setHeader = sinon.fake();
         fakeRes.writeHead = writeHead;
         fakeRes.end = end;
+        fakeRes.setHeader = setHeader;
         await receiver.requestListener(fakeReq, fakeRes);
         assert(installProviderStub.generateInstallUrl.calledWith(sinon.match({ metadata, scopes, userScopes })));
         assert.isTrue(writeHead.calledWith(200));
+        assert.isTrue(setHeader.calledWith('Content-Type', 'text/html'));
       });
 
       it('should use a custom HTML renderer for the install path webpage', async function () {

--- a/src/receivers/HTTPReceiver.spec.ts
+++ b/src/receivers/HTTPReceiver.spec.ts
@@ -298,7 +298,7 @@ describe('HTTPReceiver', function () {
         await receiver.requestListener(fakeReq, fakeRes);
         assert(installProviderStub.generateInstallUrl.calledWith(sinon.match({ metadata, scopes, userScopes })));
         assert.isTrue(writeHead.calledWith(200));
-        assert.isTrue(setHeader.calledWith('Content-Type', 'text/html'));
+        assert.isTrue(setHeader.calledWith('Content-Type', 'text/html; charset=utf-8'));
       });
 
       it('should use a custom HTML renderer for the install path webpage', async function () {

--- a/src/receivers/HTTPReceiver.ts
+++ b/src/receivers/HTTPReceiver.ts
@@ -638,8 +638,8 @@ export default class HTTPReceiver implements Receiver {
 
           // Serve a basic HTML page including the "Add to Slack" button.
           // Regarding headers:
-          // - Content-Type is usually automatically detected by browsers
           // - Content-Length is not used because Transfer-Encoding='chunked' is automatically used.
+          res.setHeader('Content-Type', 'text/html');
           res.writeHead(200);
           res.end(body);
         }

--- a/src/receivers/HTTPReceiver.ts
+++ b/src/receivers/HTTPReceiver.ts
@@ -639,7 +639,7 @@ export default class HTTPReceiver implements Receiver {
           // Serve a basic HTML page including the "Add to Slack" button.
           // Regarding headers:
           // - Content-Length is not used because Transfer-Encoding='chunked' is automatically used.
-          res.setHeader('Content-Type', 'text/html');
+          res.setHeader('Content-Type', 'text/html; charset=utf-8');
           res.writeHead(200);
           res.end(body);
         }


### PR DESCRIPTION
###  Summary

While most browsers will automatically infer the content-type header even if not set on HTTP responses, certain cloud hosting systems (e.g. AWS API Gateway) integrate with a variety of other services to provide content and have no means of inferring the content type. As a result, deploying bolt apps to AWS and integrating with API Gateway can be difficult.

This PR explicitly sets the Content-Type header to `text/html` for HTTPReceiver `/slack/install` route responses.

This PR fixes #1279.