### PR TITLE
Update SlackEvent type to include ChannelIDChangedEvent

### DIFF
--- a/src/types/events/base-events.ts
+++ b/src/types/events/base-events.ts
@@ -3,6 +3,7 @@ import { MessageEvent as AllMessageEvents } from './message-events';
 
 /**
  * All known event types in Slack's Events API
+ * Please refer to https://api.slack.com/events for more details
  *
  * This is a discriminated union. The discriminant is the `type` property.
  */

--- a/src/types/events/base-events.ts
+++ b/src/types/events/base-events.ts
@@ -16,6 +16,7 @@ export type SlackEvent =
   | ChannelCreatedEvent
   | ChannelDeletedEvent
   | ChannelHistoryChangedEvent
+  | ChannelIDChangedEvent
   | ChannelLeftEvent
   | ChannelRenameEvent
   | ChannelSharedEvent


### PR DESCRIPTION
###  Summary

Fixes #1301 by updating `SlackEvent` to include `ChannelIDChangedEvent`. 

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).