### PR TITLE
Allow passing additional types for Global and Middleware Context

### DIFF
--- a/src/App-context-types.spec.ts
+++ b/src/App-context-types.spec.ts
@@ -4,7 +4,9 @@ import { mergeOverrides, Override } from './test-helpers';
 import { OptionsSource, Receiver, ReceiverEvent, SlackAction, SlackShortcut, SlackViewAction } from './types';
 import App, { ActionConstraints, ShortcutConstraints } from './App';
 
-type IfAny<T, Y, N> = 0 extends (1 & T) ? Y : N;
+// 0 should not be able to extend (1 & <SomeType>), if it does, SomeType must be Any
+// https://stackoverflow.com/a/55541672
+type IfAnyThenElse<TypeToCheck, Then, Else> = 0 extends (1 & TypeToCheck) ? Then : Else;
 interface valid { valid: boolean }
 interface GlobalContext { globalContextKey: number }
 interface MiddlewareContext { middlewareContextKey: number }
@@ -42,16 +44,16 @@ describe('context typing', () => {
 
     // Use - Global Context
     app.use(async ({ context }) => {
-      const check = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      const check = {} as IfAnyThenElse<typeof context['globalContextKey'], never, valid>;
       check.valid = true;
     });
 
     // Use - Global & Middleware Context
     app.use<MiddlewareContext>(async ({ context }) => {
-      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      const globalCheck = {} as IfAnyThenElse<typeof context['globalContextKey'], never, valid>;
       globalCheck.valid = true;
 
-      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      const middlewareCheck = {} as IfAnyThenElse<typeof context['middlewareContextKey'], never, valid>;
       middlewareCheck.valid = true;
     });
   });
@@ -62,7 +64,7 @@ describe('context typing', () => {
 
     // Use - Middleware Context
     app.use<MiddlewareContext>(async ({ context }) => {
-      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      const middlewareCheck = {} as IfAnyThenElse<typeof context['middlewareContextKey'], never, valid>;
       middlewareCheck.valid = true;
     });
   });
