### PR TITLE
add client property to interface WorkflowStepExecuteMiddlewareArgs

### DIFF
--- a/src/WorkflowStep.ts
+++ b/src/WorkflowStep.ts
@@ -6,6 +6,7 @@ import {
   WorkflowsUpdateStepResponse,
   WorkflowsStepCompletedResponse,
   WorkflowsStepFailedResponse,
+  WebClient
 } from '@slack/web-api';
 import {
   Middleware,
@@ -96,6 +97,7 @@ export interface WorkflowStepSaveMiddlewareArgs extends SlackViewMiddlewareArgs<
 
 export interface WorkflowStepExecuteMiddlewareArgs extends SlackEventMiddlewareArgs<'workflow_step_execute'> {
   step: WorkflowStepExecuteEvent['workflow_step'];
+  client: WebClient;
   complete: StepCompleteFn;
   fail: StepFailFn;
 }


### PR DESCRIPTION
###  Summary

The client property is added to the interface, to be used later when exporting.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).