### PR TITLE
removed nonexistent link from `Deployments` sidebar

### DIFF
--- a/docs/_includes/sidebar.html
+++ b/docs/_includes/sidebar.html
@@ -68,9 +68,7 @@
   {% assign deployments_sections = site.deployments | sort: "order" | where: "lang", page.lang %}
   {% if deployments_sections.size > 0 %}
     <ul class="sidebar-section">
-      <a href="{{ site.url | append: site.baseurl | append: localized_base_url }}/deployments">
         <li class="title">{{ site.t[page.lang].deployments }}</li>
-      </a>
       {% for section in deployments_sections %}
         <a href="{{ site.url | append: site.baseurl | append: localized_base_url }}/deployments/{{ section.slug }}">
           <li>{{section.title}}</li>

--- a/docs/_includes/sidebar.html
+++ b/docs/_includes/sidebar.html
@@ -67,7 +67,7 @@
 
   {% assign deployments_sections = site.deployments | sort: "order" | where: "lang", page.lang %}
   {% if deployments_sections.size > 0 %}
-    <ul class="sidebar-section">
+    <ul class="sidebar-section"> 
         <li class="title">{{ site.t[page.lang].deployments }}</li>
       {% for section in deployments_sections %}
         <a href="{{ site.url | append: site.baseurl | append: localized_base_url }}/deployments/{{ section.slug }}">


### PR DESCRIPTION
###  Summary

This PR removes a link from the `Deployments` sidebar. Removed the anchor tag which had a link that didn't exist. Issue #992 

### Requirements (place an `x` in each `[ ]`)

* [X] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [X] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).