### PR TITLE
Fix #1335 Proper use of state parameter for the OAuth CSRF protection

### DIFF
--- a/examples/oauth-express-receiver/app.js
+++ b/examples/oauth-express-receiver/app.js
@@ -1,4 +1,4 @@
-const { App, ExpressReceiver, LogLevel } = require('@slack/bolt');
+const { App, ExpressReceiver, LogLevel, FileInstallationStore } = require('@slack/bolt');
 
 // Create an ExpressReceiver
 const receiver = new ExpressReceiver({ 
@@ -13,32 +13,7 @@ const receiver = new ExpressReceiver({
     // This flag is available in @slack/bolt v3.7 or higher
     // directInstall: true,
   },
-  installationStore: {
-    storeInstallation: async (installation) => {
-      // replace database.set so it fetches from your database
-      if (installation.isEnterpriseInstall && installation.enterprise !== undefined) {
-        // support for org wide app installation
-        return await database.set(installation.enterprise.id, installation);
-      }
-      if (installation.team !== undefined) {
-        // single team app installation
-        return await database.set(installation.team.id, installation);
-      }
-      throw new Error('Failed saving installation data to installationStore');
-    },
-    fetchInstallation: async (installQuery) => {
-      // replace database.get so it fetches from your database
-      if (installQuery.isEnterpriseInstall && installQuery.enterpriseId !== undefined) {
-        // org wide app installation lookup
-        return await database.get(installQuery.enterpriseId);
-      }
-      if (installQuery.teamId !== undefined) {
-        // single team app installation lookup
-        return await database.get(installQuery.teamId);
-      }
-      throw new Error('Failed fetching installation');
-    },
-  },
+  installationStore: new FileInstallationStore(),
 });
 
 // Create the Bolt App, using the receiver
@@ -60,6 +35,6 @@ receiver.router.get('/secret-page', (req, res) => {
 });
 
 (async () => {
-  await app.start(8080);
+  await app.start(3000);
   console.log('Express app is running');
 })();

--- a/examples/oauth-express-receiver/link.sh
+++ b/examples/oauth-express-receiver/link.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+current_dir=`dirname $0`
+cd ${current_dir}
+npm unlink @slack/bolt \
+  && npm i \
+  && cd ../.. \
+  && npm link \
+  && cd - \
+  && npm i \
+  && npm link @slack/bolt

--- a/examples/socket-mode-oauth/link.sh
+++ b/examples/socket-mode-oauth/link.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+current_dir=`dirname $0`
+cd ${current_dir}
+npm unlink @slack/bolt \
+  && npm i \
+  && cd ../.. \
+  && npm link \
+  && cd - \
+  && npm i \
+  && npm link @slack/bolt

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   },
   "dependencies": {
     "@slack/logger": "^3.0.0",
-    "@slack/oauth": "^2.4.0",
+    "@slack/oauth": "^2.5.0",
     "@slack/socket-mode": "^1.2.0",
     "@slack/types": "^2.4.0",
     "@slack/web-api": "^6.7.0",

--- a/src/receivers/HTTPReceiver.spec.ts
+++ b/src/receivers/HTTPReceiver.spec.ts
@@ -257,7 +257,7 @@ describe('HTTPReceiver', function () {
   });
   describe('request handling', function () {
     describe('handleInstallPathRequest()', function () {
-      it('should invoke installer generateInstallUrl if a request comes into the install path', async function () {
+      it('should invoke installer handleInstallPath if a request comes into the install path', async function () {
         // Arrange
         const installProviderStub = sinon.createStubInstance(InstallProvider);
         const overrides = mergeOverrides(
@@ -296,9 +296,7 @@ describe('HTTPReceiver', function () {
         fakeRes.end = end;
         fakeRes.setHeader = setHeader;
         await receiver.requestListener(fakeReq, fakeRes);
-        assert(installProviderStub.generateInstallUrl.calledWith(sinon.match({ metadata, scopes, userScopes })));
-        assert.isTrue(writeHead.calledWith(200));
-        assert.isTrue(setHeader.calledWith('Content-Type', 'text/html; charset=utf-8'));
+        assert(installProviderStub.handleInstallPath.calledWith(fakeReq, fakeRes));
       });
 
       it('should use a custom HTML renderer for the install path webpage', async function () {
@@ -340,9 +338,7 @@ describe('HTTPReceiver', function () {
         fakeRes.end = end;
         /* eslint-disable-next-line @typescript-eslint/await-thenable */
         await receiver.requestListener(fakeReq, fakeRes);
-        assert(installProviderStub.generateInstallUrl.calledWith(sinon.match({ metadata, scopes, userScopes })));
-        assert.isTrue(writeHead.calledWith(200));
-        assert.isTrue(end.calledWith('Hello world!'));
+        assert(installProviderStub.handleInstallPath.calledWith(fakeReq, fakeRes));
       });
 
       it('should redirect installers if directInstall is true', async function () {
@@ -383,8 +379,7 @@ describe('HTTPReceiver', function () {
         fakeRes.writeHead = writeHead;
         fakeRes.end = end;
         await receiver.requestListener(fakeReq, fakeRes);
-        assert(installProviderStub.generateInstallUrl.calledWith(sinon.match({ metadata, scopes, userScopes })));
-        assert.isTrue(writeHead.calledWith(302, sinon.match.object));
+        assert(installProviderStub.handleInstallPath.calledWith(fakeReq, fakeRes));
       });
     });
 

--- a/src/receivers/SocketModeReceiver.spec.ts
+++ b/src/receivers/SocketModeReceiver.spec.ts
@@ -198,7 +198,7 @@ describe('SocketModeReceiver', function () {
   });
   describe('request handling', function () {
     describe('handleInstallPathRequest()', function () {
-      it('should invoke installer generateInstallUrl if a request comes into the install path', async function () {
+      it('should invoke installer handleInstallPath if a request comes into the install path', async function () {
         // Arrange
         const installProviderStub = sinon.createStubInstance(InstallProvider);
         const overrides = mergeOverrides(
@@ -229,15 +229,13 @@ describe('SocketModeReceiver', function () {
         const fakeReq = {
           url: '/hiya',
           method: 'GET',
-        };
+        } as IncomingMessage;
         const fakeRes = {
           writeHead: sinon.fake(),
           end: sinon.fake(),
-        };
+        } as unknown as ServerResponse;
         await this.listener(fakeReq, fakeRes);
-        assert(installProviderStub.generateInstallUrl.calledWith(sinon.match({ metadata, scopes, userScopes })));
-        assert(fakeRes.writeHead.calledWith(200, sinon.match.object));
-        assert(fakeRes.end.called);
+        assert(installProviderStub.handleInstallPath.calledWith(fakeReq, fakeRes));
       });
       it('should use a custom HTML renderer for the install path webpage', async function () {
         // Arrange
@@ -271,16 +269,13 @@ describe('SocketModeReceiver', function () {
         const fakeReq = {
           url: '/hiya',
           method: 'GET',
-        };
+        } as IncomingMessage;
         const fakeRes = {
           writeHead: sinon.fake(),
           end: sinon.fake(),
-        };
+        } as unknown as ServerResponse;
         await this.listener(fakeReq, fakeRes);
-        assert(installProviderStub.generateInstallUrl.calledWith(sinon.match({ metadata, scopes, userScopes })));
-        assert(fakeRes.writeHead.calledWith(200, sinon.match.object));
-        assert(fakeRes.end.called);
-        assert.isTrue(fakeRes.end.calledWith('Hello world!'));
+        assert(installProviderStub.handleInstallPath.calledWith(fakeReq, fakeRes));
       });
       it('should redirect installers if directInstall is true', async function () {
         // Arrange
@@ -314,16 +309,13 @@ describe('SocketModeReceiver', function () {
         const fakeReq = {
           url: '/hiya',
           method: 'GET',
-        };
+        } as IncomingMessage;
         const fakeRes = {
           writeHead: sinon.fake(),
           end: sinon.fake(),
-        };
-        /* eslint-disable-next-line @typescript-eslint/await-thenable */
+        } as unknown as ServerResponse;
         await this.listener(fakeReq, fakeRes);
-        assert(installProviderStub.generateInstallUrl.calledWith(sinon.match({ metadata, scopes, userScopes })));
-        assert(fakeRes.writeHead.calledWith(302, sinon.match.object));
-        assert(fakeRes.end.called);
+        assert(installProviderStub.handleInstallPath.calledWith(fakeReq, fakeRes));
       });
     });
     describe('handleInstallRedirectRequest()', function () {


### PR DESCRIPTION
###  Summary

This pull request resolves #1335 by migrating to the new `handleInstallPath()` method, which is newly added in `@slack/oauth@2.5.0`.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).