### PR TITLE
allow disabling signature verification

### DIFF
--- a/src/receivers/ExpressReceiver.ts
+++ b/src/receivers/ExpressReceiver.ts
@@ -486,6 +486,11 @@ function verifyRequestSignature(
   signature: string | undefined,
   requestTimestamp: string | undefined,
 ): void {
+  // for testing purposes, should not be used in production
+  if (process.env.DISABLE_SIGNATURE_VERIFICATION === "true") {
+    return;
+  }
+
   if (signature === undefined || requestTimestamp === undefined) {
     throw new ReceiverAuthenticityError('Slack request signing verification failed. Some headers are missing.');
   }

--- a/src/receivers/verify-request.ts
+++ b/src/receivers/verify-request.ts
@@ -50,6 +50,11 @@ export async function verify(
   req: IncomingMessage,
   _res?: ServerResponse,
 ): Promise<BufferedIncomingMessage> {
+  // for testing purposes, should not be used in production
+  if (process.env.DISABLE_SIGNATURE_VERIFICATION === "true") {
+    return Promise.resolve({} as any);
+  }
+
   const { signingSecret } = options;
 
   // Consume the readable stream (or use the previously consumed readable stream)


### PR DESCRIPTION
###  Summary

This enables E2E testing w/o the need of manual signature verification, by doing:

```
$ DISABLE_SIGNATURE_VERIFICATION=true node path/to/app.js
```

Happy to add tests once you approve this direction

related issues:
- #1336
- #1339
- #383
- #638

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).