### PR TITLE
Fix manifest read issue

### DIFF
--- a/src/Manifest.ts
+++ b/src/Manifest.ts
@@ -15,12 +15,15 @@ export const Manifest = (definition: SlackManifestType): ManifestSchema => {
 };
 
 // pass through re-export
-export type { 
-  SlackManifest,
-  SlackManifestType,
+export { 
   DefineFunction,
   DefineWorkflow,
-  DefineType,
+  DefineOAuth2Provider,
   Schema,
-  DefineOAuth2Provider
+  SlackManifest,
+};
+
+export type {
+  SlackManifestType,
+  DefineType,
 };

--- a/src/cli/get-manifest.js
+++ b/src/cli/get-manifest.js
@@ -15,10 +15,8 @@ const { unionMerge, readManifestJSONFile, readImportedManifestFile, hasManifest 
 
   // look for a manifest files
   const manifestJSON = readManifestJSONFile(cwd, `${file}.json`);
-  const manifestTS = readImportedManifestFile(cwd, `${file}.ts`);
   const manifestJS = readImportedManifestFile(cwd, `${file}.js`);
-
-  if (!hasManifest(manifestTS, manifestJS, manifestJSON)) {
+  if (!hasManifest(manifestJS, manifestJSON)) {
     throw new Error('Unable to find a manifest file in this project');
   }
 
@@ -26,11 +24,8 @@ const { unionMerge, readManifestJSONFile, readImportedManifestFile, hasManifest 
   // check for .json
   if (manifestJSON) {
     manifest = merge(manifest, manifestJSON, { arrayMerge: unionMerge});
-  }
-  // check for either .ts or .js file
-  if (manifestTS) {
-    manifest = merge(manifest, manifestTS, { arrayMerge: unionMerge });
-  } else if (manifestJS) {
+  }  
+  if (manifestJS) {
     manifest = merge(manifest, manifestJS, { arrayMerge: unionMerge });
   }
     

--- a/src/cli/hook-utils/manifest.js
+++ b/src/cli/hook-utils/manifest.js
@@ -22,7 +22,6 @@ function readManifestJSONFile(cwd, filename) {
 
 // look for a manifest file in the current working directory
 function readImportedManifestFile(cwd, filename) {
-
   let importedManifestFilePath, manifestImported;
 
   try {


### PR DESCRIPTION
###  Summary

get-manifest now looks for .js and .json, not .ts. We expect TS developers to transpile down to .js in order to work with the CLI for the time being. This doesn't affect compatibility for developers with TS.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).