### PR TITLE
Add Bolt exports for SlackManifest definition utils

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "@slack/socket-mode": "^1.3.0",
     "@slack/types": "^2.4.0",
     "@slack/web-api": "^6.7.1",
+    "@slack/deno-slack-sdk": "@slack/deno-slack-sdk",
     "@types/express": "^4.16.1",
     "@types/node": ">=12",
     "@types/promise.allsettled": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "@slack/socket-mode": "^1.3.0",
     "@slack/types": "^2.4.0",
     "@slack/web-api": "^6.7.1",
-    "@slack/deno-slack-sdk": "@slack/deno-slack-sdk",
+    "@slack/deno-slack-sdk": "^0.0.10",
     "@types/express": "^4.16.1",
     "@types/node": ">=12",
     "@types/promise.allsettled": "^1.0.3",

--- a/src/Manifest.ts
+++ b/src/Manifest.ts
@@ -5,7 +5,8 @@ import {
   DefineWorkflow,
   DefineType,
   Schema,
-  ManifestSchema
+  ManifestSchema,
+  DefineOAuth2Provider,
 } from '@slack/deno-slack-sdk';
 
 export const Manifest = (definition: SlackManifestType): ManifestSchema => {
@@ -15,9 +16,11 @@ export const Manifest = (definition: SlackManifestType): ManifestSchema => {
 
 // pass through re-export
 export type { 
+  SlackManifest,
   SlackManifestType,
   DefineFunction,
   DefineWorkflow,
   DefineType,
-  Schema
+  Schema,
+  DefineOAuth2Provider
 };

--- a/src/Manifest.ts
+++ b/src/Manifest.ts
@@ -5,7 +5,6 @@ import {
   DefineWorkflow,
   DefineType,
   Schema,
-  DefineDatastore,
   ManifestSchema
 } from '@slack/deno-slack-sdk';
 
@@ -20,6 +19,5 @@ export type {
   DefineFunction,
   DefineWorkflow,
   DefineType,
-  DefineDatastore,
   Schema
 };

--- a/src/Manifest.ts
+++ b/src/Manifest.ts
@@ -1,0 +1,25 @@
+import { 
+  SlackManifest,
+  SlackManifestType,
+  DefineFunction,
+  DefineWorkflow,
+  DefineType,
+  Schema,
+  DefineDatastore,
+  ManifestSchema
+} from '@slack/deno-slack-sdk';
+
+export const Manifest = (definition: SlackManifestType): ManifestSchema => {
+  const manifest = new SlackManifest(definition);
+  return manifest.export();
+};
+
+// pass through re-export
+export type { 
+  SlackManifestType,
+  DefineFunction,
+  DefineWorkflow,
+  DefineType,
+  DefineDatastore,
+  Schema
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -61,6 +61,16 @@ export {
 } from './WorkflowStep';
 
 export {
+  Manifest,
+  SlackManifestType,
+  DefineFunction,
+  DefineWorkflow,
+  DefineType,
+  DefineDatastore,
+  Schema
+} from './Manifest';
+
+export {
   Installation,
   InstallURLOptions,
   InstallationQuery,

--- a/src/index.ts
+++ b/src/index.ts
@@ -61,13 +61,13 @@ export {
 } from './WorkflowStep';
 
 export {
-  Manifest,
+  SlackManifest,
   SlackManifestType,
   DefineFunction,
   DefineWorkflow,
   DefineType,
-  DefineDatastore,
-  Schema
+  Schema,
+  DefineOAuth2Provider
 } from './Manifest';
 
 export {


### PR DESCRIPTION
###  Summary

This PR adds support for `Manifest` in @slack/bolt as part of a top-level exports.

Developers can now import `Manifest`, `DefineFunction` and other helpful utilities for manifest definition in their Hermes projects. 

```
// manifest.js
// import Manifest function and 2.0 helpful functions
const { DefineFunction, Manifest, Schema } = require('@slack/bolt'); 
```

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).