### PR TITLE
Add JP transln for userScopes property, add missing comma

### DIFF
--- a/docs/_basic/authenticating_oauth.md
+++ b/docs/_basic/authenticating_oauth.md
@@ -145,7 +145,7 @@ const app = new App({
       metadata: 'some session data',
       installPath: '/slack/installApp',
       redirectUriPath: '/slack/redirect',
-      userScopes: ['chat:write']
+      userScopes: ['chat:write'],
       callbackOptions: {
         success: (installation, installOptions, req, res) => {
           // Do custom success logic here

--- a/docs/_basic/ja_authenticating_oauth.md
+++ b/docs/_basic/ja_authenticating_oauth.md
@@ -81,6 +81,7 @@ const app = new App({
 - `redirectUriPath`: Redirect URL を変更するために使用
 - `callbackOptions`: OAuth フロー完了時の成功・エラー完了画面をカスタマイズするために使用
 - `stateStore`: 組み込みの `ClearStateStore` の代わりにカスタムのデータストアを有効にするために使用
+- `userScopes`: 親の階層にある `scopes` プロパティと同様、ユーザがアプリをインストールする際に必要となるユーザスコープのリストの指定に使用
 
 </div>
 
@@ -95,6 +96,7 @@ const app = new App({
       metadata: 'some session data',
       installPath: '/slack/installApp',
       redirectUriPath: '/slack/redirect',
+      userScopes: ['chat:write'],
       callbackOptions: {
         success: (installation, installOptions, req, res) => {
           // ここで成功時のカスタムロジックを実装


### PR DESCRIPTION
###  Summary
Fixes #1289.  Adds translation for `userScopes` property, adds in missing comma in the EN docs 


### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).