### PR TITLE
Fix #1488 Incorrect types with ViewUpdateResponseAction and ViewPushResponseAction

### DIFF
--- a/src/App-routes.spec.ts
+++ b/src/App-routes.spec.ts
@@ -1013,6 +1013,26 @@ describe('App event routing', () => {
       assertMiddlewaresNotCalled();
     });
   });
+
+  describe('Quick type compatibility checks', () => {
+    it('app.view ack() method can compile with minimum inputs', async () => {
+      const MockApp = await importApp(buildOverrides([withNoopWebClient()]));
+      const app = new MockApp({ receiver: fakeReceiver, authorize: sinon.fake.resolves(dummyAuthorizationResult) });
+      app.view('callback_id', async ({ ack }) => {
+        await ack({
+          response_action: 'push',
+          view: {
+            type: 'modal',
+            title: {
+              type: 'plain_text',
+              text: 'Title',
+            },
+            blocks: [],
+          },
+        });
+      });
+    });
+  });
 });
 
 /* Testing Harness */

--- a/src/types/view/index.ts
+++ b/src/types/view/index.ts
@@ -1,4 +1,4 @@
-import { Block, KnownBlock, PlainTextElement } from '@slack/types';
+import { Block, KnownBlock, PlainTextElement, View } from '@slack/types';
 import { AckFn, RespondFn } from '../utilities';
 
 /**
@@ -62,7 +62,7 @@ export interface ViewSubmitAction {
     id: string;
     name: string;
   };
-  response_urls: ViewResponseUrl[];
+  response_urls?: ViewResponseUrl[];
 }
 
 /**
@@ -103,7 +103,7 @@ export interface ViewClosedAction {
 
 export interface ViewWorkflowStepSubmitAction extends ViewSubmitAction {
   trigger_id: string;
-  response_urls: ViewResponseUrl[];
+  response_urls?: ViewResponseUrl[];
   workflow_step: {
     workflow_step_edit_id: string;
     workflow_id: string;
@@ -174,12 +174,12 @@ export interface ViewOutput {
 
 export interface ViewUpdateResponseAction {
   response_action: 'update';
-  view: ViewOutput;
+  view: View;
 }
 
 export interface ViewPushResponseAction {
   response_action: 'push';
-  view: ViewOutput;
+  view: View;
 }
 
 export interface ViewClearResponseAction {


### PR DESCRIPTION
###  Summary

This pull request resolves #1488 

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).