### PR TITLE
Log httpServer.close error only when defined

### DIFF
--- a/src/receivers/SocketModeReceiver.ts
+++ b/src/receivers/SocketModeReceiver.ts
@@ -241,7 +241,7 @@ export default class SocketModeReceiver implements Receiver {
     if (this.httpServer !== undefined) {
       // This HTTP server is only for the OAuth flow support
       this.httpServer.close((error) => {
-        this.logger.error(`Failed to shutdown the HTTP server for OAuth flow: ${error}`);
+        if (error) this.logger.error(`Failed to shutdown the HTTP server for OAuth flow: ${error}`);
       });
     }
     return new Promise((resolve, reject) => {


### PR DESCRIPTION
###  Summary

fix #1368
Using `socketMode = true` with `customRoutes` issues irrelevant error message on `app.stop`

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).