### PR TITLE
[HERMES-3750] Fix bug where missing .js file results in JSON.parse error

### DIFF
--- a/src/cli/get-manifest.js
+++ b/src/cli/get-manifest.js
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-const { getManifestData } = require('./hook-utils/manifest');
+const { getManifestData } = require('./hook-utils/get-manifest-data');
 
 /** 
  * Implements the get-manifest script hook required by the Slack CLI

--- a/src/cli/hook-utils/get-manifest-data.js
+++ b/src/cli/hook-utils/get-manifest-data.js
@@ -1,0 +1,39 @@
+const { 
+  readManifestJSONFile,
+  readImportedManifestFile,
+  hasManifest,
+  merge,
+  unionMerge
+} = require('./manifest.js');
+const { AppManifestInitializationError } = require('../../errors');
+
+/** 
+ * Returns any manifest data, if it exists.
+ * Otherwise throws an error
+ * @param searchDir path to begin searching at
+ */
+ function getManifestData(searchDir) {
+  const file = 'manifest';
+  let manifest = {};
+  
+  // look for a manifest JSON
+  const manifestJSON = readManifestJSONFile(searchDir, `${file}.json`);
+  // look for manifest.js
+  let manifestJS = readImportedManifestFile(searchDir, `${file}.js`);
+  
+  if (!hasManifest(manifestJS, manifestJSON)) {
+    const msg = 'Unable to find a manifest file in this project';
+    throw new AppManifestInitializationError(msg);
+  }
+
+  // manage manifest merge
+  if (manifestJSON) {
+    manifest = merge(manifest, manifestJSON, { arrayMerge: unionMerge });
+  }  
+  if (manifestJS) {
+    manifest = merge(manifest, manifestJS, { arrayMerge: unionMerge });
+  }
+  return manifest;
+} 
+
+module.exports = { getManifestData };

--- a/src/cli/hook-utils/get-manifest-data.js
+++ b/src/cli/hook-utils/get-manifest-data.js
@@ -2,10 +2,10 @@ const {
   readManifestJSONFile,
   readImportedManifestFile,
   hasManifest,
-  merge,
-  unionMerge
+  unionMerge,
 } = require('./manifest.js');
