### PR TITLE
Fix #1478 ack() is not accessible in global middleware in TypeScript

### DIFF
--- a/src/types/events/index.ts
+++ b/src/types/events/index.ts
@@ -32,6 +32,8 @@ export interface SlackEventMiddlewareArgs<EventType extends string = string> {
   message: EventType extends 'message' ? this['payload'] : never;
   body: EnvelopedEvent<this['payload']>;
   say: WhenEventHasChannelContext<this['payload'], SayFn>;
+  // Add `ack` as undefined for global middleware in TypeScript
+  ack: undefined;
 }
 
 /**

--- a/types-tests/middleware.test-d.ts
+++ b/types-tests/middleware.test-d.ts
@@ -10,3 +10,10 @@ app.use(async (args) => {
 app.use(async (args) => {
   onlyCommands(args);
 });
+app.use(async ({ ack, next }) => {
+  if (ack) {
+    await ack();
+    return;
+  }
+  await next();
+});


### PR DESCRIPTION
###  Summary

This pull request resolves #1478. The type of `ack` in app.use arguments had been AckFn | never. This pull request removes the pattern of never, so that the type is now AckFn | undefined.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).