### PR TITLE
Update Function -> SlackFunction

### DIFF
--- a/src/App.ts
+++ b/src/App.ts
@@ -23,7 +23,7 @@ import processMiddleware from './middleware/process';
 import { ConversationStore, conversationContext, MemoryStore } from './conversation-store';
 import { WorkflowStep } from './WorkflowStep';
 import { Subscription, SubscriptionOptions } from './Subscription';
-import { Function as SlackFunction } from './Function';
+import { SlackFunction } from './SlackFunction';
 import {
   Middleware,
   AnyMiddlewareArgs,
@@ -600,13 +600,13 @@ export default class App {
 
   /**
    * Register listeners that process and react to a function execution event
-   * @param fnTitle the name of the fn as defined in manifest.json
-   * must match the function defined in manifest json
+   * @param title the name of the fn as defined in manifest file
+   * must match the function defined in manifest file
    * @param fn a single function to register
    * */
-  public function(fnTitle: string, fn: Middleware<SlackEventMiddlewareArgs>): this {
+  public function(title: string, fn: Middleware<SlackEventMiddlewareArgs>): this {
     // TODO: Support for multiple function listeners
-    const slackFn = new SlackFunction(fnTitle, fn);
+    const slackFn = new SlackFunction(title, fn);
     const m = slackFn.getMiddleware();
     this.middleware.push(m);
     return this;

--- a/src/index.ts
+++ b/src/index.ts
@@ -82,4 +82,5 @@ export {
   InstallProviderOptions,
 } from '@slack/oauth';
 
+export * from "./SlackFunction";
 export * from '@slack/types';

--- a/src/types/events/base-events.ts
+++ b/src/types/events/base-events.ts
@@ -424,13 +424,20 @@ export interface FileUnsharedEvent {
   channel_id: string;
   event_ts: string;
 }
-interface FunctionParams {
-  type: string,
-  name: string,
-  description: string,
-  title: string,
-  is_required: boolean,
+export interface FunctionParams {
+  type?: string,
+  name?: string,
+  description?: string,
+  title?: string,
+  is_required?: boolean,
 }
+
+export type FunctionInputValues = {
+  [key: string]: unknown;
+};
+
+export type FunctionOutputValues = FunctionInputValues;
+
 export interface FunctionExecutedEvent {
   type: 'function_executed',
   function: {
@@ -445,7 +452,7 @@ export interface FunctionExecutedEvent {
     date_updated: number,
   },
   function_execution_id: string,
-  inputs: Record<string, unknown>,
+  inputs: FunctionInputValues,
   workflow_token: string, // xwfp-xxxxxxxxxxx
   event_ts: string,
 }

--- a/src/types/middleware.ts
+++ b/src/types/middleware.ts
@@ -8,6 +8,7 @@ import { SlackOptionsMiddlewareArgs } from './options';
 import { SlackShortcutMiddlewareArgs } from './shortcuts';
 import { SlackViewMiddlewareArgs } from './view';
 import { SlackSubscriptionMiddlewareArgs } from './subscription';
+import { SlackFunctionExecutedMiddlewareArgs } from '../SlackFunction';
 
 // TODO: rename this to AnyListenerArgs, and all the constituent types
 export type AnyMiddlewareArgs =
@@ -17,7 +18,8 @@ export type AnyMiddlewareArgs =
   | SlackOptionsMiddlewareArgs
   | SlackViewMiddlewareArgs
   | SlackShortcutMiddlewareArgs
-  | SlackSubscriptionMiddlewareArgs;
+  | SlackSubscriptionMiddlewareArgs
+  | SlackFunctionExecutedMiddlewareArgs;
 export interface AllMiddlewareArgs {
   context: Context;
   logger: Logger;


### PR DESCRIPTION
###  Summary

This PR adds a few updates to improve naming in the function middleware implementation.

Updates: 
* Renames `Function` class to `SlackFunction` to reduce confusion as there's a reserved Function in JS.
* Renames `success` and `error` utility arguments to `completeSuccess` and `completeError` for better consistency with verb syntax for listener arguments.  
* Small changes to Function types

### Testing
* Build this branch locally and `npm link`
* `hermes create -t slack-samples/bolt-ts-starter-template -b future`
* `npm run build && hermes manifest` to sanity check the manifest.`hermes run -v` to start the app
* Test in your workspace that the function runs successfully. 

This PR addresses much of the feedback in: https://github.com/slackapi/bolt-js/pull/1383 with the exception of adding tests. Future PRs should add this coverage, then that PR should be ready to close out!

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).