### PR TITLE
Fix #1385 Create a signature validation function that is not tied to the request

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,11 @@ export {
   Logger,
 } from './App';
 
+export {
+  verifySlackRequest,
+  isValidSlackRequest,
+} from './receivers/verify-request';
+
 export { default as ExpressReceiver, ExpressReceiverOptions } from './receivers/ExpressReceiver';
 export { default as SocketModeReceiver, SocketModeReceiverOptions } from './receivers/SocketModeReceiver';
 export { default as HTTPReceiver, HTTPReceiverOptions } from './receivers/HTTPReceiver';

--- a/src/receivers/verify-request.spec.ts
+++ b/src/receivers/verify-request.spec.ts
@@ -1,0 +1,106 @@
+import 'mocha';
+import { assert } from 'chai';
+import { createHmac } from 'crypto';
+import { isValidSlackRequest, verifySlackRequest } from './verify-request';
+
+describe('Request verification', async () => {
+  const signingSecret = 'secret';
+
+  describe('verifySlackRequest', async () => {
+    it('should judge a valid request', async () => {
+      const timestamp = Math.floor(Date.now() / 1000);
+      const rawBody = '{"foo":"bar"}';
+      const hmac = createHmac('sha256', signingSecret);
+      hmac.update(`v0:${timestamp}:${rawBody}`);
+      const signature = hmac.digest('hex');
+      verifySlackRequest({
+        signingSecret,
+        headers: {
+          'x-slack-signature': `v0=${signature}`,
+          'x-slack-request-timestamp': timestamp,
+        },
+        body: rawBody,
+      });
+    });
+    it('should detect an invalid timestamp', async () => {
+      const timestamp = Math.floor(Date.now() / 1000) - 600; // 10 minutes
+      const rawBody = '{"foo":"bar"}';
+      const hmac = createHmac('sha256', signingSecret);
+      hmac.update(`v0:${timestamp}:${rawBody}`);
+      const signature = hmac.digest('hex');
+      try {
+        verifySlackRequest({
+          signingSecret,
+          headers: {
+            'x-slack-signature': `v0=${signature}`,
+            'x-slack-request-timestamp': timestamp,
+          },
+          body: rawBody,
+        });
+      } catch (e) {
+        assert.equal((e as any).message, 'Failed to verify authenticity: stale');
+      }
+    });
+    it('should detect an invalid signature', async () => {
+      const timestamp = Math.floor(Date.now() / 1000);
+      const rawBody = '{"foo":"bar"}';
+      try {
+        verifySlackRequest({
+          signingSecret,
+          headers: {
+            'x-slack-signature': 'v0=invalid-signature',
+            'x-slack-request-timestamp': timestamp,
+          },
+          body: rawBody,
+        });
+      } catch (e) {
+        assert.equal((e as any).message, 'Failed to verify authenticity: signature mismatch');
+      }
+    });
+  });
+
+  describe('isValidSlackRequest', async () => {
+    it('should judge a valid request', async () => {
+      const timestamp = Math.floor(Date.now() / 1000);
+      const rawBody = '{"foo":"bar"}';
+      const hmac = createHmac('sha256', signingSecret);
+      hmac.update(`v0:${timestamp}:${rawBody}`);
+      const signature = hmac.digest('hex');
+      assert.isTrue(isValidSlackRequest({
+        signingSecret,
+        headers: {
+          'x-slack-signature': `v0=${signature}`,
+          'x-slack-request-timestamp': timestamp,
+        },
+        body: rawBody,
+      }));
+    });
+    it('should detect an invalid timestamp', async () => {
+      const timestamp = Math.floor(Date.now() / 1000) - 600; // 10 minutes
+      const rawBody = '{"foo":"bar"}';
+      const hmac = createHmac('sha256', signingSecret);
+      hmac.update(`v0:${timestamp}:${rawBody}`);
+      const signature = hmac.digest('hex');
+      assert.isFalse(isValidSlackRequest({
+        signingSecret,
+        headers: {
+          'x-slack-signature': `v0=${signature}`,
+          'x-slack-request-timestamp': timestamp,
+        },
+        body: rawBody,
+      }));
+    });
+    it('should detect an invalid signature', async () => {
+      const timestamp = Math.floor(Date.now() / 1000);
+      const rawBody = '{"foo":"bar"}';
+      assert.isFalse(isValidSlackRequest({
+        signingSecret,
+        headers: {
+          'x-slack-signature': 'v0=invalid-signature',
+          'x-slack-request-timestamp': timestamp,
+        },
+        body: rawBody,
+      }));
+    });
+  });
+});

