### PR TITLE
Apply bunch of workaround for TypeScript 4.7 compiler compatibility

### DIFF
--- a/src/App.ts
+++ b/src/App.ts
@@ -605,7 +605,8 @@ export default class App {
         return matchMessage(patternOrMiddleware);
       }
       return patternOrMiddleware;
-    });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    }) as any; // FIXME: workaround for TypeScript 4.7 breaking changes
 
     this.listeners.push([
       onlyEvents,
@@ -689,7 +690,9 @@ export default class App {
       return;
     }
 
-    this.listeners.push([onlyActions, matchConstraints(constraints), ...listeners] as Middleware<AnyMiddlewareArgs>[]);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const _listeners = listeners as any; // FIXME: workaround for TypeScript 4.7 breaking changes
+    this.listeners.push([onlyActions, matchConstraints(constraints), ..._listeners] as Middleware<AnyMiddlewareArgs>[]);
   }
 
   public command(commandName: string | RegExp, ...listeners: Middleware<SlackCommandMiddlewareArgs>[]): void {
@@ -714,7 +717,9 @@ export default class App {
       { action_id: actionIdOrConstraints } :
       actionIdOrConstraints;
 
-    this.listeners.push([onlyOptions, matchConstraints(constraints), ...listeners] as Middleware<AnyMiddlewareArgs>[]);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const _listeners = listeners as any; // FIXME: workaround for TypeScript 4.7 breaking changes
+    this.listeners.push([onlyOptions, matchConstraints(constraints), ..._listeners] as Middleware<AnyMiddlewareArgs>[]);
   }
 
   public view<ViewActionType extends SlackViewAction = SlackViewAction>(
@@ -746,10 +751,12 @@ export default class App {
       return;
     }
 
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const _listeners = listeners as any; // FIXME: workaround for TypeScript 4.7 breaking changes
     this.listeners.push([
       onlyViewActions,
       matchConstraints(constraints),
-      ...listeners,
+      ..._listeners,
     ] as Middleware<AnyMiddlewareArgs>[]);
   }
 

--- a/src/middleware/builtin.spec.ts
+++ b/src/middleware/builtin.spec.ts
@@ -500,7 +500,7 @@ describe('Built-in global middleware', () => {
     it('should detect valid requests', async () => {
       const payload: SlashCommand = { ...validCommandPayload };
       const fakeNext = sinon.fake();
-      await onlyCommands({
+      const args = {
         logger,
         client,
         payload,
@@ -511,14 +511,15 @@ describe('Built-in global middleware', () => {
         ack: noop,
         next: fakeNext,
         context: {},
-      });
+      };
+      await onlyCommands(args);
       assert.isTrue(fakeNext.called);
     });
 
     it('should skip other requests', async () => {
       const payload: any = {};
       const fakeNext = sinon.fake();
-      await onlyCommands({
+      const args = {
         logger,
         client,
         payload,
@@ -530,7 +531,8 @@ describe('Built-in global middleware', () => {
         ack: noop,
         next: fakeNext,
         context: {},
-      });
+      };
+      await onlyCommands(args);
       assert.isTrue(fakeNext.notCalled);
     });
   });
@@ -580,7 +582,9 @@ describe('Built-in global middleware', () => {
 
     it('should detect valid requests', async () => {
       const fakeNext = sinon.fake();
-      const args: SlackEventMiddlewareArgs<'app_mention'> & { event?: SlackEvent } = {
+      // FIXME: Removing type def here is a workaround for TypeScript 4.7 breaking changes
+      // TS2589: Type instantiation is excessively deep and possibly infinite.
+      const args /* : SlackEventMiddlewareArgs<'app_mention'> & { event?: SlackEvent } */ = {
         payload: appMentionEvent,
         event: appMentionEvent,
         message: null as never, // a bit hackey to satisfy TS compiler as 'null' cannot be assigned to type 'never'
@@ -596,20 +600,23 @@ describe('Built-in global middleware', () => {
         },
         say: sayNoop,
       };
-      await onlyEvents({
+      const allArgs = {
         logger,
         client,
         next: fakeNext,
         context: {},
         ...args,
-      });
+      };
+      // FIXME: Using any is a workaround for TypeScript 4.7 breaking changes
+      // TS2589: Type instantiation is excessively deep and possibly infinite.
+      await onlyEvents(allArgs as any);
       assert.isTrue(fakeNext.called);
     });
 
     it('should skip other requests', async () => {
       const payload: SlashCommand = { ...validCommandPayload };
       const fakeNext = sinon.fake();
-      await onlyEvents({
+      const args = {
         logger,
         client,
         payload,
@@ -620,7 +627,8 @@ describe('Built-in global middleware', () => {
         ack: noop,
         next: fakeNext,
         context: {},
-      });
+      };
+      await onlyEvents(args);
       assert.isFalse(fakeNext.called);
     });
   });
@@ -630,6 +638,8 @@ describe('Built-in global middleware', () => {
     const client = new WebClient(undefined, { logger, slackApiUrl: undefined });
 
     function buildArgs(): SlackEventMiddlewareArgs<'app_mention'> & { event?: SlackEvent } {
+      // FIXME: Using any here is a workaround for TypeScript 4.7 breaking changes
+      // TS2589: Type instantiation is excessively deep and possibly infinite.
       return {
         payload: appMentionEvent,
         event: appMentionEvent,
@@ -645,12 +655,14 @@ describe('Built-in global middleware', () => {
           authed_users: [],
         },
         say: sayNoop,
-      };
+      } as any;
     }
 
     function buildArgsAppHomeOpened(): SlackEventMiddlewareArgs<'app_home_opened'> & {
       event?: SlackEvent;
     } {
+      // FIXME: Using any here is a workaround for TypeScript 4.7 breaking changes
+      // TS2589: Type instantiation is excessively deep and possibly infinite.
       return {
         payload: appHomeOpenedEvent,
         event: appHomeOpenedEvent,
@@ -666,66 +678,86 @@ describe('Built-in global middleware', () => {
           authed_users: [],
         },
         say: sayNoop,
-      };
+      } as any;
     }
 
     it('should detect valid requests', async () => {
       const fakeNext = sinon.fake();
-      await matchEventType('app_mention')({
+      // FIXME: Using any here is a workaround for TypeScript 4.7 breaking changes
+      // TS2589: Type instantiation is excessively deep and possibly infinite.
+      const _args = buildArgs() as any;
+      const args = {
         logger,
         client,
         next: fakeNext,
         context: {},
-        ...buildArgs(),
-      });
+        ..._args,
+      };
+      await matchEventType('app_mention')(args);
       assert.isTrue(fakeNext.called);
     });
 
     it('should detect valid RegExp requests with app_mention', async () => {
       const fakeNext = sinon.fake();
-      await matchEventType(/app_mention|app_home_opened/)({
+      // FIXME: Using any here is a workaround for TypeScript 4.7 breaking changes
+      // TS2589: Type instantiation is excessively deep and possibly infinite.
+      const _args = buildArgs() as any;
+      const args = {
         logger,
         client,
         next: fakeNext,
         context: {},
-        ...buildArgs(),
-      });
+        ..._args,
+      };
+      await matchEventType(/app_mention|app_home_opened/)(args);
       assert.isTrue(fakeNext.called);
     });
 
     it('should detect valid RegExp requests with app_home_opened', async () => {
       const fakeNext = sinon.fake();
-      await matchEventType(/app_mention|app_home_opened/)({
+      // FIXME: Using any here is a workaround for TypeScript 4.7 breaking changes
+      // TS2589: Type instantiation is excessively deep and possibly infinite.
+      const _args = buildArgsAppHomeOpened() as any;
+      const args = {
         logger,
         client,
         next: fakeNext,
         context: {},
-        ...buildArgsAppHomeOpened(),
-      });
+        ..._args,
+      };
+      await matchEventType(/app_mention|app_home_opened/)(args);
       assert.isTrue(fakeNext.called);
     });
 
     it('should skip other requests', async () => {
       const fakeNext = sinon.fake();
-      await matchEventType('app_home_opened')({
+      // FIXME: Using any here is a workaround for TypeScript 4.7 breaking changes
+      // TS2589: Type instantiation is excessively deep and possibly infinite.
+      const _args = buildArgs() as any;
+      const args = {
         logger,
         client,
         next: fakeNext,
         context: {},
-        ...buildArgs(),
-      });
+        ..._args,
+      };
+      await matchEventType('app_home_opened')(args);
       assert.isFalse(fakeNext.called);
     });
 
     it('should skip other requests for RegExp', async () => {
       const fakeNext = sinon.fake();
-      await matchEventType(/foo/)({
+      // FIXME: Using any here is a workaround for TypeScript 4.7 breaking changes
+      // TS2589: Type instantiation is excessively deep and possibly infinite.
+      const _args = buildArgs() as any;
+      const args = {
         logger,
         client,
         next: fakeNext,
         context: {},
-        ...buildArgs(),
-      });
+        ..._args,
+      } as any;
+      await matchEventType(/foo/)(args);
       assert.isFalse(fakeNext.called);
     });
   });
@@ -735,6 +767,8 @@ describe('Built-in global middleware', () => {
     const client = new WebClient(undefined, { logger, slackApiUrl: undefined });
 
     function buildArgs(): SlackEventMiddlewareArgs<'message'> & { event?: SlackEvent } {
+      // FIXME: Using any here is a workaround for TypeScript 4.7 breaking changes
+      // TS2589: Type instantiation is excessively deep and possibly infinite.
       return {
         payload: botMessageEvent,
         event: botMessageEvent,
@@ -750,30 +784,38 @@ describe('Built-in global middleware', () => {
           authed_users: [],
         },
         say: sayNoop,
-      };
+      } as any;
     }
 
     it('should detect valid requests', async () => {
       const fakeNext = sinon.fake();
-      await subtype('bot_message')({
+      // FIXME: Using any here is a workaround for TypeScript 4.7 breaking changes
+      // TS2589: Type instantiation is excessively deep and possibly infinite.
+      const _args = buildArgs() as any;
+      const args = {
         logger,
         client,
         next: fakeNext,
         context: {},
-        ...buildArgs(),
-      });
+        ..._args,
+      };
+      await subtype('bot_message')(args);
       assert.isTrue(fakeNext.called);
     });
 
     it('should skip other requests', async () => {
       const fakeNext = sinon.fake();
-      await subtype('me_message')({
+      // FIXME: Using any here is a workaround for TypeScript 4.7 breaking changes
+      // TS2589: Type instantiation is excessively deep and possibly infinite.
+      const _args = buildArgs() as any;
+      const args = {
         logger,
         client,
         next: fakeNext,
         context: {},
-        ...buildArgs(),
-      });
+        ..._args,
+      };
+      await subtype('me_message')(args);
       assert.isFalse(fakeNext.called);
     });
   });

--- a/src/middleware/builtin.ts
+++ b/src/middleware/builtin.ts
@@ -32,12 +32,13 @@ import { ContextMissingPropertyError } from '../errors';
 /**
  * Middleware that filters out any event that isn't an action
  */
-export const onlyActions: Middleware<AnyMiddlewareArgs & { action?: SlackAction }> = async ({ action, next }) => {
+export const onlyActions: Middleware<AnyMiddlewareArgs & { action?: SlackAction }> = async (args) => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { action, next } = args as any; // FIXME: workaround for TypeScript 4.7 breaking changes
   // Filter out any non-actions
   if (action === undefined) {
     return;
   }
-
   // It matches so we should continue down this middleware listener chain
   await next();
 };
@@ -45,10 +46,9 @@ export const onlyActions: Middleware<AnyMiddlewareArgs & { action?: SlackAction 
 /**
  * Middleware that filters out any event that isn't a shortcut
  */
-export const onlyShortcuts: Middleware<AnyMiddlewareArgs & { shortcut?: SlackShortcut }> = async ({
-  shortcut,
-  next,
-}) => {
+export const onlyShortcuts: Middleware<AnyMiddlewareArgs & { shortcut?: SlackShortcut }> = async (args) => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { shortcut, next } = args as any; // FIXME: workaround for TypeScript 4.7 breaking changes
   // Filter out any non-shortcuts
   if (shortcut === undefined) {
     return;
@@ -61,7 +61,9 @@ export const onlyShortcuts: Middleware<AnyMiddlewareArgs & { shortcut?: SlackSho
 /**
  * Middleware that filters out any event that isn't a command
  */
-export const onlyCommands: Middleware<AnyMiddlewareArgs & { command?: SlashCommand }> = async ({ command, next }) => {
+export const onlyCommands: Middleware<AnyMiddlewareArgs & { command?: SlashCommand }> = async (args) => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { command, next } = args as any; // FIXME: workaround for TypeScript 4.7 breaking changes
   // Filter out any non-commands
   if (command === undefined) {
     return;
@@ -74,7 +76,9 @@ export const onlyCommands: Middleware<AnyMiddlewareArgs & { command?: SlashComma
 /**
  * Middleware that filters out any event that isn't an options
  */
-export const onlyOptions: Middleware<AnyMiddlewareArgs & { options?: SlackOptions }> = async ({ options, next }) => {
+export const onlyOptions: Middleware<AnyMiddlewareArgs & { options?: SlackOptions }> = async (args) => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { options, next } = args as any; // FIXME: workaround for TypeScript 4.7 breaking changes
   // Filter out any non-options requests
   if (options === undefined) {
     return;
@@ -87,7 +91,9 @@ export const onlyOptions: Middleware<AnyMiddlewareArgs & { options?: SlackOption
 /**
  * Middleware that filters out any event that isn't an event
  */
-export const onlyEvents: Middleware<AnyMiddlewareArgs & { event?: SlackEvent }> = async ({ event, next }) => {
+export const onlyEvents: Middleware<AnyMiddlewareArgs & { event?: SlackEvent }> = async (args) => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { event, next } = args as any; // FIXME: workaround for TypeScript 4.7 breaking changes
   // Filter out any non-events
   if (event === undefined) {
     return;
@@ -100,7 +106,9 @@ export const onlyEvents: Middleware<AnyMiddlewareArgs & { event?: SlackEvent }> 
 /**
  * Middleware that filters out any event that isn't a view_submission or view_closed event
  */
-export const onlyViewActions: Middleware<AnyMiddlewareArgs & { view?: ViewOutput }> = async ({ view, next }) => {
+export const onlyViewActions: Middleware<AnyMiddlewareArgs & { view?: ViewOutput }> = async (args) => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { view, next } = args as any; // FIXME: workaround for TypeScript 4.7 breaking changes
   // Filter out anything that doesn't have a view
   if (view === undefined) {
     return;


### PR DESCRIPTION
###  Summary

This pull request resolves the issue mentioned at https://github.com/slackapi/bolt-js/pull/1465 by a different approach. It seems that bolt-js's a bit complex type system was bitten by he behavior changes in TypeScript 4.7. This pull request uses any types to skip some of the type validations by TS compiler. These are unhappy workarounds so that we may want to remove these workarounds in future TS versions.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).