### PR TITLE
Fix #1509 HTTPReceiver does not immediately respond to an invalid signature request (no response instead)

### DIFF
--- a/src/receivers/HTTPModuleFunctions.ts
+++ b/src/receivers/HTTPModuleFunctions.ts
@@ -129,6 +129,7 @@ export class HTTPModuleFunctions {
 
   public static buildNoBodyResponse(res: ServerResponse, status: number): void {
     res.writeHead(status);
+    res.end();
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
###  Summary

This pull request resolves #1509

The cause is a regression bug in https://github.com/slackapi/bolt-js/pull/1359, which has been affecting v3.11.0 through v3.12.0 

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).