### PR TITLE
Update ngrok link to point to official guide

### DIFF
--- a/docs/_tutorials/getting_started_http.md
+++ b/docs/_tutorials/getting_started_http.md
@@ -131,7 +131,7 @@ Let's enable events for your app:
 
 2. Add your Request URL. Slack will send HTTP POST requests corresponding to events to this [Request URL](https://api.slack.com/apis/connections/events-api#the-events-api__subscribing-to-event-types__events-api-request-urls) endpoint. Bolt uses the `/slack/events` path to listen to all incoming requests (whether shortcuts, events, or interactivity payloads). When configuring your Request URL within your app configuration, you'll append `/slack/events`, e.g. `https://<your-domain>/slack/events`. 💡
 
-> 💡 For local development, you can use a proxy service like [ngrok](https://ngrok.com/) to create a public URL and tunnel requests to your development environment. We've written a separate tutorial about [using ngrok with Slack for local development](https://api.slack.com/tutorials/tunneling-with-ngrok) that should help you get everything set up.
+> 💡 For local development, you can use a proxy service like [ngrok](https://ngrok.com/) to create a public URL and tunnel requests to your development environment. Refer to [ngrok's getting started guide](https://ngrok.com/docs#getting-started-expose) on how to create this tunnel.
 
  
 Finally, it's time to tell Slack what events we'd like to listen for. Under **Event Subscriptions**, toggle the switch labeled **Enable Events**. 

--- a/docs/_tutorials/ja_getting_started_http.md
+++ b/docs/_tutorials/ja_getting_started_http.md
@@ -131,7 +131,7 @@ Slack ワークスペースで発生するイベント (メッセージが投稿
 
 2. Request URLを追加します。Slackはイベントに対応するHTTP POSTリクエストをこの[Request URL](https://api.slack.com/apis/connections/events-api#the-events-api__subscribing-to-event-types__events-api-request-urls)エンドポイントに送信します。Boltは`/slack/events`のパスを使用して、すべての受信リクエスト（ショートカット、イベント、インタラクティビティのペイロードなど）をリッスンします。アプリの設定でRequest URLを設定する際には、`https://<your-domain>/slack/events`のように`/slack/events`を追加します。💡
 
-> ローカル開発では、[ngrok](https://ngrok.com/)のようなプロキシサービスを使って公開URLを作成し、リクエストを開発環境にトンネリングすることができます。[ローカル開発のためのSlackでのngrokの使用](https://api.slack.com/tutorials/tunneling-with-ngrok)については別のチュートリアルがありますので、そちらを参照してください。
+> ローカル開発では、[ngrok](https://ngrok.com/)のようなプロキシサービスを使って公開 URL を作成し、リクエストを開発環境にトンネリングすることができます。このトンネリングの方法については、[ngrok のガイド](https://ngrok.com/docs#getting-started-expose)を参照してください。
 
 最後に、聞きたいイベントをSlackに伝えましょう。**Event Subscriptions**の下にある、**Enable Events**というラベルの付いたスイッチを切り替えます。
 


### PR DESCRIPTION
###  Summary

Documentation around `ngrok` was removed at some point from the API website. The newly proposed link points to the official `ngrok` getting started guide.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).