### PR TITLE
feat: add `isEnterpriseInstall` to Context

### DIFF
--- a/src/App.ts
+++ b/src/App.ts
@@ -828,7 +828,9 @@ export default class App {
           error: e,
           logger: this.logger,
           body: bodyArg,
-          context: {},
+          context: {
+            isEnterpriseInstall,
+          },
         });
       }
     }
@@ -854,6 +856,7 @@ export default class App {
     const context: Context = {
       ...authorizeResult,
       ...event.customProperties,
+      isEnterpriseInstall,
       retryNum: event.retryNum,
       retryReason: event.retryReason,
     };
@@ -1329,7 +1332,7 @@ function buildSource<IsEnterpriseInstall extends boolean>(
     if (type === IncomingEventType.Event) {
       const bodyAsEvent = body as SlackEventMiddlewareArgs['body'];
       if (Array.isArray(bodyAsEvent.authorizations) && bodyAsEvent.authorizations[0] !== undefined) {
-        // The enteprise_id here can be null when the workspace is not in an Enterprise Grid
+        // The enterprise_id here can be null when the workspace is not in an Enterprise Grid
         const theId = bodyAsEvent.authorizations[0].enterprise_id;
         return theId !== null ? theId : undefined;
       }

--- a/src/middleware/builtin.spec.ts
+++ b/src/middleware/builtin.spec.ts
@@ -225,7 +225,9 @@ describe('Built-in global middleware', () => {
       const fakeArgs = {
         next: () => Promise.resolve(),
         message: createFakeMessageEvent(),
-        context: {},
+        context: {
+          isEnterpriseInstall: false,
+        },
       } as unknown as MessageMiddlewareArgs;
       const { directMention } = await importBuiltin();
 
@@ -510,7 +512,9 @@ describe('Built-in global middleware', () => {
         respond: noop,
         ack: noop,
         next: fakeNext,
-        context: {},
+        context: {
+          isEnterpriseInstall: false,
+        },
       };
       await onlyCommands(args);
       assert.isTrue(fakeNext.called);
@@ -530,7 +534,9 @@ describe('Built-in global middleware', () => {
         respond: noop,
         ack: noop,
         next: fakeNext,
-        context: {},
+        context: {
+          isEnterpriseInstall: false,
+        },
       };
       await onlyCommands(args);
       assert.isTrue(fakeNext.notCalled);
@@ -553,7 +559,9 @@ describe('Built-in global middleware', () => {
         respond: noop,
         ack: noop,
         next: fakeNext,
-        context: {},
+        context: {
+          isEnterpriseInstall: false,
+        },
       };
     }
 
@@ -604,7 +612,9 @@ describe('Built-in global middleware', () => {
         logger,
         client,
         next: fakeNext,
-        context: {},
+        context: {
+          isEnterpriseInstall: false,
+        },
         ...args,
       };
       // FIXME: Using any is a workaround for TypeScript 4.7 breaking changes
@@ -626,7 +636,9 @@ describe('Built-in global middleware', () => {
         respond: noop,
         ack: noop,
         next: fakeNext,
-        context: {},
+        context: {
+          isEnterpriseInstall: false,
+        },
       };
       await onlyEvents(args);
       assert.isFalse(fakeNext.called);
@@ -690,7 +702,9 @@ describe('Built-in global middleware', () => {
         logger,
         client,
         next: fakeNext,
-        context: {},
+        context: {
+          isEnterpriseInstall: false,
+        },
         ..._args,
       };
       await matchEventType('app_mention')(args);
@@ -706,7 +720,9 @@ describe('Built-in global middleware', () => {
         logger,
         client,
         next: fakeNext,
-        context: {},
+        context: {
+          isEnterpriseInstall: false,
+        },
         ..._args,
       };
       await matchEventType(/app_mention|app_home_opened/)(args);
@@ -722,7 +738,9 @@ describe('Built-in global middleware', () => {
         logger,
         client,
         next: fakeNext,
-        context: {},
+        context: {
+          isEnterpriseInstall: false,
+        },
         ..._args,
       };
       await matchEventType(/app_mention|app_home_opened/)(args);
@@ -738,7 +756,9 @@ describe('Built-in global middleware', () => {
         logger,
         client,
         next: fakeNext,
-        context: {},
+        context: {
+          isEnterpriseInstall: false,
+        },
         ..._args,
       };
       await matchEventType('app_home_opened')(args);
@@ -754,7 +774,9 @@ describe('Built-in global middleware', () => {
         logger,
         client,
         next: fakeNext,
-        context: {},
+        context: {
+          isEnterpriseInstall: false,
+        },
         ..._args,
       } as any;
       await matchEventType(/foo/)(args);
@@ -796,7 +818,9 @@ describe('Built-in global middleware', () => {
         logger,
         client,
         next: fakeNext,
-        context: {},
+        context: {
+          isEnterpriseInstall: false,
+        },
         ..._args,
       };
       await subtype('bot_message')(args);
@@ -812,7 +836,9 @@ describe('Built-in global middleware', () => {
         logger,
         client,
         next: fakeNext,
-        context: {},
+        context: {
+          isEnterpriseInstall: false,
+        },
         ..._args,
       };
       await subtype('me_message')(args);

--- a/src/types/middleware.ts
+++ b/src/types/middleware.ts
@@ -64,6 +64,10 @@ export interface Context extends StringIndexed {
    * Enterprise Grid Organization ID.
    */
   enterpriseId?: string;
+  /**
+   * Is the app installed at an Enterprise level?
+   */
+  isEnterpriseInstall: boolean,
 
   /**
    * Retry count of an Events API request (this property does not exist for other requests)


### PR DESCRIPTION
###  Summary

#1510 - Add `isEnterpriseInstall` to aid in processing events.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).