### PR TITLE
Set @types/node to set version 18.7.15

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "sinon": "^7.3.1",
     "source-map-support": "^0.5.12",
     "ts-node": "^8.1.0",
-    "tsd": "^0.11.0",
+    "tsd": "^0.22.0",
     "typescript": "^4.1.0"
   },
   "tsd": {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@slack/types": "^2.7.0",
     "@slack/web-api": "^6.7.1",
     "@types/express": "^4.16.1",
-    "@types/node": ">=12",
+    "@types/node": "18.7.15",
     "@types/promise.allsettled": "^1.0.3",
     "@types/tsscmp": "^1.0.0",
     "axios": "^0.26.1",
@@ -81,7 +81,7 @@
     "sinon": "^7.3.1",
     "source-map-support": "^0.5.12",
     "ts-node": "^8.1.0",
-    "tsd": "^0.22.0",
+    "tsd": "^0.11.0",
     "typescript": "^4.1.0"
   },
   "tsd": {


### PR DESCRIPTION
###  Summary

Setting the `@types/node` package to a set version `18.7.15` due to a breaking change in `18.7.16` 

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).