### PR TITLE
Quote add to slack URL

### DIFF
--- a/src/receivers/render-html-for-install-path.ts
+++ b/src/receivers/render-html-for-install-path.ts
@@ -1,7 +1,7 @@
 export default function defaultRenderHtmlForInstallPath(addToSlackUrl: string): string {
   return `<html>
       <body>
-        <a href=${addToSlackUrl}>
+        <a href="${addToSlackUrl}">
           <img
             alt="Add to Slack"
             height="40"


### PR DESCRIPTION
###  Summary

I needed to customize the install route and I noticed that the href URL isn't quoted.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).