### PR TITLE
Deploy the App to Heroku with one click

### DIFF
--- a/app.json
+++ b/app.json
@@ -4,7 +4,7 @@
   "keywords": ["slack", "heroku", "nodejs", "bolt", "bolt-js", "javascript"],
   "logo": "https://raw.githubusercontent.com/slackapi/bolt-js/main/docs/assets/bolt-logo.svg",
   "image": "heroku/nodejs",
-  "website": "https://slack.dev/bolt-js/tutorial/getting-started",
+  "website": "https://slack.dev/bolt-js/",
   "repository": "https://github.com/slackapi/bolt-js",
   "success_url": "/",
   "env": {

--- a/app.json
+++ b/app.json
@@ -1,0 +1,41 @@
+{
+  "name": "Deploying to Heroku ⚡️ Bolt for JavaScript",
+  "description": "This is a Slack app built with the Bolt for JavaScript framework that showcases deploying to the Heroku platform.",
+  "keywords": ["slack", "heroku", "nodejs", "bolt", "bolt-js", "javascript"],
+  "logo": "https://raw.githubusercontent.com/slackapi/bolt-js/main/docs/assets/bolt-logo.svg",
+  "image": "heroku/nodejs",
+  "website": "https://slack.dev/bolt-js/tutorial/getting-started",
+  "repository": "https://github.com/slackapi/bolt-js",
+  "success_url": "/",
+  "env": {
+    "SLACK_SIGNING_SECRET": {
+      "description": "Slack creates a unique string for your app and shares it with you. Verify requests from Slack with confidence by verifying signatures using your signing secret. (begins with xoxb-)",
+      "value": "",
+      "required": true
+    },
+    "SLACK_BOT_TOKEN": {
+      "description": "Bot tokens represent a bot associated with the app installed in a workspace. Unlike user tokens, they're not tied to a user's identity; they're just tied to your app.",
+      "value": "",
+      "required": true
+    },
+    "APP_BASE": {
+      "description": "Do not change. Used by heroku-buildpack-monorepo",
+      "value": "examples/deploy-heroku",
+      "required": false
+    }
+  },
+  "formation": {
+    "web": {
+      "quantity": 1,
+      "size": "free"
+    }
+  },
+  "buildpacks": [
+    {
+      "url": "https://github.com/lstoll/heroku-buildpack-monorepo"
+    },
+    {
+      "url": "heroku/nodejs"
+    }
+  ]
+}

--- a/examples/deploy-heroku/README.md
+++ b/examples/deploy-heroku/README.md
@@ -55,6 +55,10 @@ heroku ps:scale web=1
 2. Follow the [Deploying to Heroku with Bolt for JavaScript][1] guide to:
     - Update your **Request URL** for actions and events
 
+### 6. Bonus: Deploy to Heroku with one click
+
+[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/slackapi/bolt-js)
+
 [1]: https://slack.dev/bolt-js/deployments/heroku
 [2]: https://slack.dev/bolt-js/
 [3]: https://heroku.com/


### PR DESCRIPTION
###  Summary

- Minor change allows users to deploy the app to Heroku with one click with the deploy template.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-js-getting-started-app/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).