### PR TITLE
Adding support for new user-change events with types

### DIFF
--- a/src/types/events/base-events.ts
+++ b/src/types/events/base-events.ts
@@ -885,11 +885,14 @@ export interface UserChangeEvent {
       status_text: string;
       status_text_canonical: string;
       status_emoji: string;
+      status_emoji_display_info: [];
       status_expiration: number;
       avatar_hash: string;
+      huddle_state?: string;
+      huddle_state_expiration_ts?: number;
       first_name: string;
       last_name: string;
-      email: string;
+      email?: string;
       image_original?: string;
       is_custom_image?: boolean;
       image_24: string;
@@ -923,7 +926,7 @@ export interface UserChangeEvent {
     is_invited_user?: boolean;
     has_2fa?: boolean;
     locale: string;
-    presence: string;
+    presence?: string;
     enterprise_user?: {
       id: string;
       enterprise_id: string;
@@ -932,12 +935,13 @@ export interface UserChangeEvent {
       is_owner: boolean;
       teams: string[];
     };
-    two_factor_type: string;
-    has_files: boolean;
-    is_workflow_bot: boolean;
-    who_can_share_contact_card: boolean;
+    two_factor_type?: string;
+    has_files?: boolean;
+    is_workflow_bot?: boolean;
+    who_can_share_contact_card: string;
   };
   cache_ts: number;
+  event_ts: string;
 }
 
 export interface UserHuddleChangedEvent {
@@ -963,11 +967,14 @@ export interface UserHuddleChangedEvent {
       status_text: string;
       status_text_canonical: string;
       status_emoji: string;
+      status_emoji_display_info: [];
       status_expiration: number;
       avatar_hash: string;
+      huddle_state: string;
+      huddle_state_expiration_ts: number;
       first_name: string;
       last_name: string;
-      email: string;
+      email?: string;
       image_original?: string;
       is_custom_image?: boolean;
       image_24: string;
@@ -1001,7 +1008,7 @@ export interface UserHuddleChangedEvent {
     is_invited_user?: boolean;
     has_2fa?: boolean;
     locale: string;
-    presence: string;
+    presence?: string;
     enterprise_user?: {
       id: string;
       enterprise_id: string;
@@ -1010,12 +1017,13 @@ export interface UserHuddleChangedEvent {
       is_owner: boolean;
       teams: string[];
     };
-    two_factor_type: string;
-    has_files: boolean;
-    is_workflow_bot: boolean;
-    who_can_share_contact_card: boolean;
+    two_factor_type?: string;
+    has_files?: boolean;
+    is_workflow_bot?: boolean;
+    who_can_share_contact_card: string;
   };
   cache_ts: number;
+  event_ts: string;
 }
 
 export interface UserProfileChangedEvent {
@@ -1041,11 +1049,14 @@ export interface UserProfileChangedEvent {
       status_text: string;
       status_text_canonical: string;
       status_emoji: string;
+      status_emoji_display_info: [];
       status_expiration: number;
       avatar_hash: string;
+      huddle_state: string;
+      huddle_state_expiration_ts: number;
       first_name: string;
       last_name: string;
-      email: string;
+      email?: string;
       image_original?: string;
       is_custom_image?: boolean;
       image_24: string;
@@ -1079,7 +1090,7 @@ export interface UserProfileChangedEvent {
     is_invited_user?: boolean;
     has_2fa?: boolean;
     locale: string;
-    presence: string;
+    presence?: string;
     enterprise_user?: {
       id: string;
       enterprise_id: string;
@@ -1088,12 +1099,13 @@ export interface UserProfileChangedEvent {
       is_owner: boolean;
       teams: string[];
     };
-    two_factor_type: string;
-    has_files: boolean;
-    is_workflow_bot: boolean;
-    who_can_share_contact_card: boolean;
+    two_factor_type?: string;
+    has_files?: boolean;
+    is_workflow_bot?: boolean;
+    who_can_share_contact_card: string;
   };
   cache_ts: number;
+  event_ts: string;
 }
 
 export interface UserStatusChangedEvent {
@@ -1119,11 +1131,12 @@ export interface UserStatusChangedEvent {
       status_text: string;
       status_text_canonical: string;
       status_emoji: string;
+      status_emoji_display_info: [],
       status_expiration: number;
       avatar_hash: string;
       first_name: string;
       last_name: string;
-      email: string;
+      email?: string;
       image_original?: string;
       is_custom_image?: boolean;
       image_24: string;
@@ -1157,7 +1170,7 @@ export interface UserStatusChangedEvent {
     is_invited_user?: boolean;
     has_2fa?: boolean;
     locale: string;
-    presence: string;
+    presence?: string;
     enterprise_user?: {
       id: string;
       enterprise_id: string;
@@ -1166,12 +1179,13 @@ export interface UserStatusChangedEvent {
       is_owner: boolean;
       teams: string[];
     };
-    two_factor_type: string;
-    has_files: boolean;
-    is_workflow_bot: boolean;
-    who_can_share_contact_card: boolean;
+    two_factor_type?: string;
+    has_files?: boolean;
+    is_workflow_bot?: boolean;
+    who_can_share_contact_card: string;
   };
   cache_ts: number;
+  event_ts: string;
 }
 
 export interface WorkflowDeletedEvent {

--- a/src/types/events/base-events.ts
+++ b/src/types/events/base-events.ts
@@ -76,6 +76,9 @@ export type SlackEvent =
   | TeamRenameEvent
   | TokensRevokedEvent
   | UserChangeEvent
+  | UserHuddleChangedEvent
+  | UserProfileChangedEvent
+  | UserStatusChangedEvent
   | WorkflowDeletedEvent
   | WorkflowPublishedEvent
   | WorkflowUnpublishedEvent
@@ -861,6 +864,240 @@ export interface TokensRevokedEvent {
 
 export interface UserChangeEvent {
   type: 'user_change';
+  user: {
+    id: string;
+    team_id: string;
+    name: string;
+    deleted: boolean;
+    color: string;
+    real_name: string;
+    tz: string;
+    tz_label: string;
+    tz_offset: number;
+    profile: {
+      title: string;
+      phone: string;
+      skype: string;
+      real_name: string;
+      real_name_normalized: string;
+      display_name: string;
+      display_name_normalized: string;
+      status_text: string;
+      status_text_canonical: string;
+      status_emoji: string;
+      status_expiration: number;
+      avatar_hash: string;
+      first_name: string;
+      last_name: string;
+      email: string;
+      image_original?: string;
+      is_custom_image?: boolean;
+      image_24: string;
+      image_32: string;
+      image_48: string;
+      image_72: string;
+      image_192: string;
+      image_512: string;
+      image_1024?: string;
+      team: string;
+      fields:
+      | {
+        [key: string]: {
+          value: string;
+          alt: string;
+        };
+      }
+      | []
+      | null;
+    };
+    is_admin: boolean;
+    is_owner: boolean;
+    is_primary_owner: boolean;
+    is_restricted: boolean;
+    is_ultra_restricted: boolean;
+    is_bot: boolean;
+    is_stranger?: boolean;
+    updated: number;
+    is_email_confirmed: boolean;
+    is_app_user: boolean;
+    is_invited_user?: boolean;
+    has_2fa?: boolean;
+    locale: string;
+    presence: string;
+    enterprise_user?: {
+      id: string;
+      enterprise_id: string;
+      enterprise_name: string;
+      is_admin: boolean;
+      is_owner: boolean;
+      teams: string[];
+    };
+    two_factor_type: string;
+    has_files: boolean;
+    is_workflow_bot: boolean;
+    who_can_share_contact_card: boolean;
+  };
+  cache_ts: number;
+}
+
+export interface UserHuddleChangedEvent {
+  type: 'user_huddle_changed';
+  user: {
+    id: string;
+    team_id: string;
+    name: string;
+    deleted: boolean;
+    color: string;
+    real_name: string;
+    tz: string;
+    tz_label: string;
+    tz_offset: number;
+    profile: {
+      title: string;
+      phone: string;
+      skype: string;
+      real_name: string;
+      real_name_normalized: string;
+      display_name: string;
+      display_name_normalized: string;
+      status_text: string;
+      status_text_canonical: string;
+      status_emoji: string;
+      status_expiration: number;
+      avatar_hash: string;
+      first_name: string;
+      last_name: string;
+      email: string;
+      image_original?: string;
+      is_custom_image?: boolean;
+      image_24: string;
+      image_32: string;
+      image_48: string;
+      image_72: string;
+      image_192: string;
+      image_512: string;
+      image_1024?: string;
+      team: string;
+      fields:
+      | {
+        [key: string]: {
+          value: string;
+          alt: string;
+        };
+      }
+      | []
+      | null;
+    };
+    is_admin: boolean;
+    is_owner: boolean;
+    is_primary_owner: boolean;
+    is_restricted: boolean;
+    is_ultra_restricted: boolean;
+    is_bot: boolean;
+    is_stranger?: boolean;
+    updated: number;
+    is_email_confirmed: boolean;
+    is_app_user: boolean;
+    is_invited_user?: boolean;
+    has_2fa?: boolean;
+    locale: string;
+    presence: string;
+    enterprise_user?: {
+      id: string;
+      enterprise_id: string;
+      enterprise_name: string;
+      is_admin: boolean;
+      is_owner: boolean;
+      teams: string[];
+    };
+    two_factor_type: string;
+    has_files: boolean;
+    is_workflow_bot: boolean;
+    who_can_share_contact_card: boolean;
+  };
+  cache_ts: number;
+}
+
+export interface UserProfileChangedEvent {
+  type: 'user_profile_changed';
+  user: {
+    id: string;
+    team_id: string;
+    name: string;
+    deleted: boolean;
+    color: string;
+    real_name: string;
+    tz: string;
+    tz_label: string;
+    tz_offset: number;
+    profile: {
+      title: string;
+      phone: string;
+      skype: string;
+      real_name: string;
+      real_name_normalized: string;
+      display_name: string;
+      display_name_normalized: string;
+      status_text: string;
+      status_text_canonical: string;
+      status_emoji: string;
+      status_expiration: number;
+      avatar_hash: string;
+      first_name: string;
+      last_name: string;
+      email: string;
+      image_original?: string;
+      is_custom_image?: boolean;
+      image_24: string;
+      image_32: string;
+      image_48: string;
+      image_72: string;
+      image_192: string;
+      image_512: string;
+      image_1024?: string;
+      team: string;
+      fields:
+      | {
+        [key: string]: {
+          value: string;
+          alt: string;
+        };
+      }
+      | []
+      | null;
+    };
+    is_admin: boolean;
+    is_owner: boolean;
+    is_primary_owner: boolean;
+    is_restricted: boolean;
+    is_ultra_restricted: boolean;
+    is_bot: boolean;
+    is_stranger?: boolean;
+    updated: number;
+    is_email_confirmed: boolean;
+    is_app_user: boolean;
+    is_invited_user?: boolean;
+    has_2fa?: boolean;
+    locale: string;
+    presence: string;
+    enterprise_user?: {
+      id: string;
+      enterprise_id: string;
+      enterprise_name: string;
+      is_admin: boolean;
+      is_owner: boolean;
+      teams: string[];
+    };
+    two_factor_type: string;
+    has_files: boolean;
+    is_workflow_bot: boolean;
+    who_can_share_contact_card: boolean;
+  };
+  cache_ts: number;
+}
+
+export interface UserStatusChangedEvent {
+  type: 'user_status_changed';
   user: {
     id: string;
     team_id: string;

--- a/src/types/events/base-events.ts
+++ b/src/types/events/base-events.ts
@@ -862,6 +862,12 @@ export interface TokensRevokedEvent {
 
 // NOTE: url_verification does not use the envelope, but its also not interesting for an app developer. its omitted.
 
+export interface StatusEmojiDisplayInfo {
+  emoji_name?: string;
+  display_alias?: string;
+  display_url?: string;
+}
+
 export interface UserChangeEvent {
   type: 'user_change';
   user: {
@@ -885,7 +891,7 @@ export interface UserChangeEvent {
       status_text: string;
       status_text_canonical: string;
       status_emoji: string;
-      status_emoji_display_info: [];
+      status_emoji_display_info: StatusEmojiDisplayInfo[];
       status_expiration: number;
       avatar_hash: string;
       huddle_state?: string;
@@ -967,7 +973,7 @@ export interface UserHuddleChangedEvent {
       status_text: string;
       status_text_canonical: string;
       status_emoji: string;
-      status_emoji_display_info: [];
+      status_emoji_display_info: StatusEmojiDisplayInfo[];
       status_expiration: number;
       avatar_hash: string;
       huddle_state: string;
@@ -1049,7 +1055,7 @@ export interface UserProfileChangedEvent {
       status_text: string;
       status_text_canonical: string;
       status_emoji: string;
-      status_emoji_display_info: [];
+      status_emoji_display_info: StatusEmojiDisplayInfo[];
       status_expiration: number;
       avatar_hash: string;
       huddle_state: string;
@@ -1131,7 +1137,7 @@ export interface UserStatusChangedEvent {
       status_text: string;
       status_text_canonical: string;
       status_emoji: string;
-      status_emoji_display_info: [],
+      status_emoji_display_info: StatusEmojiDisplayInfo[],
       status_expiration: number;
       avatar_hash: string;
       first_name: string;

--- a/types-tests/event.test-d.ts
+++ b/types-tests/event.test-d.ts
@@ -1,5 +1,5 @@
 import { expectNotType, expectType } from 'tsd';
-import { App, SlackEvent, AppMentionEvent, ReactionAddedEvent, ReactionRemovedEvent } from '..';
+import { App, SlackEvent, AppMentionEvent, ReactionAddedEvent, ReactionRemovedEvent, UserHuddleChangedEvent, UserProfileChangedEvent, UserStatusChangedEvent } from '..';
 
 const app = new App({ token: 'TOKEN', signingSecret: 'Signing Secret' });
 
@@ -22,6 +22,30 @@ expectType<void>(
 expectType<void>(
   app.event('reaction_removed', async ({ event }) => {
     expectType<ReactionRemovedEvent>(event);
+    expectNotType<SlackEvent>(event);
+    await Promise.resolve(event);
+  })
+);
+
+expectType<void>(
+  app.event('user_huddle_changed', async ({ event }) => {
+    expectType<UserHuddleChangedEvent>(event);
+    expectNotType<SlackEvent>(event);
+    await Promise.resolve(event);
+  })
+);
+
+expectType<void>(
+  app.event('user_profile_changed', async ({ event }) => {
+    expectType<UserProfileChangedEvent>(event);
+    expectNotType<SlackEvent>(event);
+    await Promise.resolve(event);
+  })
+);
+
+expectType<void>(
+  app.event('user_status_changed', async ({ event }) => {
+    expectType<UserStatusChangedEvent>(event);
     expectNotType<SlackEvent>(event);
     await Promise.resolve(event);
   })


### PR DESCRIPTION
These are UserHuddleChangedEvent, UserProfileChangedEvent, UserStatusChangedEvent.

I assume this is a minor version bump but maybe not? Not sure if a new type counts as an API addition? 🤔 