### PR TITLE
Fix #1472 say argument does not exist for pin_* events in TS

### DIFF
--- a/src/types/events/base-events.ts
+++ b/src/types/events/base-events.ts
@@ -585,12 +585,38 @@ export interface MemberLeftChannelEvent {
 
 export type MessageEvent = AllMessageEvents;
 
+export interface PinnedMessageItem {
+  client_msg_id?: string;
+  type: string;
+  app_id?: string;
+  team?: string;
+  user: string;
+  bot_id?: string;
+  bot_profile?: BotProfile;
+  text?: string;
+  attachments?: MessageAttachment[];
+  blocks?: (KnownBlock | Block)[];
+  pinned_to?: string[];
+  permalink: string;
+}
+export interface PinnedFileItem {
+  id: string;
+  // TODO: Add all other possible properties here
+}
+
+export interface PinnedItem {
+  type: string;
+  channel: string;
+  created_by: string;
+  created: number;
+  message?: PinnedMessageItem;
+  file?: PinnedFileItem;
+}
 export interface PinAddedEvent {
   type: 'pin_added';
   user: string;
   channel_id: string;
-  // TODO: incomplete, should be message | file | file comment (deprecated)
-  item: Record<string, unknown>;
+  item: PinnedItem;
   item_user: string;
   pin_count: string;
   pinned_info: {
@@ -600,13 +626,11 @@ export interface PinAddedEvent {
   };
   event_ts: string;
 }
-
 export interface PinRemovedEvent {
   type: 'pin_removed';
   user: string;
   channel_id: string;
-  // TODO: incomplete, should be message | file | file comment (deprecated)
-  item: Record<string, unknown>;
+  item: PinnedItem;
   item_user: string;
   pin_count: string;
   pinned_info: {

--- a/types-tests/event.test-d.ts
+++ b/types-tests/event.test-d.ts
@@ -1,5 +1,5 @@
 import { expectNotType, expectType } from 'tsd';
-import { App, SlackEvent, AppMentionEvent, ReactionAddedEvent, ReactionRemovedEvent, UserHuddleChangedEvent, UserProfileChangedEvent, UserStatusChangedEvent } from '..';
+import { App, SlackEvent, AppMentionEvent, ReactionAddedEvent, ReactionRemovedEvent, UserHuddleChangedEvent, UserProfileChangedEvent, UserStatusChangedEvent, PinAddedEvent, SayFn, PinRemovedEvent } from '..';
 
 const app = new App({ token: 'TOKEN', signingSecret: 'Signing Secret' });
 
@@ -47,6 +47,22 @@ expectType<void>(
   app.event('user_status_changed', async ({ event }) => {
     expectType<UserStatusChangedEvent>(event);
     expectNotType<SlackEvent>(event);
+    await Promise.resolve(event);
+  })
+);
+
+expectType<void>(
+  app.event('pin_added', async ({ say, event }) => {
+    expectType<SayFn>(say);
+    expectType<PinAddedEvent>(event);
+    await Promise.resolve(event);
+  })
+);
+
+expectType<void>(
+  app.event('pin_removed', async ({ say, event }) => {
+    expectType<SayFn>(say);
+    expectType<PinRemovedEvent>(event);
     await Promise.resolve(event);
   })
 );


### PR DESCRIPTION
###  Summary

This pull request resolves #1472. The current pin_added / pin_removed event data types are not compatible with https://github.com/slackapi/bolt-js/blob/%40slack/bolt%403.11.1/src/types/events/index.ts#L81-L83

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).