### PR TITLE
Fix misspellings / typos detected by WebStorm IDE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@
 
 # macOS
 .DS_Store
+
+# WebStorm
+.idea/

--- a/src/App.ts
+++ b/src/App.ts
@@ -134,7 +134,7 @@ export interface AuthorizeResult {
   botUserId?: string; // optional but allows `ignoreSelf` global middleware be more filter more than just message events
   teamId?: string;
   enterpriseId?: string;
-  // TODO: for better type safety, we may want to reivit this
+  // TODO: for better type safety, we may want to revisit this
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   [key: string]: any;
 }
@@ -290,8 +290,6 @@ export default class App<AppCustomContext extends StringIndexed = StringIndexed>
     extendedErrorHandler = false,
     deferInitialization = false,
   }: AppOptions = {}) {
-    // this.logLevel = logLevel;
-
     /* ------------------------ Developer mode ----------------------------- */
     this.developerMode = developerMode;
     if (developerMode) {
@@ -346,7 +344,7 @@ export default class App<AppCustomContext extends StringIndexed = StringIndexed>
       httpAgent: agent,
       httpsAgent: agent,
       // disabling axios' automatic proxy support:
-      // axios would read from envvars to configure a proxy automatically, but it doesn't support TLS destinations.
+      // axios would read from env vars to configure a proxy automatically, but it doesn't support TLS destinations.
       // for compatibility with https://api.slack.com, and for a larger set of possible proxies (SOCKS or other
       // protocols), users of this package should use the `agent` option to configure a proxy.
       proxy: false,
@@ -363,7 +361,7 @@ export default class App<AppCustomContext extends StringIndexed = StringIndexed>
     };
     if (socketMode && port !== undefined && this.installerOptions.port === undefined) {
       // SocketModeReceiver only uses a custom port number  when listening for the OAuth flow.
-      // Therefore only installerOptions.port is available in the constructor arguments.
+      // Therefore, only installerOptions.port is available in the constructor arguments.
       this.installerOptions.port = port;
     }
 
@@ -1091,7 +1089,7 @@ export default class App<AppCustomContext extends StringIndexed = StringIndexed>
               context,
               client,
               this.logger,
-              // When all of the listener middleware are done processing,
+              // When all the listener middleware are done processing,
               // `listener` here will be called without a `next` execution
               async () => listener({
                 ...(listenerArgs as AnyMiddlewareArgs),
@@ -1226,8 +1224,8 @@ export default class App<AppCustomContext extends StringIndexed = StringIndexed>
       httpReceiver.installer !== undefined &&
       httpReceiver.installer.authorize !== undefined
     ) {
-      // This supports using the built in HTTPReceiver, declaring your own HTTPReceiver
-      // and theoretically, doing a fully custom (non express) receiver that implements OAuth
+      // This supports using the built-in HTTPReceiver, declaring your own HTTPReceiver
+      // and theoretically, doing a fully custom (non-Express.js) receiver that implements OAuth
       usingOauth = true;
     }
 

--- a/src/receivers/ExpressReceiver.ts
+++ b/src/receivers/ExpressReceiver.ts
@@ -521,7 +521,7 @@ function verifyRequestSignature(
 /**
  * This request handler has two responsibilities:
  * - Verify the request signature
- * - Parse request.body and assign the successfully parsed object to it.
+ * - Parse `request.body` and assign the successfully parsed object to it.
  */
 export function verifySignatureAndParseBody(
   signingSecret: string,
@@ -566,6 +566,7 @@ export function buildBodyParserMiddleware(logger: Logger): RequestHandler {
 
 function parseRequestBody(stringBody: string, contentType: string | undefined): any {
   if (contentType === 'application/x-www-form-urlencoded') {
+    // TODO: querystring is deprecated since Node.js v17
     const parsedBody = querystring.parse(stringBody);
 
     if (typeof parsedBody.payload === 'string') {

--- a/src/receivers/HTTPModuleFunctions.ts
+++ b/src/receivers/HTTPModuleFunctions.ts
@@ -71,7 +71,7 @@ export class HTTPModuleFunctions {
     const bufferedReq = await HTTPModuleFunctions.bufferIncomingMessage(req);
 
     if (options.enabled !== undefined && !options.enabled) {
-      // As the validation is disabled, immediately return the bufferred reuest
+      // As the validation is disabled, immediately return the buffered request
       return bufferedReq;
     }
     const textBody = bufferedReq.rawBody.toString();

--- a/src/receivers/HTTPReceiver.ts
+++ b/src/receivers/HTTPReceiver.ts
@@ -394,9 +394,9 @@ export default class HTTPReceiver implements Receiver {
       if (match) { return this.routes[path][method](req, res); }
     }
 
-    // If the request did not match the previous conditions, an error is thrown. The error can be caught by the
+    // If the request did not match the previous conditions, an error is thrown. The error can be caught by
     // the caller in order to defer to other routing logic (similar to calling `next()` in connect middleware).
-    // If you would like to customize the HTTP repsonse for this pattern,
+    // If you would like to customize the HTTP response for this pattern,
     // implement your own dispatchErrorHandler that handles an exception
     // with ErrorCode.HTTPReceiverDeferredRequestError.
     throw new HTTPReceiverDeferredRequestError(`Unhandled HTTP request (${method}) made to ${path}`, req, res);
@@ -412,7 +412,7 @@ export default class HTTPReceiver implements Receiver {
       try {
         bufferedReq = await httpFunc.parseAndVerifyHTTPRequest(
           {
-            // If enabled: false, this method returns bufferredReq without verification
+            // If enabled: false, this method returns bufferedReq without verification
             enabled: this.signatureVerification,
             signingSecret: this.signingSecret,
           },
@@ -431,7 +431,7 @@ export default class HTTPReceiver implements Receiver {
 
       // Parse request body
       // The object containing the parsed body is not exposed to the caller. It is preferred to reduce mutations to the
-      // req object, so that its as reusable as possible. Later, we should consider adding an option for assigning the
+      // req object, so that it's as reusable as possible. Later, we should consider adding an option for assigning the
       // parsed body to `req.body`, as this convention has been established by the popular `body-parser` package.
       try {
         body = httpFunc.parseHTTPRequestBody(bufferedReq);

--- a/src/receivers/verify-request.ts
+++ b/src/receivers/verify-request.ts
@@ -25,7 +25,7 @@ export interface SlackRequestVerificationOptions {
 
 /**
  * Verifies the signature of an incoming request from Slack.
- * If the requst is invalid, this method throws an exception with the erorr details.
+ * If the request is invalid, this method throws an exception with the error details.
  */
 export function verifySlackRequest(options: SlackRequestVerificationOptions): void {
   const requestTimestampSec = options.headers['x-slack-request-timestamp'];
@@ -67,7 +67,7 @@ export function verifySlackRequest(options: SlackRequestVerificationOptions): vo
 
 /**
  * Verifies the signature of an incoming request from Slack.
- * If the requst is invalid, this method returns false.
+ * If the request is invalid, this method returns false.
  */
 export function isValidSlackRequest(options: SlackRequestVerificationOptions): boolean {
   try {
@@ -82,7 +82,7 @@ export function isValidSlackRequest(options: SlackRequestVerificationOptions): b
 }
 
 // ------------------------------
-// legacy methods (depreacted)
+// legacy methods (deprecated)
 // ------------------------------
 
 const consoleLogger = new ConsoleLogger();

--- a/src/types/view/index.ts
+++ b/src/types/view/index.ts
@@ -201,7 +201,7 @@ export type ViewResponseAction =
 
 /**
  * Type function which given a view action `VA` returns a corresponding type for the `ack()` function. The function is
- * used to acknowledge the receipt (and possibly signal failure) of an view submission or closure from a listener or
+ * used to acknowledge the receipt (and possibly signal failure) of a view submission or closure from a listener or
  * middleware.
  */
 type ViewAckFn<VA extends SlackViewAction = SlackViewAction> = VA extends ViewSubmitAction


### PR DESCRIPTION
###  Summary

This pull request resolves misspellings/typos in the code, that were detected by WebStorm IDE. 

Although WebStorm suggested changing many of the private fields to read-only ones too, I didn't do so this time. Changing the modifiers would be safe enough, but it can break the existing test code.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).