### PR TITLE
Fix say absence in TS for reaction_ events (ref #1473)

### DIFF
--- a/src/types/events/base-events.ts
+++ b/src/types/events/base-events.ts
@@ -650,6 +650,7 @@ export interface ReactionMessageItem {
 
 export interface ReactionFileItem {
   type: 'file';
+  channel: string;
   file: string;
 }
 
@@ -657,6 +658,7 @@ export interface ReactionFileItem {
 // See https://api.slack.com/changelog/2018-05-file-threads-soon-tread
 export interface ReactionFileCommentItem {
   type: 'file_comment';
+  channel: string;
   file_comment: string;
   file: string;
 }

--- a/types-tests/event.test-d.ts
+++ b/types-tests/event.test-d.ts
@@ -66,3 +66,17 @@ expectType<void>(
     await Promise.resolve(event);
   })
 );
+
+expectType<void>(
+  app.event('reaction_added', async ({ say, event }) => {
+    expectType<SayFn>(say);
+    await Promise.resolve(event);
+  })
+);
+
+expectType<void>(
+  app.event('reaction_removed', async ({ say, event }) => {
+    expectType<SayFn>(say);
+    await Promise.resolve(event);
+  })
+);


### PR DESCRIPTION
###  Summary

This pull request resolves the issue mentioned at https://github.com/slackapi/bolt-js/pull/1473#issuecomment-1146061559

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).