### PR TITLE
Update SocketModeFunctions.ts

### DIFF
--- a/src/receivers/SocketModeFunctions.ts
+++ b/src/receivers/SocketModeFunctions.ts
@@ -17,7 +17,7 @@ export class SocketModeFunctions {
     // TODO: more details like envelop_id, payload type etc. here
     // To make them available, we need to enhance underlying SocketModeClient
     // to return more properties to 'slack_event' listeners
-    logger.error(`An unhandled error occurred while Bolt processed (type: ${event.body.type}, error: ${error})`);
+    logger.error(`An unhandled error occurred while Bolt processed (type: ${event.body?.type}, error: ${error})`);
     logger.debug(`Error details: ${error}, retry num: ${event.retryNum}, retry reason: ${event.retryReason}`);
     const errorCode = (error as CodedError).code;
     if (errorCode === ErrorCode.AuthorizationError) {


### PR DESCRIPTION
###  Summary

This PR will fix an issue where the bolt app will crash due to disabling socket mode while running. When this is disabled, the app crashes due to an attempt to access a key of an undefined value, body.type. All that is needed to avoid this crash is to add optional chaining.

This is the error that is displayed (locally) when socket mode is disabled:
```
C:\Users\RileyEaton\Documents\gameon\node_modules\@slack\bolt\dist\receivers\SocketModeFunctions.js:17
        logger.error(`An unhandled error occurred while Bolt processed (type: ${event.body.type}, error: ${error})`);
                                                                                           ^

TypeError: Cannot read properties of undefined (reading 'type')
    at SocketModeReceiver.defaultProcessEventErrorHandler [as processEventErrorHandler] (C:\Users\RileyEaton\Documents\gameon\node_modules\@slack\bolt\dist\receivers\SocketModeFunctions.js:17:92)
    at SocketModeClient.<anonymous> (C:\Users\RileyEaton\Documents\gameon\node_modules\@slack\bolt\dist\receivers\SocketModeReceiver.js:129:50)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
```

This is because the event object is:
```
{
  body: undefined,
  ack: [AsyncFunction: ack],
  retryNum: undefined,
  retryReason: undefined,
  customProperties: {}
}
```
    
It is important that this is fixed because it cannot be caught by any users of this library as it is an internal process.

Please correct me if this pull request should be to a different base branch as I am not familiar with the current branch structure.

### Requirements 

* [X] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [X] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).