-const { AppManifestInitializationError } = require('../../errors');
+const merge = require('deepmerge');
+
 
 /** 
  * Returns any manifest data, if it exists.
@@ -23,7 +23,7 @@ const { AppManifestInitializationError } = require('../../errors');
   
   if (!hasManifest(manifestJS, manifestJSON)) {
     const msg = 'Unable to find a manifest file in this project';
-    throw new AppManifestInitializationError(msg);
+    throw new Error(msg);
   }
 
   // manage manifest merge

--- a/src/cli/hook-utils/get-manifest-data.spec.js
+++ b/src/cli/hook-utils/get-manifest-data.spec.js
@@ -4,7 +4,6 @@ const { expect, assert } = require('chai');
 const rewiremock = require('rewiremock/node');
 const { hasManifest } = require('./manifest');
 const merge = require('deepmerge');
-const { AppManifestInitializationError } = require('../../errors');
 
 async function importGetManifestDataMock(overrides) {
   return rewiremock.module(() => import('./get-manifest-data.js'), overrides);
@@ -93,6 +92,6 @@ describe('Slack CLI Script Hooks: get-manifest-data', () => {
    
     // doesnt error
     const shouldThrow = () => getManifestData('testSearchDir', 'testFilename');
-    assert.throws(shouldThrow, AppManifestInitializationError, 'Unable to find a manifest');
+    assert.throws(shouldThrow, Error, 'Unable to find a manifest');
   });
 });

--- a/src/cli/hook-utils/get-manifest-data.spec.js
+++ b/src/cli/hook-utils/get-manifest-data.spec.js
@@ -1,0 +1,98 @@
+require('mocha');
+const sinon = require('sinon');
+const { expect, assert } = require('chai');
+const rewiremock = require('rewiremock/node');
+const { hasManifest } = require('./manifest');
+const merge = require('deepmerge');
+const { AppManifestInitializationError } = require('../../errors');
+
+async function importGetManifestDataMock(overrides) {
+  return rewiremock.module(() => import('./get-manifest-data.js'), overrides);
+}
+
+describe('Slack CLI Script Hooks: get-manifest-data', () => {
+  it('returns a manifest object, when manifest.json and .js exist', async () => {
+    // Override methods that return manifest file data
+    const { getManifestData } = await importGetManifestDataMock({
+      './manifest.js': {
+        'readManifestJSONFile': () => ({
+          testJSONKey: ''
+        }),
+        'readImportedManifestFile': () => ({
+          testModuleKey: ''
+        }),
+        'hasManifest': hasManifest,
+        'merge': merge
+      }
+    });
+   
+    // doesnt error
+    const shouldNotThrow = () => getManifestData('testSearchDir', 'testFilename');
+    assert.doesNotThrow(shouldNotThrow);
+
+    // returns a manifest with keys
+    const manifestData = getManifestData('testSearchDir', 'testFilename');
+    assert.isNotEmpty(manifestData);
+    assert.containsAllKeys(manifestData, ['testJSONKey', 'testModuleKey']);
+  });
+  it('returns a manifest object, when manifest.json exists', async () => {
+    const { getManifestData } = await importGetManifestDataMock({
+      './manifest.js': {
+        'readManifestJSONFile': () => ({
+          testJSONKey: ''
+        }),
+        'readImportedManifestFile': () => null, // no manifest.js found
+        'hasManifest': hasManifest,
+        'merge': merge
+      }
+    });
+   
+    // doesnt error
+    const shouldNotThrow = () => getManifestData('testSearchDir', 'testFilename');
+    assert.doesNotThrow(shouldNotThrow);
+
+    // returns a manifest
+    const manifestData = getManifestData('testSearchDir', 'testFilename');
+    assert.isNotEmpty(manifestData);
+    assert.containsAllKeys(manifestData, ['testJSONKey']);
+    assert.doesNotHaveAllKeys(manifestData, ['testModuleKey']);
+  });
+  it('returns a manifest object, when manifest.js exists', async () => {
+    // Override readManifestJSON to return a value
+    const { getManifestData } = await importGetManifestDataMock({
+      './manifest.js': {
+        'readManifestJSONFile': () => null,
+        'readImportedManifestFile': () => ({
+          testModuleKey: ''
+        }),
+        'hasManifest': hasManifest,
+        'merge': merge
+      }
+    });
+   
+    // doesnt error
+    const shouldNotThrow = () => getManifestData('testSearchDir', 'testFilename');
+    assert.doesNotThrow(shouldNotThrow);
+
+    // returns a manifest
+    const manifestData = getManifestData('testSearchDir', 'testFilename');
+    assert.isNotEmpty(manifestData);
+    assert.containsAllKeys(manifestData, ['testModuleKey']);
+    assert.doesNotHaveAllKeys(manifestData, ['testJSONKey']);
+  });
+  it('errors when no manifest js or json exist', async () => {
+    // Override neither manifest json nor js found
+    const { getManifestData } = await importGetManifestDataMock({
+      './manifest.js': {
+        'readManifestJSONFile': () => null,
+        'readImportedManifestFile': () => null,
+        'hasManifest': hasManifest,
+        'merge': merge
+      }
+    });
+   
+    // doesnt error
+    const shouldThrow = () => getManifestData('testSearchDir', 'testFilename');
+    assert.throws(shouldThrow, AppManifestInitializationError, 'Unable to find a manifest');
+  });
+});

--- a/src/cli/hook-utils/manifest.js
+++ b/src/cli/hook-utils/manifest.js
@@ -81,15 +81,15 @@ function find(currentPath, targetFilename) {
 function getManifestData(searchDir) {
   const file = 'manifest';
   let manifest = {};
-
+  
   // look for a manifest JSON
   const manifestJSON = readManifestJSONFile(searchDir, `${file}.json`);
-  
   // look for manifest.js
   // stringify and parses the JSON in order to ensure that objects with .toJSON() functions
   // resolve properly. This is a known behavior for CustomType
-  const manifestJS = JSON.parse(JSON.stringify(readImportedManifestFile(searchDir, `${file}.js`)));
-
+  let manifestJS = JSON.stringify(readImportedManifestFile(searchDir, `${file}.js`));
+  manifestJS = (manifestJS !== undefined) ? JSON.parse(manifestJS): undefined;
+  
   if (!hasManifest(manifestJS, manifestJSON)) {
     throw new Error('Unable to find a manifest file in this project');
   }

--- a/src/cli/hook-utils/manifest.js
+++ b/src/cli/hook-utils/manifest.js
@@ -1,11 +1,10 @@
 const fs = require('fs');
 const path = require('path');
-const merge = require('deepmerge');
 
 /** 
  * Union merge of arrays
  */
