### PR TITLE
Fix #1357 port argument in App can be ignored when using a custom receiver

### DIFF
--- a/src/App.ts
+++ b/src/App.ts
@@ -1072,7 +1072,7 @@ export default class App {
   ): Receiver {
     if (port !== undefined && receiver !== undefined) {
       // Check https://github.com/slackapi/bolt-js/issues/1357 for the context
-      this.logger.info("You've passed both port and receiver. Some receivers may not respect the port passed in App constructor. If you encounter the unexpected behavior, check the appropriate way to pass port to the receiver.");
+      this.logger.info("You provided both port and receiver arguments. Some receivers may not respect the port passed to the App constructor. If you encounter any unexpected behavior, check the appropriate way to pass port to the receiver.");
     }
 
     if (receiver !== undefined) {

--- a/src/App.ts
+++ b/src/App.ts
@@ -1070,6 +1070,11 @@ export default class App {
     appToken?: string,
     logger?: Logger,
   ): Receiver {
+    if (port !== undefined && receiver !== undefined) {
+      // Check https://github.com/slackapi/bolt-js/issues/1357 for the context
+      this.logger.info("You've passed both port and receiver. Some receivers may not respect the port passed in App constructor. If you encounter the unexpected behavior, check the appropriate way to pass port to the receiver.");
+    }
+
     if (receiver !== undefined) {
       // Custom receiver supplied
       if (this.socketMode === true) {


### PR DESCRIPTION
###  Summary

This pull request resolves #1357 by adding info-level logging for mitigating confusion.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).