### PR TITLE
Update link to reference documentation in App.ts

### DIFF
--- a/src/App.ts
+++ b/src/App.ts
@@ -653,7 +653,7 @@ export default class App {
   }
 
   // NOTE: this is what's called a convenience generic, so that types flow more easily without casting.
-  // https://basarat.gitbooks.io/typescript/docs/types/generics.html#design-pattern-convenience-generic
+  // https://web.archive.org/web/20210629110615/https://basarat.gitbook.io/typescript/type-system/generics#motivation-and-samples
   public action<Action extends SlackAction = SlackAction>(
     actionId: string | RegExp,
     ...listeners: Middleware<SlackActionMiddlewareArgs<Action>>[]


### PR DESCRIPTION
###  Summary
Existing link was moved. This change updates the URL to use the WebArchive to ensure data availability

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).