### PR TITLE
Fix #1376 CustomRoute interface should be accessible from developers

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -37,6 +37,12 @@ export * from './types';
 export { ConversationStore, MemoryStore } from './conversation-store';
 
 export {
+  CustomRoute,
+  ReceiverRoutes,
+  buildReceiverRoutes,
+} from './receivers/custom-routes';
+
+export {
   WorkflowStep,
   WorkflowStepConfig,
   WorkflowStepEditMiddleware,

--- a/src/receivers/HTTPReceiver.ts
+++ b/src/receivers/HTTPReceiver.ts
@@ -15,7 +15,7 @@ import {
   HTTPReceiverDeferredRequestError,
   CodedError,
 } from '../errors';
-import { CustomRoute, prepareRoutes, ReceiverRoutes } from './custom-routes';
+import { CustomRoute, buildReceiverRoutes, ReceiverRoutes } from './custom-routes';
 import { StringIndexed } from '../types/helpers';
 import { BufferedIncomingMessage } from './BufferedIncomingMessage';
 import {
@@ -191,7 +191,7 @@ export default class HTTPReceiver implements Receiver {
       })();
     this.endpoints = Array.isArray(endpoints) ? endpoints : [endpoints];
     this.port = installerOptions?.port ? installerOptions.port : port;
-    this.routes = prepareRoutes(customRoutes);
+    this.routes = buildReceiverRoutes(customRoutes);
 
     // Verify redirect options if supplied, throws coded error if invalid
     verifyRedirectOpts({ redirectUri, redirectUriPath: installerOptions.redirectUriPath });

--- a/src/receivers/SocketModeReceiver.ts
+++ b/src/receivers/SocketModeReceiver.ts
@@ -9,7 +9,7 @@ import App from '../App';
 import { Receiver, ReceiverEvent } from '../types';
 import defaultRenderHtmlForInstallPath from './render-html-for-install-path';
 import { StringIndexed } from '../types/helpers';
-import { prepareRoutes, ReceiverRoutes } from './custom-routes';
+import { buildReceiverRoutes, ReceiverRoutes } from './custom-routes';
 import { verifyRedirectOpts } from './verify-redirect-opts';
 
 // TODO: we throw away the key names for endpoints, so maybe we should use this interface. is it better for migrations?
@@ -97,7 +97,7 @@ export default class SocketModeReceiver implements Receiver {
       defaultLogger.setLevel(logLevel);
       return defaultLogger;
     })();
-    this.routes = prepareRoutes(customRoutes);
+    this.routes = buildReceiverRoutes(customRoutes);
 
     // Verify redirect options if supplied, throws coded error if invalid
     verifyRedirectOpts({ redirectUri, redirectUriPath: installerOptions.redirectUriPath });

--- a/src/receivers/custom-routes.ts
+++ b/src/receivers/custom-routes.ts
@@ -13,7 +13,7 @@ export interface ReceiverRoutes {
   };
 }
 
-export function prepareRoutes(customRoutes: CustomRoute[]): ReceiverRoutes {
+export function buildReceiverRoutes(customRoutes: CustomRoute[]): ReceiverRoutes {
   const routes: ReceiverRoutes = {};
 
   validateCustomRoutes(customRoutes);


### PR DESCRIPTION
###  Summary

This pull request resolves #1376 by exporting the two types and one method from `./receivers/custom-routes`.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).