### PR TITLE
Use npx instead of npm exec to support npm 6+

### DIFF
--- a/src/cli/get-hooks.js
+++ b/src/cli/get-hooks.js
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
 console.log(JSON.stringify({
   hooks: {
-    'get-manifest': 'npm exec --package=@slack/bolt slack-cli-get-manifest',
-    start: 'npm exec --package=@slack/bolt slack-cli-start',
+    'get-manifest': 'npx -q --no-install -p @slack/bolt slack-cli-get-manifest',
+    start: 'npx -q --no-install -p @slack/bolt slack-cli-start',
   },
   config: {
     watch: {


### PR DESCRIPTION
`npm exec` is not available in npm v6 (thanks for catching this @srajiang !) so moving to use `npx` instead, which is supported in older versions of npm.

This PR should be used in conjunction with https://github.com/srajiang/bolt-js-starter-template/pull/2.