### PR TITLE
Add more error handlers to ExpressReceiver

### DIFF
--- a/src/receivers/HTTPModuleFunctions.ts
+++ b/src/receivers/HTTPModuleFunctions.ts
@@ -179,6 +179,10 @@ export class HTTPModuleFunctions {
     response.end();
   }
 
+  public static async defaultAsyncDispatchErrorHandler(args: ReceiverDispatchErrorHandlerArgs): Promise<void> {
+    return HTTPModuleFunctions.defaultDispatchErrorHandler(args);
+  }
+
   // The default processEventErrorHandler implementation:
   // Developers can customize this behavior by passing processEventErrorHandler to the constructor
   public static async defaultProcessEventErrorHandler(


### PR DESCRIPTION
###  Summary

As mentioned at https://github.com/slackapi/bolt-js/issues/1402, `ExpressReceiver` does not have the additional error handlers. This pull request adds those to the receiver.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).