### PR TITLE
Fix issue with parsing manifest module with object functions

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "url": "https://github.com/slackapi/bolt-js/issues"
   },
   "dependencies": {
-    "@slack/deno-slack-sdk": ">=0.0.10",
+    "@slack/deno-slack-sdk": "^0.1.0",
     "@slack/logger": "^3.0.0",
     "@slack/oauth": "^2.5.1",
     "@slack/socket-mode": "^1.3.0",

--- a/src/Manifest.ts
+++ b/src/Manifest.ts
@@ -21,9 +21,9 @@ export {
   DefineOAuth2Provider,
   Schema,
   SlackManifest,
+  DefineType,
 };
 
 export type {
   SlackManifestType,
-  DefineType,
 };

--- a/src/cli/get-manifest.js
+++ b/src/cli/get-manifest.js
@@ -13,15 +13,19 @@ const { unionMerge, readManifestJSONFile, readImportedManifestFile, hasManifest 
   const file = 'manifest';
   let manifest = {};
 
-  // look for a manifest files
+  // look for a manifest JSON
   const manifestJSON = readManifestJSONFile(cwd, `${file}.json`);
-  const manifestJS = readImportedManifestFile(cwd, `${file}.js`);
+  
+  // look for manifest.js
+  // stringify and parses the JSON in order to ensure that objects with .toJSON() functions
+  // resolve properly. This is a known behavior for CustomType
+  const manifestJS = JSON.parse(JSON.stringify(readImportedManifestFile(cwd, `${file}.js`)));
+
   if (!hasManifest(manifestJS, manifestJSON)) {
     throw new Error('Unable to find a manifest file in this project');
   }
 
   // manage manifest merge
-  // check for .json
   if (manifestJSON) {
     manifest = merge(manifest, manifestJSON, { arrayMerge: unionMerge});
   }  


### PR DESCRIPTION
###  Summary

Fix issue with parsing manifest module with object functions

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).