@@ -73,184 +75,184 @@ describe('context typing', () => {
 
     // Message passes global context to all middleware
     app.message(async ({ context }) => {
-      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      const globalCheck = {} as IfAnyThenElse<typeof context['globalContextKey'], never, valid>;
       globalCheck.valid = true;
     }, async ({ context }) => {
-      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      const globalCheck = {} as IfAnyThenElse<typeof context['globalContextKey'], never, valid>;
       globalCheck.valid = true;
     });
 
     // Message passes global and middleware context to all middleware
     app.message<MiddlewareContext>(async ({ context }) => {
-      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      const globalCheck = {} as IfAnyThenElse<typeof context['globalContextKey'], never, valid>;
       globalCheck.valid = true;
 
-      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      const middlewareCheck = {} as IfAnyThenElse<typeof context['middlewareContextKey'], never, valid>;
       middlewareCheck.valid = true;
     }, async ({ context }) => {
-      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      const globalCheck = {} as IfAnyThenElse<typeof context['globalContextKey'], never, valid>;
       globalCheck.valid = true;
 
-      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      const middlewareCheck = {} as IfAnyThenElse<typeof context['middlewareContextKey'], never, valid>;
       middlewareCheck.valid = true;
     });
 
     // Message passes global context when using RegExp pattern and passes context to all middleware
     app.message(/^regex/, async ({ context }) => {
-      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      const globalCheck = {} as IfAnyThenElse<typeof context['globalContextKey'], never, valid>;
       globalCheck.valid = true;
     }, async ({ context }) => {
-      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      const globalCheck = {} as IfAnyThenElse<typeof context['globalContextKey'], never, valid>;
       globalCheck.valid = true;
     });
 
     // Message passes global context when using string pattern and passes context to all middleware
     app.message('string', async ({ context }) => {
-      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      const globalCheck = {} as IfAnyThenElse<typeof context['globalContextKey'], never, valid>;
       globalCheck.valid = true;
     }, async ({ context }) => {
-      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      const globalCheck = {} as IfAnyThenElse<typeof context['globalContextKey'], never, valid>;
       globalCheck.valid = true;
     });
 
     // Message passes global and middleware context when using RegExp patterns and passes context to all middleware
     app.message<MiddlewareContext>(/^regex/, async ({ context }) => {
-      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      const globalCheck = {} as IfAnyThenElse<typeof context['globalContextKey'], never, valid>;
       globalCheck.valid = true;
 
-      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      const middlewareCheck = {} as IfAnyThenElse<typeof context['middlewareContextKey'], never, valid>;
       middlewareCheck.valid = true;
     }, async ({ context }) => {
-      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      const globalCheck = {} as IfAnyThenElse<typeof context['globalContextKey'], never, valid>;
       globalCheck.valid = true;
 
-      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      const middlewareCheck = {} as IfAnyThenElse<typeof context['middlewareContextKey'], never, valid>;
       middlewareCheck.valid = true;
     });
 
     // Message passes global and middleware context when using String patterns and passes context to all middleware
     app.message<MiddlewareContext>('string', async ({ context }) => {
-      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      const globalCheck = {} as IfAnyThenElse<typeof context['globalContextKey'], never, valid>;
       globalCheck.valid = true;
 
-      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      const middlewareCheck = {} as IfAnyThenElse<typeof context['middlewareContextKey'], never, valid>;
       middlewareCheck.valid = true;
     }, async ({ context }) => {
-      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      const globalCheck = {} as IfAnyThenElse<typeof context['globalContextKey'], never, valid>;
       globalCheck.valid = true;
 
-      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      const middlewareCheck = {} as IfAnyThenElse<typeof context['middlewareContextKey'], never, valid>;
       middlewareCheck.valid = true;
     });
 
     // Message filter with RegExp pattern is aware of global context and passes context to all middleware
     app.message(async ({ context }) => {
-      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      const globalCheck = {} as IfAnyThenElse<typeof context['globalContextKey'], never, valid>;
       globalCheck.valid = true;
     }, /^regex/, async ({ context }) => {
-      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      const globalCheck = {} as IfAnyThenElse<typeof context['globalContextKey'], never, valid>;
       globalCheck.valid = true;
     }, async ({ context }) => {
-      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      const globalCheck = {} as IfAnyThenElse<typeof context['globalContextKey'], never, valid>;
       globalCheck.valid = true;
     });
 
     // Message filter with String pattern is aware of global context and passes context to all middleware
     app.message(async ({ context }) => {
-      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      const globalCheck = {} as IfAnyThenElse<typeof context['globalContextKey'], never, valid>;
       globalCheck.valid = true;
     }, 'string', async ({ context }) => {
-      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      const globalCheck = {} as IfAnyThenElse<typeof context['globalContextKey'], never, valid>;
       globalCheck.valid = true;
     }, async ({ context }) => {
-      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      const globalCheck = {} as IfAnyThenElse<typeof context['globalContextKey'], never, valid>;
       globalCheck.valid = true;
     });
 
     // Message filter with RegExp pattern is aware of global and middleware context and passes context to all middleware
     app.message<MiddlewareContext>(async ({ context }) => {
-      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      const globalCheck = {} as IfAnyThenElse<typeof context['globalContextKey'], never, valid>;
       globalCheck.valid = true;
 
-      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      const middlewareCheck = {} as IfAnyThenElse<typeof context['middlewareContextKey'], never, valid>;
       middlewareCheck.valid = true;
     }, /^regex/, async ({ context }) => {
-      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      const globalCheck = {} as IfAnyThenElse<typeof context['globalContextKey'], never, valid>;
       globalCheck.valid = true;
 
-      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      const middlewareCheck = {} as IfAnyThenElse<typeof context['middlewareContextKey'], never, valid>;
       middlewareCheck.valid = true;
     }, async ({ context }) => {
-      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      const globalCheck = {} as IfAnyThenElse<typeof context['globalContextKey'], never, valid>;
       globalCheck.valid = true;
 
-      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      const middlewareCheck = {} as IfAnyThenElse<typeof context['middlewareContextKey'], never, valid>;
       middlewareCheck.valid = true;
     });
 
     // Message filter with String pattern is aware of global and middleware context and passes context to all middleware
     app.message<MiddlewareContext>(async ({ context }) => {
-      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      const globalCheck = {} as IfAnyThenElse<typeof context['globalContextKey'], never, valid>;
       globalCheck.valid = true;
 
-      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      const middlewareCheck = {} as IfAnyThenElse<typeof context['middlewareContextKey'], never, valid>;
       middlewareCheck.valid = true;
     }, 'string', async ({ context }) => {
-      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      const globalCheck = {} as IfAnyThenElse<typeof context['globalContextKey'], never, valid>;
       globalCheck.valid = true;
 
-      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      const middlewareCheck = {} as IfAnyThenElse<typeof context['middlewareContextKey'], never, valid>;
       middlewareCheck.valid = true;
     }, async ({ context }) => {
-      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      const globalCheck = {} as IfAnyThenElse<typeof context['globalContextKey'], never, valid>;
       globalCheck.valid = true;
 
-      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      const middlewareCheck = {} as IfAnyThenElse<typeof context['middlewareContextKey'], never, valid>;
       middlewareCheck.valid = true;
     });
 
     // Message filter is aware of global context and passes context to all middleware
     app.message(async ({ context }) => {
-      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      const globalCheck = {} as IfAnyThenElse<typeof context['globalContextKey'], never, valid>;
       globalCheck.valid = true;
     }, async ({ context }) => {
-      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      const globalCheck = {} as IfAnyThenElse<typeof context['globalContextKey'], never, valid>;
       globalCheck.valid = true;
     }, async ({ context }) => {
-      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      const globalCheck = {} as IfAnyThenElse<typeof context['globalContextKey'], never, valid>;
       globalCheck.valid = true;
     });
 
     // Message filter is aware of global and middleware context and passes context to all middleware
     app.message<MiddlewareContext>(async ({ context }) => {
-      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      const globalCheck = {} as IfAnyThenElse<typeof context['globalContextKey'], never, valid>;
       globalCheck.valid = true;
 
-      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      const middlewareCheck = {} as IfAnyThenElse<typeof context['middlewareContextKey'], never, valid>;
       middlewareCheck.valid = true;
     }, async ({ context }) => {
-      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      const globalCheck = {} as IfAnyThenElse<typeof context['globalContextKey'], never, valid>;
       globalCheck.valid = true;
 
-      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      const middlewareCheck = {} as IfAnyThenElse<typeof context['middlewareContextKey'], never, valid>;
       middlewareCheck.valid = true;
     }, async ({ context }) => {
-      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      const globalCheck = {} as IfAnyThenElse<typeof context['globalContextKey'], never, valid>;
       globalCheck.valid = true;
 
-      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      const middlewareCheck = {} as IfAnyThenElse<typeof context['middlewareContextKey'], never, valid>;
       middlewareCheck.valid = true;
     });
 
     // Message with mixed patterns and middleware is aware of global context passes context to all middleware
     app.message('test_string', async ({ context }) => {
-      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      const globalCheck = {} as IfAnyThenElse<typeof context['globalContextKey'], never, valid>;
       globalCheck.valid = true;
     }, 'test_string_2', async ({ context }) => {
-      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      const globalCheck = {} as IfAnyThenElse<typeof context['globalContextKey'], never, valid>;
       globalCheck.valid = true;
     }, /regex/, async ({ context }) => {
-      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      const globalCheck = {} as IfAnyThenElse<typeof context['globalContextKey'], never, valid>;
       globalCheck.valid = true;
     });
 
@@ -259,22 +261,22 @@ describe('context typing', () => {
     * middleware context and passes context to all middleware
     */
     app.message<MiddlewareContext>('test_string', async ({ context }) => {
-      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      const globalCheck = {} as IfAnyThenElse<typeof context['globalContextKey'], never, valid>;
       globalCheck.valid = true;
 
-      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      const middlewareCheck = {} as IfAnyThenElse<typeof context['middlewareContextKey'], never, valid>;
       middlewareCheck.valid = true;
     }, 'test_string_2', async ({ context }) => {
-      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      const globalCheck = {} as IfAnyThenElse<typeof context['globalContextKey'], never, valid>;
       globalCheck.valid = true;
 
-      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      const middlewareCheck = {} as IfAnyThenElse<typeof context['middlewareContextKey'], never, valid>;
       middlewareCheck.valid = true;
     }, /regex/, async ({ context }) => {
-      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      const globalCheck = {} as IfAnyThenElse<typeof context['globalContextKey'], never, valid>;
       globalCheck.valid = true;
 
-      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      const middlewareCheck = {} as IfAnyThenElse<typeof context['middlewareContextKey'], never, valid>;
       middlewareCheck.valid = true;
     });
   });
@@ -285,55 +287,55 @@ describe('context typing', () => {
 
     // Message passes middleware context to all middleware
     app.message<MiddlewareContext>(async ({ context }) => {
-      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      const middlewareCheck = {} as IfAnyThenElse<typeof context['middlewareContextKey'], never, valid>;
       middlewareCheck.valid = true;
     }, async ({ context }) => {
-      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      const middlewareCheck = {} as IfAnyThenElse<typeof context['middlewareContextKey'], never, valid>;
       middlewareCheck.valid = true;
     });
 
     // Message passes middleware context when using RegExp patterns and passes context to all middleware
     app.message<MiddlewareContext>(/^regex/, async ({ context }) => {
-      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      const middlewareCheck = {} as IfAnyThenElse<typeof context['middlewareContextKey'], never, valid>;
       middlewareCheck.valid = true;
     }, async ({ context }) => {
-      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      const middlewareCheck = {} as IfAnyThenElse<typeof context['middlewareContextKey'], never, valid>;
       middlewareCheck.valid = true;
     }, async ({ context }) => {
-      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      const middlewareCheck = {} as IfAnyThenElse<typeof context['middlewareContextKey'], never, valid>;
       middlewareCheck.valid = true;
     });
 
     // Message passes middleware context when using String patterns and passes context to all middleware
     app.message<MiddlewareContext>('string', async ({ context }) => {
-      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      const middlewareCheck = {} as IfAnyThenElse<typeof context['middlewareContextKey'], never, valid>;
       middlewareCheck.valid = true;
     }, async ({ context }) => {
-      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      const middlewareCheck = {} as IfAnyThenElse<typeof context['middlewareContextKey'], never, valid>;
       middlewareCheck.valid = true;
     });
 
     // Message filter with RegExp pattern is aware of middleware context and passes context to all middleware
     app.message<MiddlewareContext>(async ({ context }) => {
-      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      const middlewareCheck = {} as IfAnyThenElse<typeof context['middlewareContextKey'], never, valid>;
       middlewareCheck.valid = true;
     }, /^regex/, async ({ context }) => {
-      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      const middlewareCheck = {} as IfAnyThenElse<typeof context['middlewareContextKey'], never, valid>;
       middlewareCheck.valid = true;
     }, async ({ context }) => {
-      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      const middlewareCheck = {} as IfAnyThenElse<typeof context['middlewareContextKey'], never, valid>;
       middlewareCheck.valid = true;
     });
 
     // Message filter is aware of middleware context and passes context to all middleware
     app.message<MiddlewareContext>(async ({ context }) => {
-      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      const middlewareCheck = {} as IfAnyThenElse<typeof context['middlewareContextKey'], never, valid>;
       middlewareCheck.valid = true;
     }, async ({ context }) => {
-      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      const middlewareCheck = {} as IfAnyThenElse<typeof context['middlewareContextKey'], never, valid>;
       middlewareCheck.valid = true;
     }, async ({ context }) => {
-      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      const middlewareCheck = {} as IfAnyThenElse<typeof context['middlewareContextKey'], never, valid>;
       middlewareCheck.valid = true;
     });
 
@@ -342,13 +344,13 @@ describe('context typing', () => {
     * middleware context and passes context to all middleware
     */
     app.message<MiddlewareContext>('test_string', async ({ context }) => {
-      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      const middlewareCheck = {} as IfAnyThenElse<typeof context['middlewareContextKey'], never, valid>;
       middlewareCheck.valid = true;
     }, 'test_string_2', async ({ context }) => {
-      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      const middlewareCheck = {} as IfAnyThenElse<typeof context['middlewareContextKey'], never, valid>;
       middlewareCheck.valid = true;
     }, /regex/, async ({ context }) => {
-      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      const middlewareCheck = {} as IfAnyThenElse<typeof context['middlewareContextKey'], never, valid>;
       middlewareCheck.valid = true;
     });
   });
@@ -359,73 +361,73 @@ describe('context typing', () => {
 
     // Shortcut with RegExp callbackId is aware of global context and passes context to all middleware
     app.shortcut(/callback_id/, async ({ context }) => {
-      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      const globalCheck = {} as IfAnyThenElse<typeof context['globalContextKey'], never, valid>;
       globalCheck.valid = true;
     }, async ({ context }) => {
-      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      const globalCheck = {} as IfAnyThenElse<typeof context['globalContextKey'], never, valid>;
       globalCheck.valid = true;
     });
 
     // Shortcut with string callbackId is aware of global context and passes context to all middleware
     app.shortcut('callback_id', async ({ context }) => {
-      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      const globalCheck = {} as IfAnyThenElse<typeof context['globalContextKey'], never, valid>;
       globalCheck.valid = true;
     }, async ({ context }) => {
-      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      const globalCheck = {} as IfAnyThenElse<typeof context['globalContextKey'], never, valid>;
       globalCheck.valid = true;
     });
 
     // Shortcut with RegExp callbackId is aware of global and middleware context and passes context to all middleware
     app.shortcut<SlackShortcut, MiddlewareContext>(/callback_id/, async ({ context }) => {
-      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      const globalCheck = {} as IfAnyThenElse<typeof context['globalContextKey'], never, valid>;
       globalCheck.valid = true;
 
-      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      const middlewareCheck = {} as IfAnyThenElse<typeof context['middlewareContextKey'], never, valid>;
       middlewareCheck.valid = true;
     }, async ({ context }) => {
-      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      const globalCheck = {} as IfAnyThenElse<typeof context['globalContextKey'], never, valid>;
       globalCheck.valid = true;
 
-      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      const middlewareCheck = {} as IfAnyThenElse<typeof context['middlewareContextKey'], never, valid>;
       middlewareCheck.valid = true;
     });
 
     // Shortcut with string callbackId is aware of global and middleware context and passes context to all middleware
     app.shortcut<SlackShortcut, MiddlewareContext>('callback_id', async ({ context }) => {
-      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      const globalCheck = {} as IfAnyThenElse<typeof context['globalContextKey'], never, valid>;
       globalCheck.valid = true;
 
-      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      const middlewareCheck = {} as IfAnyThenElse<typeof context['middlewareContextKey'], never, valid>;
       middlewareCheck.valid = true;
     }, async ({ context }) => {
-      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      const globalCheck = {} as IfAnyThenElse<typeof context['globalContextKey'], never, valid>;
       globalCheck.valid = true;
 
-      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      const middlewareCheck = {} as IfAnyThenElse<typeof context['middlewareContextKey'], never, valid>;
       middlewareCheck.valid = true;
     });
 
     // Shortcut with constraints is aware of global context and passes context to all middleware
     app.shortcut({ type: 'shortcut' }, async ({ context }) => {
-      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      const globalCheck = {} as IfAnyThenElse<typeof context['globalContextKey'], never, valid>;
       globalCheck.valid = true;
     }, async ({ context }) => {
-      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      const globalCheck = {} as IfAnyThenElse<typeof context['globalContextKey'], never, valid>;
       globalCheck.valid = true;
     });
 
     // Shortcut with constraints is aware of global and middleware context and passes context to all middleware
     app.shortcut<SlackShortcut, ShortcutConstraints<SlackShortcut>, MiddlewareContext>({ type: 'shortcut' }, async ({ context }) => {
-      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      const globalCheck = {} as IfAnyThenElse<typeof context['globalContextKey'], never, valid>;
       globalCheck.valid = true;
 
-      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      const middlewareCheck = {} as IfAnyThenElse<typeof context['middlewareContextKey'], never, valid>;
       middlewareCheck.valid = true;
     }, async ({ context }) => {
-      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      const globalCheck = {} as IfAnyThenElse<typeof context['globalContextKey'], never, valid>;
       globalCheck.valid = true;
 
-      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      const middlewareCheck = {} as IfAnyThenElse<typeof context['middlewareContextKey'], never, valid>;
       middlewareCheck.valid = true;
     });
   });
@@ -436,28 +438,28 @@ describe('context typing', () => {
 
     // Shortcut with RegExp callbackId is aware of middleware context and passes context to all middleware
     app.shortcut<SlackShortcut, MiddlewareContext>(/callback_id/, async ({ context }) => {
-      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      const middlewareCheck = {} as IfAnyThenElse<typeof context['middlewareContextKey'], never, valid>;
       middlewareCheck.valid = true;
     }, async ({ context }) => {
-      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      const middlewareCheck = {} as IfAnyThenElse<typeof context['middlewareContextKey'], never, valid>;
       middlewareCheck.valid = true;
     });
 
     // Shortcut with string callbackId is aware of middleware context and passes context to all middleware
     app.shortcut<SlackShortcut, MiddlewareContext>('callback_id', async ({ context }) => {
-      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      const middlewareCheck = {} as IfAnyThenElse<typeof context['middlewareContextKey'], never, valid>;
       middlewareCheck.valid = true;
     }, async ({ context }) => {
-      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      const middlewareCheck = {} as IfAnyThenElse<typeof context['middlewareContextKey'], never, valid>;
       middlewareCheck.valid = true;
     });
 
     // Shortcut with constraints is aware of middleware context and passes context to all middleware
     app.shortcut<SlackShortcut, ShortcutConstraints, MiddlewareContext>({ type: 'shortcut' }, async ({ context }) => {
-      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      const middlewareCheck = {} as IfAnyThenElse<typeof context['middlewareContextKey'], never, valid>;
       middlewareCheck.valid = true;
     }, async ({ context }) => {
-      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      const middlewareCheck = {} as IfAnyThenElse<typeof context['middlewareContextKey'], never, valid>;
       middlewareCheck.valid = true;
     });
   });
@@ -468,73 +470,73 @@ describe('context typing', () => {
 
     // Action with RegExp callbackId is aware of global context and passes context to all middleware
     app.action(/callback_id/, async ({ context }) => {
-      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      const globalCheck = {} as IfAnyThenElse<typeof context['globalContextKey'], never, valid>;
       globalCheck.valid = true;
     }, async ({ context }) => {
-      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      const globalCheck = {} as IfAnyThenElse<typeof context['globalContextKey'], never, valid>;
       globalCheck.valid = true;
     });
 
     // Action with string callbackId is aware of global context and passes context to all middleware
     app.action('callback_id', async ({ context }) => {
-      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      const globalCheck = {} as IfAnyThenElse<typeof context['globalContextKey'], never, valid>;
       globalCheck.valid = true;
     }, async ({ context }) => {
-      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      const globalCheck = {} as IfAnyThenElse<typeof context['globalContextKey'], never, valid>;
       globalCheck.valid = true;
     });
 
     // Action with RegExp callbackId is aware of global and middleware context and passes context to all middleware
     app.action<SlackAction, MiddlewareContext>(/callback_id/, async ({ context }) => {
-      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      const globalCheck = {} as IfAnyThenElse<typeof context['globalContextKey'], never, valid>;
       globalCheck.valid = true;
 
-      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      const middlewareCheck = {} as IfAnyThenElse<typeof context['middlewareContextKey'], never, valid>;
       middlewareCheck.valid = true;
     }, async ({ context }) => {
-      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      const globalCheck = {} as IfAnyThenElse<typeof context['globalContextKey'], never, valid>;
       globalCheck.valid = true;
 
-      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      const middlewareCheck = {} as IfAnyThenElse<typeof context['middlewareContextKey'], never, valid>;
       middlewareCheck.valid = true;
     });
 
     // Action with string callbackId is aware of global and middleware context and passes context to all middleware
     app.action<SlackAction, MiddlewareContext>('callback_id', async ({ context }) => {
-      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      const globalCheck = {} as IfAnyThenElse<typeof context['globalContextKey'], never, valid>;
       globalCheck.valid = true;
 
-      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      const middlewareCheck = {} as IfAnyThenElse<typeof context['middlewareContextKey'], never, valid>;
       middlewareCheck.valid = true;
     }, async ({ context }) => {
-      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      const globalCheck = {} as IfAnyThenElse<typeof context['globalContextKey'], never, valid>;
       globalCheck.valid = true;
 
-      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      const middlewareCheck = {} as IfAnyThenElse<typeof context['middlewareContextKey'], never, valid>;
       middlewareCheck.valid = true;
     });
 
     // Action with constraints is aware of global context and passes context to all middleware
     app.action({ type: 'interactive_message' }, async ({ context }) => {
-      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      const globalCheck = {} as IfAnyThenElse<typeof context['globalContextKey'], never, valid>;
       globalCheck.valid = true;
     }, async ({ context }) => {
-      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      const globalCheck = {} as IfAnyThenElse<typeof context['globalContextKey'], never, valid>;
       globalCheck.valid = true;
     });
 
     // Action with constraints is aware of global and middleware context and passes context to all middleware
     app.action<SlackAction, ActionConstraints, MiddlewareContext>({ type: 'interactive_message' }, async ({ context }) => {
-      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      const globalCheck = {} as IfAnyThenElse<typeof context['globalContextKey'], never, valid>;
       globalCheck.valid = true;
 
-      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      const middlewareCheck = {} as IfAnyThenElse<typeof context['middlewareContextKey'], never, valid>;
       middlewareCheck.valid = true;
     }, async ({ context }) => {
-      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      const globalCheck = {} as IfAnyThenElse<typeof context['globalContextKey'], never, valid>;
       globalCheck.valid = true;
 
-      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      const middlewareCheck = {} as IfAnyThenElse<typeof context['middlewareContextKey'], never, valid>;
       middlewareCheck.valid = true;
     });
   });
@@ -545,28 +547,28 @@ describe('context typing', () => {
 
     // Action with RegExp callbackId is aware of middleware context and passes context to all middleware
     app.action<SlackAction, MiddlewareContext>(/callback_id/, async ({ context }) => {
-      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      const middlewareCheck = {} as IfAnyThenElse<typeof context['middlewareContextKey'], never, valid>;
       middlewareCheck.valid = true;
     }, async ({ context }) => {
-      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      const middlewareCheck = {} as IfAnyThenElse<typeof context['middlewareContextKey'], never, valid>;
       middlewareCheck.valid = true;
     });
 
     // Action with string callbackId is aware of middleware context and passes context to all middleware
     app.action<SlackAction, MiddlewareContext>('callback_id', async ({ context }) => {
-      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      const middlewareCheck = {} as IfAnyThenElse<typeof context['middlewareContextKey'], never, valid>;
       middlewareCheck.valid = true;
     }, async ({ context }) => {
-      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      const middlewareCheck = {} as IfAnyThenElse<typeof context['middlewareContextKey'], never, valid>;
       middlewareCheck.valid = true;
     });
 
     // Action with constraints is aware of middleware context and passes context to all middleware
     app.action<SlackAction, ActionConstraints, MiddlewareContext>({ type: 'interactive_message' }, async ({ context }) => {
-      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      const middlewareCheck = {} as IfAnyThenElse<typeof context['middlewareContextKey'], never, valid>;
       middlewareCheck.valid = true;
     }, async ({ context }) => {
-      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      const middlewareCheck = {} as IfAnyThenElse<typeof context['middlewareContextKey'], never, valid>;
       middlewareCheck.valid = true;
     });
   });
@@ -578,49 +580,49 @@ describe('context typing', () => {
 
     // Command with RegExp commandName is aware of global and middleware context and passes context to all middleware
     app.command(/command_name/, async ({ context }) => {
-      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      const globalCheck = {} as IfAnyThenElse<typeof context['globalContextKey'], never, valid>;
       globalCheck.valid = true;
     }, async ({ context }) => {
-      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      const globalCheck = {} as IfAnyThenElse<typeof context['globalContextKey'], never, valid>;
       globalCheck.valid = true;
     });
 
     // Command with String commandName is aware of global and middleware context and passes context to all middleware
     app.command('command_name', async ({ context }) => {
-      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      const globalCheck = {} as IfAnyThenElse<typeof context['globalContextKey'], never, valid>;
       globalCheck.valid = true;
     }, async ({ context }) => {
-      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      const globalCheck = {} as IfAnyThenElse<typeof context['globalContextKey'], never, valid>;
       globalCheck.valid = true;
     });
 
     // Command with RegExp commandName is aware of global and middleware context and passes context to all middleware
     app.command<MiddlewareContext>(/command_name/, async ({ context }) => {
-      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      const globalCheck = {} as IfAnyThenElse<typeof context['globalContextKey'], never, valid>;
       globalCheck.valid = true;
 
-      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      const middlewareCheck = {} as IfAnyThenElse<typeof context['middlewareContextKey'], never, valid>;
       middlewareCheck.valid = true;
     }, async ({ context }) => {
-      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      const globalCheck = {} as IfAnyThenElse<typeof context['globalContextKey'], never, valid>;
       globalCheck.valid = true;
 
-      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      const middlewareCheck = {} as IfAnyThenElse<typeof context['middlewareContextKey'], never, valid>;
       middlewareCheck.valid = true;
     });
 
     // Command with string commandName is aware of global and middleware context and passes context to all middleware
     app.command<MiddlewareContext>('command_name', async ({ context }) => {
-      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      const globalCheck = {} as IfAnyThenElse<typeof context['globalContextKey'], never, valid>;
       globalCheck.valid = true;
 
-      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      const middlewareCheck = {} as IfAnyThenElse<typeof context['middlewareContextKey'], never, valid>;
       middlewareCheck.valid = true;
     }, async ({ context }) => {
-      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      const globalCheck = {} as IfAnyThenElse<typeof context['globalContextKey'], never, valid>;
       globalCheck.valid = true;
 
-      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      const middlewareCheck = {} as IfAnyThenElse<typeof context['middlewareContextKey'], never, valid>;
       middlewareCheck.valid = true;
     });
   });
@@ -631,19 +633,19 @@ describe('context typing', () => {
 
     // Command with RegExp commandName is aware of middleware context and passes context to all middleware
     app.command<MiddlewareContext>(/command_name/, async ({ context }) => {
-      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      const middlewareCheck = {} as IfAnyThenElse<typeof context['middlewareContextKey'], never, valid>;
       middlewareCheck.valid = true;
     }, async ({ context }) => {
-      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      const middlewareCheck = {} as IfAnyThenElse<typeof context['middlewareContextKey'], never, valid>;
       middlewareCheck.valid = true;
     });
 
     // Command with string commandName is aware of middleware context and passes context to all middleware
     app.command<MiddlewareContext>('command_name', async ({ context }) => {
-      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      const middlewareCheck = {} as IfAnyThenElse<typeof context['middlewareContextKey'], never, valid>;
       middlewareCheck.valid = true;
     }, async ({ context }) => {
-      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      const middlewareCheck = {} as IfAnyThenElse<typeof context['middlewareContextKey'], never, valid>;
       middlewareCheck.valid = true;
     });
   });
@@ -654,73 +656,73 @@ describe('context typing', () => {
 
     // Options with RegExp actionId is aware of global context and passes context to all middleware
     app.options(/action_id/, async ({ context }) => {
-      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      const globalCheck = {} as IfAnyThenElse<typeof context['globalContextKey'], never, valid>;
       globalCheck.valid = true;
     }, async ({ context }) => {
-      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      const globalCheck = {} as IfAnyThenElse<typeof context['globalContextKey'], never, valid>;
       globalCheck.valid = true;
     });
 
     // Options with string actionId is aware of global context and passes context to all middleware
     app.options('action_id', async ({ context }) => {
-      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      const globalCheck = {} as IfAnyThenElse<typeof context['globalContextKey'], never, valid>;
       globalCheck.valid = true;
     }, async ({ context }) => {
-      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      const globalCheck = {} as IfAnyThenElse<typeof context['globalContextKey'], never, valid>;
       globalCheck.valid = true;
     });
 
     // Options with RegExp actionId is aware of global and middleware context and passes context to all middleware
     app.options<'block_suggestion', MiddlewareContext>(/action_id/, async ({ context }) => {
-      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      const globalCheck = {} as IfAnyThenElse<typeof context['globalContextKey'], never, valid>;
       globalCheck.valid = true;
 
-      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      const middlewareCheck = {} as IfAnyThenElse<typeof context['middlewareContextKey'], never, valid>;
       middlewareCheck.valid = true;
     }, async ({ context }) => {
-      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      const globalCheck = {} as IfAnyThenElse<typeof context['globalContextKey'], never, valid>;
       globalCheck.valid = true;
 
-      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      const middlewareCheck = {} as IfAnyThenElse<typeof context['middlewareContextKey'], never, valid>;
       middlewareCheck.valid = true;
     });
 
     // Options with string actionId is aware of global and middleware context and passes context to all middleware
     app.options<'block_suggestion', MiddlewareContext>('action_id', async ({ context }) => {
-      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      const globalCheck = {} as IfAnyThenElse<typeof context['globalContextKey'], never, valid>;
       globalCheck.valid = true;
 
-      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      const middlewareCheck = {} as IfAnyThenElse<typeof context['middlewareContextKey'], never, valid>;
       middlewareCheck.valid = true;
     }, async ({ context }) => {
-      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      const globalCheck = {} as IfAnyThenElse<typeof context['globalContextKey'], never, valid>;
       globalCheck.valid = true;
 
-      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      const middlewareCheck = {} as IfAnyThenElse<typeof context['middlewareContextKey'], never, valid>;
       middlewareCheck.valid = true;
     });
 
     // Options with constraint is aware of global context and passes context to all middleware
     app.options({ type: 'block_actions' }, async ({ context }) => {
-      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      const globalCheck = {} as IfAnyThenElse<typeof context['globalContextKey'], never, valid>;
       globalCheck.valid = true;
     }, async ({ context }) => {
-      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      const globalCheck = {} as IfAnyThenElse<typeof context['globalContextKey'], never, valid>;
       globalCheck.valid = true;
     });
 
     // Options with constraint is aware of global and middleware context and passes context to all middleware
     app.options<OptionsSource, MiddlewareContext>({ type: 'block_actions' }, async ({ context }) => {
-      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      const globalCheck = {} as IfAnyThenElse<typeof context['globalContextKey'], never, valid>;
       globalCheck.valid = true;
 
-      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      const middlewareCheck = {} as IfAnyThenElse<typeof context['middlewareContextKey'], never, valid>;
       middlewareCheck.valid = true;
     }, async ({ context }) => {
-      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      const globalCheck = {} as IfAnyThenElse<typeof context['globalContextKey'], never, valid>;
       globalCheck.valid = true;
 
-      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      const middlewareCheck = {} as IfAnyThenElse<typeof context['middlewareContextKey'], never, valid>;
       middlewareCheck.valid = true;
     });
   });
@@ -731,28 +733,28 @@ describe('context typing', () => {
 
     // Options with RegExp actionId is aware of middleware context and passes context to all middleware
     app.options<'block_suggestion', MiddlewareContext>(/action_id/, async ({ context }) => {
-      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      const middlewareCheck = {} as IfAnyThenElse<typeof context['middlewareContextKey'], never, valid>;
       middlewareCheck.valid = true;
     }, async ({ context }) => {
-      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      const middlewareCheck = {} as IfAnyThenElse<typeof context['middlewareContextKey'], never, valid>;
       middlewareCheck.valid = true;
     });
 
     // Options with string actionId is aware of middleware context and passes context to all middleware
     app.options<'block_suggestion', MiddlewareContext>('action_id', async ({ context }) => {
-      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      const middlewareCheck = {} as IfAnyThenElse<typeof context['middlewareContextKey'], never, valid>;
       middlewareCheck.valid = true;
     }, async ({ context }) => {
-      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      const middlewareCheck = {} as IfAnyThenElse<typeof context['middlewareContextKey'], never, valid>;
       middlewareCheck.valid = true;
     });
 
     // Options with constraint is aware of middleware context and passes context to all middleware
     app.options<OptionsSource, MiddlewareContext>({ type: 'block_actions' }, async ({ context }) => {
-      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      const middlewareCheck = {} as IfAnyThenElse<typeof context['middlewareContextKey'], never, valid>;
       middlewareCheck.valid = true;
     }, async ({ context }) => {
-      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      const middlewareCheck = {} as IfAnyThenElse<typeof context['middlewareContextKey'], never, valid>;
       middlewareCheck.valid = true;
     });
   });
@@ -763,73 +765,73 @@ describe('context typing', () => {
 
     // View with RegExp callbackId is aware of global context and passes context to all middleware
     app.view(/callback_id/, async ({ context }) => {
-      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      const globalCheck = {} as IfAnyThenElse<typeof context['globalContextKey'], never, valid>;
       globalCheck.valid = true;
     }, async ({ context }) => {
-      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      const globalCheck = {} as IfAnyThenElse<typeof context['globalContextKey'], never, valid>;
       globalCheck.valid = true;
     });
 
     // View with string callbackId is aware of global context and passes context to all middleware
     app.view('callback_id', async ({ context }) => {
-      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      const globalCheck = {} as IfAnyThenElse<typeof context['globalContextKey'], never, valid>;
       globalCheck.valid = true;
     }, async ({ context }) => {
-      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      const globalCheck = {} as IfAnyThenElse<typeof context['globalContextKey'], never, valid>;
       globalCheck.valid = true;
     });
 
     // View with RegExp callbackId is aware of global and middleware context and passes context to all middleware
     app.view<SlackViewAction, MiddlewareContext>(/callback_id/, async ({ context }) => {
-      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      const globalCheck = {} as IfAnyThenElse<typeof context['globalContextKey'], never, valid>;
       globalCheck.valid = true;
 
-      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      const middlewareCheck = {} as IfAnyThenElse<typeof context['middlewareContextKey'], never, valid>;
       middlewareCheck.valid = true;
     }, async ({ context }) => {
-      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      const globalCheck = {} as IfAnyThenElse<typeof context['globalContextKey'], never, valid>;
       globalCheck.valid = true;
 
-      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      const middlewareCheck = {} as IfAnyThenElse<typeof context['middlewareContextKey'], never, valid>;
       middlewareCheck.valid = true;
     });
 
     // View with string callbackId is aware of global and middleware context and passes context to all middleware
     app.view<SlackViewAction, MiddlewareContext>('callback_id', async ({ context }) => {
-      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      const globalCheck = {} as IfAnyThenElse<typeof context['globalContextKey'], never, valid>;
       globalCheck.valid = true;
 
-      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      const middlewareCheck = {} as IfAnyThenElse<typeof context['middlewareContextKey'], never, valid>;
       middlewareCheck.valid = true;
     }, async ({ context }) => {
-      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      const globalCheck = {} as IfAnyThenElse<typeof context['globalContextKey'], never, valid>;
       globalCheck.valid = true;
 
-      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      const middlewareCheck = {} as IfAnyThenElse<typeof context['middlewareContextKey'], never, valid>;
       middlewareCheck.valid = true;
     });
 
     // View with constraint is aware of global context and passes context to all middleware
     app.view({ type: 'view_closed' }, async ({ context }) => {
-      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      const globalCheck = {} as IfAnyThenElse<typeof context['globalContextKey'], never, valid>;
       globalCheck.valid = true;
     }, async ({ context }) => {
-      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      const globalCheck = {} as IfAnyThenElse<typeof context['globalContextKey'], never, valid>;
       globalCheck.valid = true;
     });
 
     // View with constraint is aware of global and middleware context and passes context to all middleware
     app.view<SlackViewAction, MiddlewareContext>({ type: 'view_closed' }, async ({ context }) => {
-      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      const globalCheck = {} as IfAnyThenElse<typeof context['globalContextKey'], never, valid>;
       globalCheck.valid = true;
 
-      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      const middlewareCheck = {} as IfAnyThenElse<typeof context['middlewareContextKey'], never, valid>;
       middlewareCheck.valid = true;
     }, async ({ context }) => {
-      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      const globalCheck = {} as IfAnyThenElse<typeof context['globalContextKey'], never, valid>;
       globalCheck.valid = true;
 
-      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      const middlewareCheck = {} as IfAnyThenElse<typeof context['middlewareContextKey'], never, valid>;
       middlewareCheck.valid = true;
     });
   });
@@ -840,28 +842,28 @@ describe('context typing', () => {
 
     // View with RegExp callbackId is aware of global and middleware context and passes context to all middleware
     app.view<SlackViewAction, MiddlewareContext>(/callback_id/, async ({ context }) => {
-      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      const middlewareCheck = {} as IfAnyThenElse<typeof context['middlewareContextKey'], never, valid>;
       middlewareCheck.valid = true;
     }, async ({ context }) => {
-      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      const middlewareCheck = {} as IfAnyThenElse<typeof context['middlewareContextKey'], never, valid>;
       middlewareCheck.valid = true;
     });
 
     // View with string callbackId is aware of global and middleware context and passes context to all middleware
     app.view<SlackViewAction, MiddlewareContext>('callback_id', async ({ context }) => {
-      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      const middlewareCheck = {} as IfAnyThenElse<typeof context['middlewareContextKey'], never, valid>;
       middlewareCheck.valid = true;
     }, async ({ context }) => {
-      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      const middlewareCheck = {} as IfAnyThenElse<typeof context['middlewareContextKey'], never, valid>;
       middlewareCheck.valid = true;
     });
 
     // View with constraint is aware of global and middleware context and passes context to all middleware
     app.view<SlackViewAction, MiddlewareContext>({ type: 'view_closed' }, async ({ context }) => {
-      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      const middlewareCheck = {} as IfAnyThenElse<typeof context['middlewareContextKey'], never, valid>;
       middlewareCheck.valid = true;
     }, async ({ context }) => {
-      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      const middlewareCheck = {} as IfAnyThenElse<typeof context['middlewareContextKey'], never, valid>;
       middlewareCheck.valid = true;
     });
   });

--- a/src/App-context-types.spec.ts
+++ b/src/App-context-types.spec.ts
@@ -1,13 +1,13 @@
 import sinon from 'sinon';
 import rewiremock from 'rewiremock';
 import { mergeOverrides, Override } from './test-helpers';
-import { Receiver, ReceiverEvent } from './types';
-import App from './App';
+import { OptionsSource, Receiver, ReceiverEvent, SlackAction, SlackShortcut, SlackViewAction } from './types';
+import App, { ActionConstraints, ShortcutConstraints } from './App';
 
 type IfAny<T, Y, N> = 0 extends (1 & T) ? Y : N;
 interface valid { valid: boolean }
 interface GlobalContext { globalContextKey: number }
-interface MiddlewareContext { middleWareContextKey: number }
+interface MiddlewareContext { middlewareContextKey: number }
 
 // Loading the system under test using overrides
 async function importApp(
@@ -36,26 +36,833 @@ const noopAuthorize = () => Promise.resolve({});
 const receiver = new FakeReceiver();
 
 describe('context typing', () => {
-  it('should pass global context to message middleware', async () => {
-
+  it('use should handle global and middleware context', async () => {
     const MockApp = await importApp();
     const app = new MockApp<GlobalContext>({ receiver, authorize: noopAuthorize });
 
-    app.message('hello', async ({ context }) => {
-      // If the globalContextKey in the context is not explicitly typed, then it will be 'any'
-      // The IfAny check will then set 'check' to 'never', causing the check.valid call later to fail
+    // Use - Global Context
+    app.use(async ({ context }) => {
       const check = {} as IfAny<typeof context['globalContextKey'], never, valid>;
       check.valid = true;
     });
+
+    // Use - Global & Middleware Context
+    app.use<MiddlewareContext>(async ({ context }) => {
+      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      globalCheck.valid = true;
+
+      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      middlewareCheck.valid = true;
+    });
   });
 
-  it('should pass middleware context to message middleware', async () => {
+  it('use should handle middleware context', async () => {
     const MockApp = await importApp();
     const app = new MockApp({ receiver, authorize: noopAuthorize });
 
-    app.message<MiddlewareContext>('hello', async ({ context }) => {
-      const check = {} as IfAny<typeof context['middleWareContextKey'], never, valid>;
-      check.valid = true;
+    // Use - Middleware Context
+    app.use<MiddlewareContext>(async ({ context }) => {
+      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      middlewareCheck.valid = true;
+    });
+  });
+
+  it('message should handle global and middleware context', async () => {
+    const MockApp = await importApp();
+    const app = new MockApp<GlobalContext>({ receiver, authorize: noopAuthorize });
+
+    // Message passes global context to all middleware
+    app.message(async ({ context }) => {
+      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      globalCheck.valid = true;
+    }, async ({ context }) => {
+      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      globalCheck.valid = true;
+    });
+
+    // Message passes global and middleware context to all middleware
+    app.message<MiddlewareContext>(async ({ context }) => {
+      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      globalCheck.valid = true;
+
+      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      middlewareCheck.valid = true;
+    }, async ({ context }) => {
+      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      globalCheck.valid = true;
+
+      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      middlewareCheck.valid = true;
+    });
+
+    // Message passes global context when using RegExp pattern and passes context to all middleware
+    app.message(/^regex/, async ({ context }) => {
+      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      globalCheck.valid = true;
+    }, async ({ context }) => {
+      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      globalCheck.valid = true;
+    });
+
+    // Message passes global context when using string pattern and passes context to all middleware
+    app.message('string', async ({ context }) => {
+      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      globalCheck.valid = true;
+    }, async ({ context }) => {
+      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      globalCheck.valid = true;
+    });
+
+    // Message passes global and middleware context when using RegExp patterns and passes context to all middleware
+    app.message<MiddlewareContext>(/^regex/, async ({ context }) => {
+      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      globalCheck.valid = true;
+
+      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      middlewareCheck.valid = true;
+    }, async ({ context }) => {
+      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      globalCheck.valid = true;
+
+      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      middlewareCheck.valid = true;
+    });
+
+    // Message passes global and middleware context when using String patterns and passes context to all middleware
+    app.message<MiddlewareContext>('string', async ({ context }) => {
+      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      globalCheck.valid = true;
+
+      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      middlewareCheck.valid = true;
+    }, async ({ context }) => {
+      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      globalCheck.valid = true;
+
+      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      middlewareCheck.valid = true;
+    });
+
+    // Message filter with RegExp pattern is aware of global context and passes context to all middleware
+    app.message(async ({ context }) => {
+      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      globalCheck.valid = true;
+    }, /^regex/, async ({ context }) => {
+      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      globalCheck.valid = true;
+    }, async ({ context }) => {
+      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      globalCheck.valid = true;
+    });
+
+    // Message filter with String pattern is aware of global context and passes context to all middleware
+    app.message(async ({ context }) => {
+      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      globalCheck.valid = true;
+    }, 'string', async ({ context }) => {
+      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      globalCheck.valid = true;
+    }, async ({ context }) => {
+      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      globalCheck.valid = true;
+    });
+
+    // Message filter with RegExp pattern is aware of global and middleware context and passes context to all middleware
+    app.message<MiddlewareContext>(async ({ context }) => {
+      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      globalCheck.valid = true;
+
+      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      middlewareCheck.valid = true;
+    }, /^regex/, async ({ context }) => {
+      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      globalCheck.valid = true;
+
+      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      middlewareCheck.valid = true;
+    }, async ({ context }) => {
+      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      globalCheck.valid = true;
+
+      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      middlewareCheck.valid = true;
+    });
+
+    // Message filter with String pattern is aware of global and middleware context and passes context to all middleware
+    app.message<MiddlewareContext>(async ({ context }) => {
+      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      globalCheck.valid = true;
+
+      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      middlewareCheck.valid = true;
+    }, 'string', async ({ context }) => {
+      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      globalCheck.valid = true;
+
+      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      middlewareCheck.valid = true;
+    }, async ({ context }) => {
+      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      globalCheck.valid = true;
+
+      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      middlewareCheck.valid = true;
+    });
+
+    // Message filter is aware of global context and passes context to all middleware
+    app.message(async ({ context }) => {
+      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      globalCheck.valid = true;
+    }, async ({ context }) => {
+      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      globalCheck.valid = true;
+    }, async ({ context }) => {
+      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      globalCheck.valid = true;
+    });
+
+    // Message filter is aware of global and middleware context and passes context to all middleware
+    app.message<MiddlewareContext>(async ({ context }) => {
+      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      globalCheck.valid = true;
+
+      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      middlewareCheck.valid = true;
+    }, async ({ context }) => {
+      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      globalCheck.valid = true;
+
+      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      middlewareCheck.valid = true;
+    }, async ({ context }) => {
+      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      globalCheck.valid = true;
+
+      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      middlewareCheck.valid = true;
+    });
+
+    // Message with mixed patterns and middleware is aware of global context passes context to all middleware
+    app.message('test_string', async ({ context }) => {
+      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      globalCheck.valid = true;
+    }, 'test_string_2', async ({ context }) => {
+      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      globalCheck.valid = true;
+    }, /regex/, async ({ context }) => {
+      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      globalCheck.valid = true;
+    });
+
+    /**
+    * Message with mixed patterns and middleware is aware of global and
+    * middleware context and passes context to all middleware
+    */
+    app.message<MiddlewareContext>('test_string', async ({ context }) => {
+      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      globalCheck.valid = true;
+
+      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      middlewareCheck.valid = true;
+    }, 'test_string_2', async ({ context }) => {
+      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      globalCheck.valid = true;
+
+      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      middlewareCheck.valid = true;
+    }, /regex/, async ({ context }) => {
+      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      globalCheck.valid = true;
+
+      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      middlewareCheck.valid = true;
+    });
+  });
+
+  it('message should handle middleware context', async () => {
+    const MockApp = await importApp();
+    const app = new MockApp({ receiver, authorize: noopAuthorize });
+
+    // Message passes middleware context to all middleware
+    app.message<MiddlewareContext>(async ({ context }) => {
+      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      middlewareCheck.valid = true;
+    }, async ({ context }) => {
+      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      middlewareCheck.valid = true;
+    });
+
+    // Message passes middleware context when using RegExp patterns and passes context to all middleware
+    app.message<MiddlewareContext>(/^regex/, async ({ context }) => {
+      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      middlewareCheck.valid = true;
+    }, async ({ context }) => {
+      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      middlewareCheck.valid = true;
+    }, async ({ context }) => {
+      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      middlewareCheck.valid = true;
+    });
+
+    // Message passes middleware context when using String patterns and passes context to all middleware
+    app.message<MiddlewareContext>('string', async ({ context }) => {
+      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      middlewareCheck.valid = true;
+    }, async ({ context }) => {
+      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      middlewareCheck.valid = true;
+    });
+
+    // Message filter with RegExp pattern is aware of middleware context and passes context to all middleware
+    app.message<MiddlewareContext>(async ({ context }) => {
+      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      middlewareCheck.valid = true;
+    }, /^regex/, async ({ context }) => {
+      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      middlewareCheck.valid = true;
+    }, async ({ context }) => {
+      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      middlewareCheck.valid = true;
+    });
+
+    // Message filter is aware of middleware context and passes context to all middleware
+    app.message<MiddlewareContext>(async ({ context }) => {
+      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      middlewareCheck.valid = true;
+    }, async ({ context }) => {
+      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      middlewareCheck.valid = true;
+    }, async ({ context }) => {
+      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      middlewareCheck.valid = true;
+    });
+
+    /**
+    * Message with mixed patterns and middleware is aware of global and
+    * middleware context and passes context to all middleware
+    */
+    app.message<MiddlewareContext>('test_string', async ({ context }) => {
+      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      middlewareCheck.valid = true;
+    }, 'test_string_2', async ({ context }) => {
+      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      middlewareCheck.valid = true;
+    }, /regex/, async ({ context }) => {
+      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      middlewareCheck.valid = true;
+    });
+  });
+
+  it('shortcut should handle global and middleware context', async () => {
+    const MockApp = await importApp();
+    const app = new MockApp<GlobalContext>({ receiver, authorize: noopAuthorize });
+
+    // Shortcut with RegExp callbackId is aware of global context and passes context to all middleware
+    app.shortcut(/callback_id/, async ({ context }) => {
+      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      globalCheck.valid = true;
+    }, async ({ context }) => {
+      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      globalCheck.valid = true;
+    });
+
+    // Shortcut with string callbackId is aware of global context and passes context to all middleware
+    app.shortcut('callback_id', async ({ context }) => {
+      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      globalCheck.valid = true;
+    }, async ({ context }) => {
+      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      globalCheck.valid = true;
+    });
+
+    // Shortcut with RegExp callbackId is aware of global and middleware context and passes context to all middleware
+    app.shortcut<SlackShortcut, MiddlewareContext>(/callback_id/, async ({ context }) => {
+      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      globalCheck.valid = true;
+
+      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      middlewareCheck.valid = true;
+    }, async ({ context }) => {
+      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      globalCheck.valid = true;
+
+      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      middlewareCheck.valid = true;
+    });
+
+    // Shortcut with string callbackId is aware of global and middleware context and passes context to all middleware
+    app.shortcut<SlackShortcut, MiddlewareContext>('callback_id', async ({ context }) => {
+      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      globalCheck.valid = true;
+
+      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      middlewareCheck.valid = true;
+    }, async ({ context }) => {
+      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      globalCheck.valid = true;
+
+      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      middlewareCheck.valid = true;
+    });
+
+    // Shortcut with constraints is aware of global context and passes context to all middleware
+    app.shortcut({ type: 'shortcut' }, async ({ context }) => {
+      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      globalCheck.valid = true;
+    }, async ({ context }) => {
+      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      globalCheck.valid = true;
+    });
+
+    // Shortcut with constraints is aware of global and middleware context and passes context to all middleware
+    app.shortcut<SlackShortcut, ShortcutConstraints<SlackShortcut>, MiddlewareContext>({ type: 'shortcut' }, async ({ context }) => {
+      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      globalCheck.valid = true;
+
+      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      middlewareCheck.valid = true;
+    }, async ({ context }) => {
+      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      globalCheck.valid = true;
+
+      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      middlewareCheck.valid = true;
+    });
+  });
+
+  it('shortcut should handle middleware context', async () => {
+    const MockApp = await importApp();
+    const app = new MockApp({ receiver, authorize: noopAuthorize });
+
+    // Shortcut with RegExp callbackId is aware of middleware context and passes context to all middleware
+    app.shortcut<SlackShortcut, MiddlewareContext>(/callback_id/, async ({ context }) => {
+      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      middlewareCheck.valid = true;
+    }, async ({ context }) => {
+      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      middlewareCheck.valid = true;
+    });
+
+    // Shortcut with string callbackId is aware of middleware context and passes context to all middleware
+    app.shortcut<SlackShortcut, MiddlewareContext>('callback_id', async ({ context }) => {
+      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      middlewareCheck.valid = true;
+    }, async ({ context }) => {
+      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      middlewareCheck.valid = true;
+    });
+
+    // Shortcut with constraints is aware of middleware context and passes context to all middleware
+    app.shortcut<SlackShortcut, ShortcutConstraints, MiddlewareContext>({ type: 'shortcut' }, async ({ context }) => {
+      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      middlewareCheck.valid = true;
+    }, async ({ context }) => {
+      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      middlewareCheck.valid = true;
+    });
+  });
+
+  it('action should handle global and middleware context', async () => {
+    const MockApp = await importApp();
+    const app = new MockApp<GlobalContext>({ receiver, authorize: noopAuthorize });
+
+    // Action with RegExp callbackId is aware of global context and passes context to all middleware
+    app.action(/callback_id/, async ({ context }) => {
+      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      globalCheck.valid = true;
+    }, async ({ context }) => {
+      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      globalCheck.valid = true;
+    });
+
+    // Action with string callbackId is aware of global context and passes context to all middleware
+    app.action('callback_id', async ({ context }) => {
+      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      globalCheck.valid = true;
+    }, async ({ context }) => {
+      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      globalCheck.valid = true;
+    });
+
+    // Action with RegExp callbackId is aware of global and middleware context and passes context to all middleware
+    app.action<SlackAction, MiddlewareContext>(/callback_id/, async ({ context }) => {
+      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      globalCheck.valid = true;
+
+      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      middlewareCheck.valid = true;
+    }, async ({ context }) => {
+      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      globalCheck.valid = true;
+
+      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      middlewareCheck.valid = true;
+    });
+
+    // Action with string callbackId is aware of global and middleware context and passes context to all middleware
+    app.action<SlackAction, MiddlewareContext>('callback_id', async ({ context }) => {
+      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      globalCheck.valid = true;
+
+      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      middlewareCheck.valid = true;
+    }, async ({ context }) => {
+      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      globalCheck.valid = true;
+
+      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      middlewareCheck.valid = true;
+    });
+
+    // Action with constraints is aware of global context and passes context to all middleware
+    app.action({ type: 'interactive_message' }, async ({ context }) => {
+      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      globalCheck.valid = true;
+    }, async ({ context }) => {
+      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      globalCheck.valid = true;
+    });
+
+    // Action with constraints is aware of global and middleware context and passes context to all middleware
+    app.action<SlackAction, ActionConstraints, MiddlewareContext>({ type: 'interactive_message' }, async ({ context }) => {
+      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      globalCheck.valid = true;
+
+      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      middlewareCheck.valid = true;
+    }, async ({ context }) => {
+      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      globalCheck.valid = true;
+
+      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      middlewareCheck.valid = true;
+    });
+  });
+
+  it('action should handle middleware context', async () => {
+    const MockApp = await importApp();
+    const app = new MockApp({ receiver, authorize: noopAuthorize });
+
+    // Action with RegExp callbackId is aware of middleware context and passes context to all middleware
+    app.action<SlackAction, MiddlewareContext>(/callback_id/, async ({ context }) => {
+      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      middlewareCheck.valid = true;
+    }, async ({ context }) => {
+      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      middlewareCheck.valid = true;
+    });
+
+    // Action with string callbackId is aware of middleware context and passes context to all middleware
+    app.action<SlackAction, MiddlewareContext>('callback_id', async ({ context }) => {
+      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      middlewareCheck.valid = true;
+    }, async ({ context }) => {
+      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      middlewareCheck.valid = true;
+    });
+
+    // Action with constraints is aware of middleware context and passes context to all middleware
+    app.action<SlackAction, ActionConstraints, MiddlewareContext>({ type: 'interactive_message' }, async ({ context }) => {
+      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      middlewareCheck.valid = true;
+    }, async ({ context }) => {
+      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      middlewareCheck.valid = true;
+    });
+  });
+
+  it('command should handle global and middleware context', async () => {
+    const MockApp = await importApp();
+    const app = new MockApp<GlobalContext>({ receiver, authorize: noopAuthorize });
+    // Command with commandName is aware of global context and passes context to all middleware
+
+    // Command with RegExp commandName is aware of global and middleware context and passes context to all middleware
+    app.command(/command_name/, async ({ context }) => {
+      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      globalCheck.valid = true;
+    }, async ({ context }) => {
+      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      globalCheck.valid = true;
+    });
+
+    // Command with String commandName is aware of global and middleware context and passes context to all middleware
+    app.command('command_name', async ({ context }) => {
+      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      globalCheck.valid = true;
+    }, async ({ context }) => {
+      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      globalCheck.valid = true;
+    });
+
+    // Command with RegExp commandName is aware of global and middleware context and passes context to all middleware
+    app.command<MiddlewareContext>(/command_name/, async ({ context }) => {
+      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      globalCheck.valid = true;
+
+      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      middlewareCheck.valid = true;
+    }, async ({ context }) => {
+      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      globalCheck.valid = true;
+
+      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      middlewareCheck.valid = true;
+    });
+
+    // Command with string commandName is aware of global and middleware context and passes context to all middleware
+    app.command<MiddlewareContext>('command_name', async ({ context }) => {
+      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      globalCheck.valid = true;
+
+      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      middlewareCheck.valid = true;
+    }, async ({ context }) => {
+      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      globalCheck.valid = true;
+
+      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      middlewareCheck.valid = true;
+    });
+  });
+
+  it('command should handle middleware context', async () => {
+    const MockApp = await importApp();
+    const app = new MockApp({ receiver, authorize: noopAuthorize });
+
+    // Command with RegExp commandName is aware of middleware context and passes context to all middleware
+    app.command<MiddlewareContext>(/command_name/, async ({ context }) => {
+      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      middlewareCheck.valid = true;
+    }, async ({ context }) => {
+      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      middlewareCheck.valid = true;
+    });
+
+    // Command with string commandName is aware of middleware context and passes context to all middleware
+    app.command<MiddlewareContext>('command_name', async ({ context }) => {
+      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      middlewareCheck.valid = true;
+    }, async ({ context }) => {
+      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      middlewareCheck.valid = true;
+    });
+  });
+
+  it('options should handle global and middleware context', async () => {
+    const MockApp = await importApp();
+    const app = new MockApp<GlobalContext>({ receiver, authorize: noopAuthorize });
+
+    // Options with RegExp actionId is aware of global context and passes context to all middleware
+    app.options(/action_id/, async ({ context }) => {
+      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      globalCheck.valid = true;
+    }, async ({ context }) => {
+      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      globalCheck.valid = true;
+    });
+
+    // Options with string actionId is aware of global context and passes context to all middleware
+    app.options('action_id', async ({ context }) => {
+      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      globalCheck.valid = true;
+    }, async ({ context }) => {
+      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      globalCheck.valid = true;
+    });
+
+    // Options with RegExp actionId is aware of global and middleware context and passes context to all middleware
+    app.options<'block_suggestion', MiddlewareContext>(/action_id/, async ({ context }) => {
+      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      globalCheck.valid = true;
+
+      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      middlewareCheck.valid = true;
+    }, async ({ context }) => {
+      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      globalCheck.valid = true;
+
+      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      middlewareCheck.valid = true;
+    });
+
+    // Options with string actionId is aware of global and middleware context and passes context to all middleware
+    app.options<'block_suggestion', MiddlewareContext>('action_id', async ({ context }) => {
+      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      globalCheck.valid = true;
+
+      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      middlewareCheck.valid = true;
+    }, async ({ context }) => {
+      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      globalCheck.valid = true;
+
+      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      middlewareCheck.valid = true;
+    });
+
+    // Options with constraint is aware of global context and passes context to all middleware
+    app.options({ type: 'block_actions' }, async ({ context }) => {
+      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      globalCheck.valid = true;
+    }, async ({ context }) => {
+      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      globalCheck.valid = true;
+    });
+
+    // Options with constraint is aware of global and middleware context and passes context to all middleware
+    app.options<OptionsSource, MiddlewareContext>({ type: 'block_actions' }, async ({ context }) => {
+      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      globalCheck.valid = true;
+
+      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      middlewareCheck.valid = true;
+    }, async ({ context }) => {
+      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      globalCheck.valid = true;
+
+      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      middlewareCheck.valid = true;
+    });
+  });
+
+  it('options should handle middleware context', async () => {
+    const MockApp = await importApp();
+    const app = new MockApp({ receiver, authorize: noopAuthorize });
+
+    // Options with RegExp actionId is aware of middleware context and passes context to all middleware
+    app.options<'block_suggestion', MiddlewareContext>(/action_id/, async ({ context }) => {
+      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      middlewareCheck.valid = true;
+    }, async ({ context }) => {
+      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      middlewareCheck.valid = true;
+    });
+
+    // Options with string actionId is aware of middleware context and passes context to all middleware
+    app.options<'block_suggestion', MiddlewareContext>('action_id', async ({ context }) => {
+      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      middlewareCheck.valid = true;
+    }, async ({ context }) => {
+      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      middlewareCheck.valid = true;
+    });
+
+    // Options with constraint is aware of middleware context and passes context to all middleware
+    app.options<OptionsSource, MiddlewareContext>({ type: 'block_actions' }, async ({ context }) => {
+      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      middlewareCheck.valid = true;
+    }, async ({ context }) => {
+      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      middlewareCheck.valid = true;
+    });
+  });
+
+  it('view should handle global and middleware context', async () => {
+    const MockApp = await importApp();
+    const app = new MockApp<GlobalContext>({ receiver, authorize: noopAuthorize });
+
+    // View with RegExp callbackId is aware of global context and passes context to all middleware
+    app.view(/callback_id/, async ({ context }) => {
+      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      globalCheck.valid = true;
+    }, async ({ context }) => {
+      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      globalCheck.valid = true;
+    });
+
+    // View with string callbackId is aware of global context and passes context to all middleware
+    app.view('callback_id', async ({ context }) => {
+      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      globalCheck.valid = true;
+    }, async ({ context }) => {
+      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      globalCheck.valid = true;
+    });
+
+    // View with RegExp callbackId is aware of global and middleware context and passes context to all middleware
+    app.view<SlackViewAction, MiddlewareContext>(/callback_id/, async ({ context }) => {
+      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      globalCheck.valid = true;
+
+      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      middlewareCheck.valid = true;
+    }, async ({ context }) => {
+      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      globalCheck.valid = true;
+
+      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      middlewareCheck.valid = true;
+    });
+
+    // View with string callbackId is aware of global and middleware context and passes context to all middleware
+    app.view<SlackViewAction, MiddlewareContext>('callback_id', async ({ context }) => {
+      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      globalCheck.valid = true;
+
+      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      middlewareCheck.valid = true;
+    }, async ({ context }) => {
+      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      globalCheck.valid = true;
+
+      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      middlewareCheck.valid = true;
+    });
+
+    // View with constraint is aware of global context and passes context to all middleware
+    app.view({ type: 'view_closed' }, async ({ context }) => {
+      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      globalCheck.valid = true;
+    }, async ({ context }) => {
+      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      globalCheck.valid = true;
+    });
+
+    // View with constraint is aware of global and middleware context and passes context to all middleware
+    app.view<SlackViewAction, MiddlewareContext>({ type: 'view_closed' }, async ({ context }) => {
+      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      globalCheck.valid = true;
+
+      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      middlewareCheck.valid = true;
+    }, async ({ context }) => {
+      const globalCheck = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      globalCheck.valid = true;
+
+      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      middlewareCheck.valid = true;
+    });
+  });
+
+  it('view should handle middleware context', async () => {
+    const MockApp = await importApp();
+    const app = new MockApp({ receiver, authorize: noopAuthorize });
+
+    // View with RegExp callbackId is aware of global and middleware context and passes context to all middleware
+    app.view<SlackViewAction, MiddlewareContext>(/callback_id/, async ({ context }) => {
+      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      middlewareCheck.valid = true;
+    }, async ({ context }) => {
+      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      middlewareCheck.valid = true;
+    });
+
+    // View with string callbackId is aware of global and middleware context and passes context to all middleware
+    app.view<SlackViewAction, MiddlewareContext>('callback_id', async ({ context }) => {
+      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      middlewareCheck.valid = true;
+    }, async ({ context }) => {
+      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      middlewareCheck.valid = true;
+    });
+
+    // View with constraint is aware of global and middleware context and passes context to all middleware
+    app.view<SlackViewAction, MiddlewareContext>({ type: 'view_closed' }, async ({ context }) => {
+      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      middlewareCheck.valid = true;
+    }, async ({ context }) => {
+      const middlewareCheck = {} as IfAny<typeof context['middlewareContextKey'], never, valid>;
+      middlewareCheck.valid = true;
     });
   });
 });

--- a/src/App-context-types.spec.ts
+++ b/src/App-context-types.spec.ts
@@ -1,0 +1,78 @@
+import sinon from 'sinon';
+import rewiremock from 'rewiremock';
+import { mergeOverrides, Override } from './test-helpers';
+import { Receiver, ReceiverEvent } from './types';
+import App from './App';
+
+type IfAny<T, Y, N> = 0 extends (1 & T) ? Y : N;
+interface valid { valid: boolean }
+interface GlobalContext { globalContextKey: number }
+interface MiddlewareContext { middleWareContextKey: number }
+
+// Loading the system under test using overrides
+async function importApp(
+  overrides: Override = mergeOverrides(withNoopAppMetadata(), withNoopWebClient()),
+): Promise<typeof import('./App').default> {
+  return (await rewiremock.module(() => import('./App'), overrides)).default;
+}
+
+class FakeReceiver implements Receiver {
+  private bolt: App | undefined;
+
+  public init = (bolt: App) => {
+    this.bolt = bolt;
+  };
+
+  public start = sinon.fake((...params: any[]): Promise<unknown> => Promise.resolve([...params]));
+
+  public stop = sinon.fake((...params: any[]): Promise<unknown> => Promise.resolve([...params]));
+
+  public async sendEvent(event: ReceiverEvent): Promise<void> {
+    return this.bolt?.processEvent(event);
+  }
+}
+
+const noopAuthorize = () => Promise.resolve({});
+const receiver = new FakeReceiver();
+
+describe('context typing', () => {
+  it('should pass global context to message middleware', async () => {
+
+    const MockApp = await importApp();
+    const app = new MockApp<GlobalContext>({ receiver, authorize: noopAuthorize });
+
+    app.message('hello', async ({ context }) => {
+      // If the globalContextKey in the context is not explicitly typed, then it will be 'any'
+      // The IfAny check will then set 'check' to 'never', causing the check.valid call later to fail
+      const check = {} as IfAny<typeof context['globalContextKey'], never, valid>;
+      check.valid = true;
+    });
+  });
+
+  it('should pass middleware context to message middleware', async () => {
+    const MockApp = await importApp();
+    const app = new MockApp({ receiver, authorize: noopAuthorize });
+
+    app.message<MiddlewareContext>('hello', async ({ context }) => {
+      const check = {} as IfAny<typeof context['middleWareContextKey'], never, valid>;
+      check.valid = true;
+    });
+  });
+});
+
+// Composable overrides
+function withNoopWebClient(): Override {
+  return {
+    '@slack/web-api': {
+      WebClient: class {},
+    },
+  };
+}
+
+function withNoopAppMetadata(): Override {
+  return {
+    '@slack/web-api': {
+      addAppMetadata: sinon.fake(),
+    },
+  };
+}

--- a/src/App.ts
+++ b/src/App.ts
@@ -607,7 +607,8 @@ export default class App<AppCustomContext extends StringIndexed = StringIndexed>
   public message<
       MiddlewareCustomContext extends StringIndexed = StringIndexed,
   >(
-    filter: MessageEventMiddleware, pattern: string | RegExp,
+    filter: MessageEventMiddleware<AppCustomContext & MiddlewareCustomContext>,
+    pattern: string | RegExp,
     ...listeners: MessageEventMiddleware<AppCustomContext & MiddlewareCustomContext>[]
   ): void;
   /**

--- a/src/App.ts
+++ b/src/App.ts
@@ -182,7 +182,9 @@ export interface AnyErrorHandler extends ErrorHandler, ExtendedErrorHandler {
 }
 
 // Used only in this file
-type MessageEventMiddleware = Middleware<SlackEventMiddlewareArgs<'message'>>;
+type MessageEventMiddleware<
+    CustomContext extends StringIndexed = StringIndexed,
+> = Middleware<SlackEventMiddlewareArgs<'message'>, CustomContext>;
 
 class WebClientPool {
   private pool: { [token: string]: WebClient } = {};
@@ -201,7 +203,7 @@ class WebClientPool {
 /**
  * A Slack App
  */
-export default class App {
+export default class App<AppCustomContext extends StringIndexed = StringIndexed> {
   /** Slack Web API client */
   public client: WebClient;
 
@@ -488,8 +490,10 @@ export default class App {
    *
    * @param m global middleware function
    */
-  public use(m: Middleware<AnyMiddlewareArgs>): this {
-    this.middleware.push(m);
+  public use<MiddlewareCustomContext extends StringIndexed = StringIndexed>(
+    m: Middleware<AnyMiddlewareArgs, AppCustomContext & MiddlewareCustomContext>,
+  ): this {
+    this.middleware.push(m as Middleware<AnyMiddlewareArgs>);
     return this;
   }
 
@@ -528,17 +532,26 @@ export default class App {
     return this.receiver.stop(...args);
   }
 
-  public event<EventType extends string = string>(
+  public event<
+      EventType extends string = string,
+      MiddlewareCustomContext extends StringIndexed = StringIndexed,
+  >(
     eventName: EventType,
-    ...listeners: Middleware<SlackEventMiddlewareArgs<EventType>>[]
+    ...listeners: Middleware<SlackEventMiddlewareArgs<EventType>, AppCustomContext & MiddlewareCustomContext>[]
   ): void;
-  public event<EventType extends RegExp = RegExp>(
+  public event<
+      EventType extends RegExp = RegExp,
+      MiddlewareCustomContext extends StringIndexed = StringIndexed,
+  >(
     eventName: EventType,
-    ...listeners: Middleware<SlackEventMiddlewareArgs<string>>[]
+    ...listeners: Middleware<SlackEventMiddlewareArgs<string>, AppCustomContext & MiddlewareCustomContext>[]
   ): void;
-  public event<EventType extends EventTypePattern = EventTypePattern>(
+  public event<
+      EventType extends EventTypePattern = EventTypePattern,
+      MiddlewareCustomContext extends StringIndexed = StringIndexed,
+  >(
     eventNameOrPattern: EventType,
-    ...listeners: Middleware<SlackEventMiddlewareArgs<string>>[]
+    ...listeners: Middleware<SlackEventMiddlewareArgs<string>, AppCustomContext & MiddlewareCustomContext>[]
   ): void {
     let invalidEventName = false;
     if (typeof eventNameOrPattern === 'string') {
@@ -568,14 +581,21 @@ export default class App {
    *
    * @param listeners Middlewares that process and react to a message event
    */
-  public message(...listeners: MessageEventMiddleware[]): void;
+  public message<
+      MiddlewareCustomContext extends StringIndexed = StringIndexed,
+  >(...listeners: MessageEventMiddleware<AppCustomContext & MiddlewareCustomContext>[]): void;
   /**
    *
    * @param pattern Used for filtering out messages that don't match.
    * Strings match via {@link String.prototype.includes}.
    * @param listeners Middlewares that process and react to the message events that matched the provided patterns.
    */
-  public message(pattern: string | RegExp, ...listeners: MessageEventMiddleware[]): void;
+  public message<
+      MiddlewareCustomContext extends StringIndexed = StringIndexed,
+  >(
+    pattern: string | RegExp,
+    ...listeners: MessageEventMiddleware<AppCustomContext & MiddlewareCustomContext>[]
+  ): void;
   /**
    *
    * @param filter Middleware that can filter out messages. Generally this is done by returning before
@@ -584,8 +604,11 @@ export default class App {
    * via {@link String.prototype.includes}.
    * @param listeners Middlewares that process and react to the message events that matched the provided pattern.
    */
-  public message(
-    filter: MessageEventMiddleware, pattern: string | RegExp, ...listeners: MessageEventMiddleware[]
+  public message<
+      MiddlewareCustomContext extends StringIndexed = StringIndexed,
+  >(
+    filter: MessageEventMiddleware, pattern: string | RegExp,
+    ...listeners: MessageEventMiddleware<AppCustomContext & MiddlewareCustomContext>[]
   ): void;
   /**
    *
@@ -593,15 +616,28 @@ export default class App {
    * {@link AllMiddlewareArgs.next} if there is no match. See {@link directMention} for an example.
    * @param listeners Middlewares that process and react to the message events that matched the provided patterns.
    */
-  public message(filter: MessageEventMiddleware, ...listeners: MessageEventMiddleware[]): void;
+  public message<
+    MiddlewareCustomContext extends StringIndexed = StringIndexed,
+  >(
+    filter: MessageEventMiddleware,
+    ...listeners: MessageEventMiddleware<AppCustomContext & MiddlewareCustomContext>[]
+  ): void;
   /**
    * This allows for further control of the filtering and response logic. Patterns and middlewares are processed in
    * the order provided. If any patterns do not match, or a middleware does not call {@link AllMiddlewareArgs.next},
    * all remaining patterns and middlewares will be skipped.
    * @param patternsOrMiddleware A mix of patterns and/or middlewares.
    */
-  public message(...patternsOrMiddleware: (string | RegExp | MessageEventMiddleware)[]): void;
-  public message(...patternsOrMiddleware: (string | RegExp | MessageEventMiddleware)[]): void {
+  public message<
+    MiddlewareCustomContext extends StringIndexed = StringIndexed,
+  >(
+    ...patternsOrMiddleware: (string | RegExp | MessageEventMiddleware<AppCustomContext & MiddlewareCustomContext>)[]
+  ): void;
+  public message<
+    MiddlewareCustomContext extends StringIndexed = StringIndexed,
+  >(
+    ...patternsOrMiddleware: (string | RegExp | MessageEventMiddleware<AppCustomContext & MiddlewareCustomContext>)[]
+  ): void {
     const messageMiddleware = patternsOrMiddleware.map((patternOrMiddleware) => {
       if (typeof patternOrMiddleware === 'string' || util.types.isRegExp(patternOrMiddleware)) {
         return matchMessage(patternOrMiddleware);
@@ -617,23 +653,28 @@ export default class App {
     ] as Middleware<AnyMiddlewareArgs>[]);
   }
 
-  public shortcut<Shortcut extends SlackShortcut = SlackShortcut>(
+  public shortcut<
+    Shortcut extends SlackShortcut = SlackShortcut,
+    MiddlewareCustomContext extends StringIndexed = StringIndexed,
+  >(
     callbackId: string | RegExp,
-    ...listeners: Middleware<SlackShortcutMiddlewareArgs<Shortcut>>[]
+    ...listeners: Middleware<SlackShortcutMiddlewareArgs<Shortcut>, AppCustomContext & MiddlewareCustomContext>[]
   ): void;
   public shortcut<
     Shortcut extends SlackShortcut = SlackShortcut,
     Constraints extends ShortcutConstraints<Shortcut> = ShortcutConstraints<Shortcut>,
+    MiddlewareCustomContext extends StringIndexed = StringIndexed,
   >(
     constraints: Constraints,
-    ...listeners: Middleware<SlackShortcutMiddlewareArgs<Extract<Shortcut, { type: Constraints['type'] }>>>[]
+    ...listeners: Middleware<SlackShortcutMiddlewareArgs<Extract<Shortcut, { type: Constraints['type'] }>>, AppCustomContext & MiddlewareCustomContext>[]
   ): void;
   public shortcut<
     Shortcut extends SlackShortcut = SlackShortcut,
     Constraints extends ShortcutConstraints<Shortcut> = ShortcutConstraints<Shortcut>,
+    MiddlewareCustomContext extends StringIndexed = StringIndexed,
   >(
     callbackIdOrConstraints: string | RegExp | Constraints,
-    ...listeners: Middleware<SlackShortcutMiddlewareArgs<Extract<Shortcut, { type: Constraints['type'] }>>>[]
+    ...listeners: Middleware<SlackShortcutMiddlewareArgs<Extract<Shortcut, { type: Constraints['type'] }>>, AppCustomContext & MiddlewareCustomContext>[]
   ): void {
     const constraints: ShortcutConstraints = typeof callbackIdOrConstraints === 'string' || util.types.isRegExp(callbackIdOrConstraints) ?
       { callback_id: callbackIdOrConstraints } :
@@ -659,24 +700,29 @@ export default class App {
 
   // NOTE: this is what's called a convenience generic, so that types flow more easily without casting.
   // https://web.archive.org/web/20210629110615/https://basarat.gitbook.io/typescript/type-system/generics#motivation-and-samples
-  public action<Action extends SlackAction = SlackAction>(
+  public action<
+    Action extends SlackAction = SlackAction,
+    MiddlewareCustomContext extends StringIndexed = StringIndexed,
+  >(
     actionId: string | RegExp,
-    ...listeners: Middleware<SlackActionMiddlewareArgs<Action>>[]
+    ...listeners: Middleware<SlackActionMiddlewareArgs<Action>, AppCustomContext & MiddlewareCustomContext>[]
   ): void;
   public action<
     Action extends SlackAction = SlackAction,
     Constraints extends ActionConstraints<Action> = ActionConstraints<Action>,
+    MiddlewareCustomContext extends StringIndexed = StringIndexed,
   >(
     constraints: Constraints,
     // NOTE: Extract<> is able to return the whole union when type: undefined. Why?
-    ...listeners: Middleware<SlackActionMiddlewareArgs<Extract<Action, { type: Constraints['type'] }>>>[]
+    ...listeners: Middleware<SlackActionMiddlewareArgs<Extract<Action, { type: Constraints['type'] }>>, AppCustomContext & MiddlewareCustomContext>[]
   ): void;
   public action<
     Action extends SlackAction = SlackAction,
     Constraints extends ActionConstraints<Action> = ActionConstraints<Action>,
+    MiddlewareCustomContext extends StringIndexed = StringIndexed,
   >(
     actionIdOrConstraints: string | RegExp | Constraints,
-    ...listeners: Middleware<SlackActionMiddlewareArgs<Extract<Action, { type: Constraints['type'] }>>>[]
+    ...listeners: Middleware<SlackActionMiddlewareArgs<Extract<Action, { type: Constraints['type'] }>>, AppCustomContext & MiddlewareCustomContext>[]
   ): void {
     // Normalize Constraints
     const constraints: ActionConstraints = typeof actionIdOrConstraints === 'string' || util.types.isRegExp(actionIdOrConstraints) ?
@@ -699,7 +745,12 @@ export default class App {
     this.listeners.push([onlyActions, matchConstraints(constraints), ..._listeners] as Middleware<AnyMiddlewareArgs>[]);
   }
 
-  public command(commandName: string | RegExp, ...listeners: Middleware<SlackCommandMiddlewareArgs>[]): void {
+  public command<MiddlewareCustomContext extends StringIndexed = StringIndexed>(
+    commandName: string | RegExp, ...listeners: Middleware<
+    SlackCommandMiddlewareArgs,
+    AppCustomContext & MiddlewareCustomContext
+    >[]
+  ): void {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const _listeners = listeners as any; // FIXME: workaround for TypeScript 4.7 breaking changes
     this.listeners.push([
@@ -709,19 +760,28 @@ export default class App {
     ] as Middleware<AnyMiddlewareArgs>[]);
   }
 
-  public options<Source extends OptionsSource = 'block_suggestion'>(
+  public options<
+    Source extends OptionsSource = 'block_suggestion',
+    MiddlewareCustomContext extends StringIndexed = StringIndexed,
+  >(
     actionId: string | RegExp,
-    ...listeners: Middleware<SlackOptionsMiddlewareArgs<Source>>[]
+    ...listeners: Middleware<SlackOptionsMiddlewareArgs<Source>, AppCustomContext & MiddlewareCustomContext>[]
   ): void;
-  // TODO: reflect the type in constraits to Source
-  public options<Source extends OptionsSource = OptionsSource>(
+  // TODO: reflect the type in constraints to Source
+  public options<
+    Source extends OptionsSource = OptionsSource,
+    MiddlewareCustomContext extends StringIndexed = StringIndexed,
+  >(
     constraints: ActionConstraints,
-    ...listeners: Middleware<SlackOptionsMiddlewareArgs<Source>>[]
+    ...listeners: Middleware<SlackOptionsMiddlewareArgs<Source>, AppCustomContext & MiddlewareCustomContext>[]
   ): void;
-  // TODO: reflect the type in constraits to Source
-  public options<Source extends OptionsSource = OptionsSource>(
+  // TODO: reflect the type in constraints to Source
+  public options<
+    Source extends OptionsSource = OptionsSource,
+    MiddlewareCustomContext extends StringIndexed = StringIndexed,
+  >(
     actionIdOrConstraints: string | RegExp | ActionConstraints,
-    ...listeners: Middleware<SlackOptionsMiddlewareArgs<Source>>[]
+    ...listeners: Middleware<SlackOptionsMiddlewareArgs<Source>, AppCustomContext & MiddlewareCustomContext>[]
   ): void {
     const constraints: ActionConstraints = typeof actionIdOrConstraints === 'string' || util.types.isRegExp(actionIdOrConstraints) ?
       { action_id: actionIdOrConstraints } :
@@ -732,17 +792,26 @@ export default class App {
     this.listeners.push([onlyOptions, matchConstraints(constraints), ..._listeners] as Middleware<AnyMiddlewareArgs>[]);
   }
 
-  public view<ViewActionType extends SlackViewAction = SlackViewAction>(
+  public view<
+    ViewActionType extends SlackViewAction = SlackViewAction,
+    MiddlewareCustomContext extends StringIndexed = StringIndexed,
+  >(
     callbackId: string | RegExp,
-    ...listeners: Middleware<SlackViewMiddlewareArgs<ViewActionType>>[]
+    ...listeners: Middleware<SlackViewMiddlewareArgs<ViewActionType>, AppCustomContext & MiddlewareCustomContext>[]
   ): void;
-  public view<ViewActionType extends SlackViewAction = SlackViewAction>(
+  public view<
+    ViewActionType extends SlackViewAction = SlackViewAction,
+    MiddlewareCustomContext extends StringIndexed = StringIndexed,
+  >(
     constraints: ViewConstraints,
-    ...listeners: Middleware<SlackViewMiddlewareArgs<ViewActionType>>[]
+    ...listeners: Middleware<SlackViewMiddlewareArgs<ViewActionType>, AppCustomContext & MiddlewareCustomContext>[]
   ): void;
-  public view<ViewActionType extends SlackViewAction = SlackViewAction>(
+  public view<
+    ViewActionType extends SlackViewAction = SlackViewAction,
+    MiddlewareCustomContext extends StringIndexed = StringIndexed,
+  >(
     callbackIdOrConstraints: string | RegExp | ViewConstraints,
-    ...listeners: Middleware<SlackViewMiddlewareArgs<ViewActionType>>[]
+    ...listeners: Middleware<SlackViewMiddlewareArgs<ViewActionType>, AppCustomContext & MiddlewareCustomContext>[]
   ): void {
     const constraints: ViewConstraints = typeof callbackIdOrConstraints === 'string' || util.types.isRegExp(callbackIdOrConstraints) ?
       { callback_id: callbackIdOrConstraints, type: 'view_submission' } :

--- a/src/types/middleware.ts
+++ b/src/types/middleware.ts
@@ -17,8 +17,8 @@ export type AnyMiddlewareArgs =
   | SlackViewMiddlewareArgs
   | SlackShortcutMiddlewareArgs;
 
-export interface AllMiddlewareArgs {
-  context: Context;
+export interface AllMiddlewareArgs<CustomContext = StringIndexed> {
+  context: Context & CustomContext;
   logger: Logger;
   client: WebClient;
   next: NextFn;
@@ -26,8 +26,8 @@ export interface AllMiddlewareArgs {
 
 // NOTE: Args should extend AnyMiddlewareArgs, but because of contravariance for function types, including that as a
 // constraint would mess up the interface of App#event(), App#message(), etc.
-export interface Middleware<Args> {
-  (args: Args & AllMiddlewareArgs): Promise<void>;
+export interface Middleware<Args, CustomContext = StringIndexed> {
+  (args: Args & AllMiddlewareArgs<CustomContext>): Promise<void>;
 }
 
 /**


### PR DESCRIPTION
###  Summary

This pr picks up from #1157 and allows users to pass custom types to the App initialization(Global Context) as well as individual middleware(Localized Context). This allows IDEs to provide more specific suggestions as well as better type checking.

I've included an example of the direction I'm thinking would work for testing this. Testing is a little weird because this is purely a type system addition. As it's just the type system, the only forms of tests I can think of will cause compilation errors rather than test failures. Additionally, as the Context type is still StringIndexed an `IsAny` check was used which was found via [StackOverflow](https://stackoverflow.com/a/55541672). If there are any suggestions for better way to test this, I'd be happy to give it a try, otherwise I can move forward with the test cases using the my current method.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).