### PR TITLE
Add Socket Mode OAuth example app

### DIFF
--- a/examples/socket-mode-oauth/.gitignore
+++ b/examples/socket-mode-oauth/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+package-lock.json

--- a/examples/socket-mode-oauth/app.js
+++ b/examples/socket-mode-oauth/app.js
@@ -1,0 +1,32 @@
+const { App, SocketModeReceiver } = require('@slack/bolt');
+
+const socketModeReceiver = new SocketModeReceiver({
+  appToken: process.env.SLACK_APP_TOKEN,
+  clientId: process.env.SLACK_CLIENT_ID,
+  clientSecret: process.env.SLACK_CLIENT_SECRET,
+  stateSecret: 'my-state-secret',
+  scopes: ['channels:history', 'chat:write', 'commands'],
+  customRoutes: [
+    {
+      path: '/health-check',
+      method: ['GET'],
+      handler: (req, res) => {
+        res.writeHead(200);
+        res.end('Health check information displayed here!');
+      },
+    },
+  ],
+});
+const app = new App({
+  receiver: socketModeReceiver,
+});
+
+/** Start Bolt App */
+(async () => {
+  try {
+    await app.start(process.env.PORT);
+    console.log('⚡️ Bolt app is running! ⚡️');
+  } catch (error) {
+    console.error('Unable to start App', error);
+  }
+})();

--- a/examples/socket-mode-oauth/app.js
+++ b/examples/socket-mode-oauth/app.js
@@ -18,5 +18,6 @@ const app = new App({
     console.log('⚡️ Bolt app is running! ⚡️');
   } catch (error) {
     console.error('Unable to start App', error);
+    process.exit(1);
   }
 })();

--- a/examples/socket-mode-oauth/app.js
+++ b/examples/socket-mode-oauth/app.js
@@ -9,16 +9,6 @@ const app = new App({
   clientSecret: process.env.SLACK_CLIENT_SECRET,
   stateSecret: 'my-state-secret',
   scopes: ['channels:history', 'chat:write', 'commands'],
-  customRoutes: [
-    {
-      path: '/health-check',
-      method: ['GET'],
-      handler: (req, res) => {
-        res.writeHead(200);
-        res.end('Health check information displayed here!');
-      },
-    },
-  ],
 });
 
 /** Start Bolt App */

--- a/examples/socket-mode-oauth/app.js
+++ b/examples/socket-mode-oauth/app.js
@@ -1,7 +1,10 @@
-const { App, SocketModeReceiver } = require('@slack/bolt');
+const { App, LogLevel } = require('@slack/bolt');
 
-const socketModeReceiver = new SocketModeReceiver({
+const app = new App({
+  logLevel: LogLevel.DEBUG,
+  socketMode: true,
   appToken: process.env.SLACK_APP_TOKEN,
+  signingSecret: process.env.SLACK_SIGNING_SECRET,
   clientId: process.env.SLACK_CLIENT_ID,
   clientSecret: process.env.SLACK_CLIENT_SECRET,
   stateSecret: 'my-state-secret',
@@ -16,9 +19,6 @@ const socketModeReceiver = new SocketModeReceiver({
       },
     },
   ],
-});
-const app = new App({
-  receiver: socketModeReceiver,
 });
 
 /** Start Bolt App */

--- a/examples/socket-mode-oauth/package.json
+++ b/examples/socket-mode-oauth/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "socket-mode-oauth-example",
+  "version": "1.0.0",
+  "description": "Example of Bolt SocketMode App with Oauth enabled",
+  "main": "app.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "start": "node app.js"
+  },
+  "author": "Slack Technologies, LLC",
+  "license": "MIT",
+  "dependencies": {
+    "@slack/bolt": "^3.2.0"
+  }
+}

--- a/examples/socket-mode-oauth/package.json
+++ b/examples/socket-mode-oauth/package.json
@@ -10,6 +10,6 @@
   "author": "Slack Technologies, LLC",
   "license": "MIT",
   "dependencies": {
-    "@slack/bolt": "^3.2.0"
+    "@slack/bolt": "^3.10.0"
   }
 }


### PR DESCRIPTION
###  Summary

Add a SocketMode + Oauth enabled Slack app to `/examples`

Testing
*`npm install` + `node app.js` to fire up the app
* Sanity check oauth routes --- `curl http://localhost:3000/slack/install` to confirm that the install route is working
* Sanity check custom routes --- `curl http://localhost:3000/test-route` to confirm the custom route is working

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).