--- a/src/receivers/verify-request.ts
+++ b/src/receivers/verify-request.ts
@@ -1,10 +1,89 @@
 // Deprecated: this function will be removed in the near future. Use HTTPModuleFunctions instead.
 import { ConsoleLogger, Logger } from '@slack/logger';
+import { createHmac } from 'crypto';
+import tsscmp from 'tsscmp';
 import type { IncomingMessage, ServerResponse } from 'http';
 import { BufferedIncomingMessage } from './BufferedIncomingMessage';
 import { HTTPModuleFunctions, RequestVerificationOptions } from './HTTPModuleFunctions';
 
-const logger = new ConsoleLogger();
+// ------------------------------
+// HTTP module independent methods
+// ------------------------------
+
+const verifyErrorPrefix = 'Failed to verify authenticity';
+
+export interface SlackRequestVerificationOptions {
+  signingSecret: string;
+  body: string;
+  headers: {
+    'x-slack-signature': string,
+    'x-slack-request-timestamp': number,
+  };
+  nowMilliseconds?: number;
+  logger?: Logger;
+}
+
+/**
+ * Verifies the signature of an incoming request from Slack.
+ * If the requst is invalid, this method throws an exception with the erorr details.
+ */
+export function verifySlackRequest(options: SlackRequestVerificationOptions): void {
+  const requestTimestampSec = options.headers['x-slack-request-timestamp'];
+  const signature = options.headers['x-slack-signature'];
+  if (Number.isNaN(requestTimestampSec)) {
+    throw new Error(
+      `${verifyErrorPrefix}: header x-slack-request-timestamp did not have the expected type (${requestTimestampSec})`,
+    );
+  }
+
+  // Calculate time-dependent values
+  const nowMs = options.nowMilliseconds ?? Date.now();
+  const fiveMinutesAgoSec = Math.floor(nowMs / 1000) - 60 * 5;
+
+  // Enforce verification rules
+
+  // Rule 1: Check staleness
+  if (requestTimestampSec < fiveMinutesAgoSec) {
+    throw new Error(`${verifyErrorPrefix}: stale`);
+  }
+
+  // Rule 2: Check signature
+  // Separate parts of signature
+  const [signatureVersion, signatureHash] = signature.split('=');
+  // Only handle known versions
+  if (signatureVersion !== 'v0') {
+    throw new Error(`${verifyErrorPrefix}: unknown signature version`);
+  }
+  // Compute our own signature hash
+  const hmac = createHmac('sha256', options.signingSecret);
+  hmac.update(`${signatureVersion}:${requestTimestampSec}:${options.body}`);
+  const ourSignatureHash = hmac.digest('hex');
+  if (!signatureHash || !tsscmp(signatureHash, ourSignatureHash)) {
+    throw new Error(`${verifyErrorPrefix}: signature mismatch`);
+  }
+}
+
+/**
+ * Verifies the signature of an incoming request from Slack.
+ * If the requst is invalid, this method returns false.
+ */
+export function isValidSlackRequest(options: SlackRequestVerificationOptions): boolean {
+  try {
+    verifySlackRequest(options);
+    return true;
+  } catch (e) {
+    if (options.logger) {
+      options.logger.debug(`Signature verification error: ${e}`);
+    }
+  }
+  return false;
+}
+
+// ------------------------------
+// legacy methods (depreacted)
+// ------------------------------
+
+const consoleLogger = new ConsoleLogger();
 
 // Deprecated: this function will be removed in the near future. Use HTTPModuleFunctions instead.
 export interface VerifyOptions extends RequestVerificationOptions {
@@ -20,6 +99,6 @@ export async function verify(
   req: IncomingMessage,
   res?: ServerResponse,
 ): Promise<BufferedIncomingMessage> {
-  logger.warn('This method is deprecated. Use HTTPModuleFunctions.parseAndVerifyHTTPRequest(options, req, res) instead.');
+  consoleLogger.warn('This method is deprecated. Use HTTPModuleFunctions.parseAndVerifyHTTPRequest(options, req, res) instead.');
   return HTTPModuleFunctions.parseAndVerifyHTTPRequest(options, req, res);
 }


### PR DESCRIPTION
###  Summary

This pull request resolves #1385 

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).