### PR TITLE
temporarily pin version of typescript to 4.6.4 due to build errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "source-map-support": "^0.5.12",
     "ts-node": "^8.1.0",
     "tsd": "^0.13.1",
-    "typescript": "^4.1.0"
+    "typescript": "4.6.4"
   },
   "tsd": {
     "directory": "types-tests"


### PR DESCRIPTION
###  Summary

temporarily pin version of typescript to 4.6.4 due to build errors with 4.7.2. We should ideally fix the breaks and support 4.7.2.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).