-export function unionMerge(array1, array2) {
+function unionMerge(array1, array2) {
   return [...new Set(array1.concat(array2))];
 }
 

--- a/src/cli/hook-utils/manifest.spec.js
+++ b/src/cli/hook-utils/manifest.spec.js
@@ -5,6 +5,7 @@ const { fs } = require('memfs');
 const mockfs = require('mock-fs');
 const manifestUtils = require('./manifest');
 const { unionMerge, hasManifest, find } = manifestUtils;
+const rewiremock = require('rewiremock');
 
 describe('Slack CLI Script Hooks: get-manifest utilities', () => {
   describe('unionMerge', () => {
@@ -29,7 +30,10 @@ describe('Slack CLI Script Hooks: get-manifest utilities', () => {
     });
     it('should return false if all empty objects', () => {
       expect(hasManifest({}));
-    })
+    });
+    it('should handle an undefined or null objects', () => {
+      expect(hasManifest(undefined, null, { testKey: "testValue"})).to.be.true;
+    });
   });
   describe('find', () => {
     beforeEach(() => {

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -38,8 +38,6 @@ export enum ErrorCode {
   SlackFunctionInitializationError = 'slack_bolt_slack_function_initialization_error',
   SlackFunctionExecutionError = 'slack_bolt_slack_function_execution_error',
   SlackFunctionCompleteError = 'slack_bolt_slack_function_initialization_error',
-
-  AppManifestInitializationError = 'slack_bolt_app_manifest_initialization_error',
 }
 
 export class UnknownError extends Error implements CodedError {
@@ -64,10 +62,6 @@ export function asCodedError(error: CodedError | Error): CodedError {
 
 export class AppInitializationError extends Error implements CodedError {
   public code = ErrorCode.AppInitializationError;
-}
-
-export class AppManifestInitializationError extends Error implements CodedError {
-  public code = ErrorCode.AppManifestInitializationError;
 }
 
 export class AuthorizationError extends Error implements CodedError {

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -38,6 +38,8 @@ export enum ErrorCode {
   SlackFunctionInitializationError = 'slack_bolt_slack_function_initialization_error',
   SlackFunctionExecutionError = 'slack_bolt_slack_function_execution_error',
   SlackFunctionCompleteError = 'slack_bolt_slack_function_initialization_error',
+
+  AppManifestInitializationError = 'slack_bolt_app_manifest_initialization_error',
 }
 
 export class UnknownError extends Error implements CodedError {
@@ -62,6 +64,10 @@ export function asCodedError(error: CodedError | Error): CodedError {
 
 export class AppInitializationError extends Error implements CodedError {
   public code = ErrorCode.AppInitializationError;
+}
+
+export class AppManifestInitializationError extends Error implements CodedError {
+  public code = ErrorCode.AppManifestInitializationError;
 }
 
 export class AuthorizationError extends Error implements CodedError {


### PR DESCRIPTION
###  Summary

* resolves a bug where if JSON is defined but .js is undefined, the hook throws an error
* adds additional tests for getManifestData() util method
* moves getManifestData() into a standalone file and away from lower utility methods, for easier mocking in tests

### Testing
* Adds some tests to cover this case for when there is 
   * A JSON only
   * A .js only
   * A JSON and .js
* Manual test step: 
   * Use this branch `npm link` & `npm link @slack/bolt`
   * Run `hermes manifest` and `hermes manifest validate` and a manifest should properly generate

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).