### PR TITLE
Cancel LambdaReceiver and HTTPResponseAck timeout

### DIFF
--- a/src/receivers/AwsLambdaReceiver.ts
+++ b/src/receivers/AwsLambdaReceiver.ts
@@ -172,6 +172,7 @@ export default class AwsLambdaReceiver implements Receiver {
             throw new ReceiverMultipleAckError();
           }
           isAcknowledged = true;
+          clearTimeout(noAckTimeoutId);
           if (typeof response === 'undefined' || response == null) {
             storedResponse = '';
           } else {
@@ -186,7 +187,6 @@ export default class AwsLambdaReceiver implements Receiver {
       // Send the event to the app for processing
       try {
         await this.app?.processEvent(event);
-        clearTimeout(noAckTimeoutId);
         if (storedResponse !== undefined) {
           if (typeof storedResponse === 'string') {
             return { statusCode: 200, body: storedResponse };
@@ -198,7 +198,6 @@ export default class AwsLambdaReceiver implements Receiver {
           };
         }
       } catch (err) {
-        clearTimeout(noAckTimeoutId);
         this.logger.error('An unhandled error occurred while Bolt processed an event');
         this.logger.debug(`Error details: ${err}, storedResponse: ${storedResponse}`);
         return { statusCode: 500, body: 'Internal server error' };

--- a/src/receivers/HTTPResponseAck.spec.ts
+++ b/src/receivers/HTTPResponseAck.spec.ts
@@ -39,6 +39,25 @@ describe('HTTPResponseAck', async () => {
       done();
     }, 2);
   });
+  it('should not trigger unhandledRequestHandler if acknowledged', (done) => {
+    const httpRequest = sinon.createStubInstance(IncomingMessage) as IncomingMessage;
+    const httpResponse: ServerResponse = sinon.createStubInstance(ServerResponse) as unknown as ServerResponse;
+    const spy = sinon.spy();
+    // eslint-disable-next-line no-new
+    const responseAck = new HTTPResponseAck({
+      logger: createFakeLogger(),
+      processBeforeResponse: false,
+      unhandledRequestTimeoutMillis: 1,
+      unhandledRequestHandler: spy,
+      httpRequest,
+      httpResponse,
+    });
+    responseAck.ack();
+    setTimeout(() => {
+      assert(spy.notCalled);
+      done();
+    }, 2);
+  });
   it('should throw an error if a bound Ack invocation was already acknowledged', async () => {
     const httpRequest = sinon.createStubInstance(IncomingMessage) as IncomingMessage;
     const httpResponse: ServerResponse = sinon.createStubInstance(ServerResponse) as unknown as ServerResponse;

--- a/src/receivers/HTTPResponseAck.ts
+++ b/src/receivers/HTTPResponseAck.ts
@@ -31,6 +31,8 @@ export class HTTPResponseAck {
 
   private httpResponse: ServerResponse;
 
+  private noAckTimeoutId?: NodeJS.Timeout;
+
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   public storedResponse: any | string | undefined;
 
@@ -43,11 +45,12 @@ export class HTTPResponseAck {
     this.httpRequest = args.httpRequest;
     this.httpResponse = args.httpResponse;
     this.storedResponse = undefined;
+    this.noAckTimeoutId = undefined;
     this.init();
   }
 
   private init(): HTTPResponseAck {
-    setTimeout(() => {
+    this.noAckTimeoutId = setTimeout(() => {
       if (!this.isAcknowledged) {
         this.unhandledRequestHandler({
           logger: this.logger,
@@ -84,5 +87,8 @@ export class HTTPResponseAck {
 
   public ack(): void {
     this.isAcknowledged = true;
+    if (this.noAckTimeoutId) {
+      clearTimeout(this.noAckTimeoutId);
+    }
   }
 }


### PR DESCRIPTION
###  Summary

Closes #1435. I am seeing my lambda functions remain open after finishing processing. Using the debugging tool `wtfnode` I am able to see that there is an open timeout with 3001 MS delay and this is the only one in the code. Happy to make edits.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).