### PR TITLE
Add dependabot version management

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: "npm" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5 
+    allow:
+      - dependency-name: "typescript"
+      - dependency-name: "@types/node"
+    ignore:
+      - dependency-name: "*" 
+        update-types: ["version-update:semver-patch", "version-update:semver-minor"] 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,8 +6,9 @@ updates:
       interval: "weekly"
     open-pull-requests-limit: 5 
     allow:
+      # allow updates for typescript
       - dependency-name: "typescript"
+      # allow updates for node types
       - dependency-name: "@types/node"
-    ignore:
-      - dependency-name: "*" 
-        update-types: ["version-update:semver-patch", "version-update:semver-minor"] 
+      # allow updates for slack official libraries
+      - dependency-name: "@slack/*"

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "source-map-support": "^0.5.12",
     "ts-node": "^8.1.0",
     "tsd": "^0.22.0",
-    "typescript": "^4.1.0"
+    "typescript": "4.7.4"
   },
   "tsd": {
     "directory": "types-tests"


### PR DESCRIPTION
###  Summary

Adds dependabot version management to bolt-js repos. Limits # of active PRs to 5 at any 1 time to manage volume, and works off an allowlist. 

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).