### PR TITLE
Improve OAuth documentation

### DIFF
--- a/docs/_basic/authenticating_oauth.md
+++ b/docs/_basic/authenticating_oauth.md
@@ -24,6 +24,7 @@ const app = new App({
   clientSecret: process.env.SLACK_CLIENT_SECRET,
   stateSecret: 'my-state-secret',
   scopes: ['chat:write'],
+  // optional code for directInstall. Defaults to false. When set to true, this option skips the user from seeing the "Add to Slack" button page. 
   installerOptions: {
     directInstall: true,
   },

--- a/docs/_basic/authenticating_oauth.md
+++ b/docs/_basic/authenticating_oauth.md
@@ -24,7 +24,7 @@ const app = new App({
   clientSecret: process.env.SLACK_CLIENT_SECRET,
   stateSecret: 'my-state-secret',
   scopes: ['chat:write'],
-  // optional code for directInstall. Defaults to false. When set to true, this option skips the user from seeing the "Add to Slack" button page. 
+  // optional code for directInstall. Defaults to false. When set to true, user does not see "Add to Slack" button page. 
   installerOptions: {
     directInstall: true,
   },

--- a/docs/_basic/authenticating_oauth.md
+++ b/docs/_basic/authenticating_oauth.md
@@ -15,7 +15,11 @@ You will need to provide your:
 ---
 
 ##### Installing your App
-Bolt for JavaScript provides an **Install Path** `/slack/install` out-of-the-box. This returns a simple `Add to Slack` button where users can initiate direct installs of your app. For example, if your app was hosted at `www.example.com`, you would be able to install your app at `www.example.com/slack/install`. Once you click on the `Add to Slack` button, this will initiate the OAuth process. You will see a green `Allow` button and dialouge of your app asking permissions. Once you click on the `Allow` button, this is when the redirect URI will be called. The out of the box redirect will ask you to "Open Slack". Once you open Slack, the `fetchInstallation` and `storeInstallation` part of the OAuth code will execute. 
+Bolt for JavaScript provides an **Install Path** `/slack/install` out-of-the-box. This endpoint returns a simple `Add to Slack` button where users can initiate direct installs of your app. For example, if your app was hosted at `www.example.com`, you would be able to install your app at `www.example.com/slack/install`. 
+
+Once you click on the `Add to Slack` button, this will initiate the OAuth process. Users will see a green `Allow` button and dialogue of your app asking for permissions. Once you click on the `Allow` button, Slack will call your app's redirect URI. After this, the `fetchInstallation` and `storeInstallation` handlers you will execute. 
+
+Bolt provides a redirect URI out-of-the-box. See the following section, Redirect URI for more details.  
 
 Additionally, you can expect the `installation` object to look like the following:
 

--- a/docs/_basic/authenticating_oauth.md
+++ b/docs/_basic/authenticating_oauth.md
@@ -15,7 +15,41 @@ You will need to provide your:
 ---
 
 ##### Installing your App
-Bolt for JavaScript provides an **Install Path** `/slack/install` out-of-the-box. This returns a simple `Add to Slack` button where users can initiate direct installs of your app. 
+Bolt for JavaScript provides an **Install Path** `/slack/install` out-of-the-box. This returns a simple `Add to Slack` button where users can initiate direct installs of your app. For example, if your app was hosted at `www.example.com`, you would be able to install your app at `www.example.com/slack/install`. Once you click on the `Add to Slack` button, this will initiate the OAuth process. You will see a green `Allow` button and dialouge of your app asking permissions. Once you click on the `Allow` button, this is when the redirect URI will be called. The out of the box redirect will ask you to "Open Slack". Once you open Slack, the `fetchInstallation` and `storeInstallation` part of the OAuth code will execute. 
+
+Additionally, you can expect the `installation` object to look like the following:
+
+```json
+{
+  team: { id: 'T012345678', name: 'example-team-name' },
+  enterprise: undefined,
+  user: { token: undefined, scopes: undefined, id: 'U01234567' },
+  tokenType: 'bot',
+  isEnterpriseInstall: false,
+  appId: 'A01234567',
+  authVersion: 'v2',
+  bot: {
+    scopes: [
+      'chat:write',
+    ],
+    token: 'xoxb-244493-28*********-********************',
+    userId: 'U012345678',
+    id: 'B01234567'
+  }
+}
+```
+
+Similarly, the installQuery object will look like the following:
+
+```json
+{
+  userId: 'U012345678',
+  isEnterpriseInstall: false,
+  teamId: 'T012345678',
+  enterpriseId: undefined,
+  conversationId: 'D02345678'
+}
+```
 
 If you need additional authorizations (user tokens) from users inside a team when your app is already installed, or have a reason to dynamically generate an install URL, manually instantiate an `ExpressReceiver`, assign the instance to a variable named `receiver`, and then call `receiver.installer.generateInstallUrl()`. Read more about `generateInstallUrl()` in the [OAuth docs](https://slack.dev/node-slack-sdk/oauth#generating-an-installation-url).
 

--- a/docs/_basic/authenticating_oauth.md
+++ b/docs/_basic/authenticating_oauth.md
@@ -15,7 +15,8 @@ You will need to provide your:
 ---
 
 ##### Installing your App
-Bolt for JavaScript provides an **Install Path** `/slack/install` out-of-the-box. This endpoint returns a simple `Add to Slack` button where users can initiate direct installs of your app. For example, if your app was hosted at `www.example.com`, you would be able to install your app at `www.example.com/slack/install`. 
+Bolt for JavaScript provides an **Install Path** `/slack/install` out-of-the-box. This endpoint returns a simple `Add to Slack` button where users can initiate direct installs of your app with a valid `state` parameter. For example, if your app was hosted at `www.example.com`, you would be able to install your app at `www.example.com/slack/install`. If you would like to skip rendering the simple webpage and directly navigate end-users to Slack authorize URL, your app can set `installerOptions.directInstall: true` in the `App` constructor.
+
 
 Once you click on the `Add to Slack` button, this will initiate the OAuth process. Users will see a green `Allow` button and dialogue of your app asking for permissions. Once you click on the `Allow` button, Slack will call your app's redirect URI. This will bring you to the `slack/oauth_redirect` endpoint and alert you in your browser to "Open Slack". Only after you **Open Slack** will the `fetchInstallation` and `storeInstallation` handlers execute. 
 

--- a/docs/_basic/authenticating_oauth.md
+++ b/docs/_basic/authenticating_oauth.md
@@ -22,8 +22,8 @@ const app = new App({
   signingSecret: process.env.SLACK_SIGNING_SECRET,
   clientId: process.env.SLACK_CLIENT_ID,
   clientSecret: process.env.SLACK_CLIENT_SECRET,
-  ...
-  scopes: [],
+  stateSecret: 'my-state-secret',
+  scopes: ['chat:write'],
   installerOptions: {
     directInstall: true,
   },

--- a/docs/_basic/authenticating_oauth.md
+++ b/docs/_basic/authenticating_oauth.md
@@ -15,8 +15,20 @@ You will need to provide your:
 ---
 
 ##### Installing your App
-Bolt for JavaScript provides an **Install Path** `/slack/install` out-of-the-box. This endpoint returns a simple `Add to Slack` button where users can initiate direct installs of your app with a valid `state` parameter. For example, if your app was hosted at `www.example.com`, you would be able to install your app at `www.example.com/slack/install`. If you would like to skip rendering the simple webpage and directly navigate end-users to Slack authorize URL, your app can set `installerOptions.directInstall: true` in the `App` constructor.
+Bolt for JavaScript provides an **Install Path** `/slack/install` out-of-the-box. This endpoint returns a simple `Add to Slack` button where users can initiate direct installs of your app with a valid `state` parameter. For example, if your app was hosted at `www.example.com`, you would be able to install your app at `www.example.com/slack/install`. If you would like to skip rendering the simple webpage and directly navigate end-users to Slack authorize URL, your app can set `installerOptions.directInstall: true` in the `App` constructor. See example code below:
 
+```javascript
+const app = new App({
+  signingSecret: process.env.SLACK_SIGNING_SECRET,
+  clientId: process.env.SLACK_CLIENT_ID,
+  clientSecret: process.env.SLACK_CLIENT_SECRET,
+  ...
+  scopes: [],
+  installerOptions: {
+    directInstall: true,
+  },
+});
+```
 
 Once you click on the `Add to Slack` button, this will initiate the OAuth process. Users will see a green `Allow` button and dialogue of your app asking for permissions. Once you click on the `Allow` button, Slack will call your app's redirect URI. This will bring you to the `slack/oauth_redirect` endpoint and alert you in your browser to "Open Slack". Only after you **Open Slack** will the `fetchInstallation` and `storeInstallation` handlers execute. 
 

--- a/docs/_basic/authenticating_oauth.md
+++ b/docs/_basic/authenticating_oauth.md
@@ -31,7 +31,7 @@ const app = new App({
 });
 ```
 
-Once you click on the `Add to Slack` button, this will initiate the OAuth process. Users will see a green `Allow` button and dialogue of your app asking for permissions. Once you click on the `Allow` button, Slack will call your app's redirect URI. This will bring you to the `slack/oauth_redirect` endpoint and alert you in your browser to "Open Slack". Only after you **Open Slack** will the `fetchInstallation` and `storeInstallation` handlers execute. 
+Once you click on the `Add to Slack` button, this will initiate the OAuth process. Users will see a green `Allow` button and dialogue of your app asking for permissions. Once you click on the `Allow` button, Slack will call your app's redirect URI. This will bring you to the `slack/oauth_redirect` endpoint and alert you in your browser to "Open Slack". After you **Open Slack** and here on after as your app processes events from Slack, `fetchInstallation` and `storeInstallation` handlers will execute. 
 
 Bolt provides a redirect URI out-of-the-box. See the following section, Redirect URI for more details.  
 

--- a/docs/_basic/authenticating_oauth.md
+++ b/docs/_basic/authenticating_oauth.md
@@ -17,7 +17,7 @@ You will need to provide your:
 ##### Installing your App
 Bolt for JavaScript provides an **Install Path** `/slack/install` out-of-the-box. This endpoint returns a simple `Add to Slack` button where users can initiate direct installs of your app. For example, if your app was hosted at `www.example.com`, you would be able to install your app at `www.example.com/slack/install`. 
 
-Once you click on the `Add to Slack` button, this will initiate the OAuth process. Users will see a green `Allow` button and dialogue of your app asking for permissions. Once you click on the `Allow` button, Slack will call your app's redirect URI. After this, the `fetchInstallation` and `storeInstallation` handlers you will execute. 
+Once you click on the `Add to Slack` button, this will initiate the OAuth process. Users will see a green `Allow` button and dialogue of your app asking for permissions. Once you click on the `Allow` button, Slack will call your app's redirect URI. This will bring you to the `slack/oauth_redirect` endpoint and alert you in your browser to "Open Slack". Only after you **Open Slack** will the `fetchInstallation` and `storeInstallation` handlers execute. 
 
 Bolt provides a redirect URI out-of-the-box. See the following section, Redirect URI for more details.  
 


### PR DESCRIPTION
Fixes #1306

Added details about when storeInstallation and fetchInstallation execute in Bolt
* Added detail about the install path: if your app was hosted at `www.example.com`, you would be able to install your app at `www.example.com/slack/install`
* Added details about OAuth process: first you must click on add to slack, then allow, then open Slack, and only then will fetch/storeInstallation will execute
* Added sample `installation` object (useful for folks working on DB schemas before the fetch/storeInstallation runs
* Added sample `installQuery` object

###  Summary

Describe the goal of this PR. Mention any related Issue numbers.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).