### PR TITLE
Upgrade socket-mode dependency to the latest minor

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   "dependencies": {
     "@slack/logger": "^3.0.0",
     "@slack/oauth": "^2.5.1",
-    "@slack/socket-mode": "^1.2.0",
+    "@slack/socket-mode": "^1.3.0",
     "@slack/types": "^2.4.0",
     "@slack/web-api": "^6.7.1",
     "@types/express": "^4.16.1",


### PR DESCRIPTION
###  Summary

`@slack/socket-mode@1.3.0` is now available: https://github.com/slackapi/node-slack-sdk/releases/tag/%40slack%2Fsocket-mode%401.3.0

Since the version is pretty much stabler than the past versions, we should upgrade the oldest version to use along with.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).