### PR TITLE
Add client and logger to SlackViewMiddlewareArgs

### DIFF
--- a/src/types/view/index.ts
+++ b/src/types/view/index.ts
@@ -1,5 +1,6 @@
 import { Block, KnownBlock, PlainTextElement, View } from '@slack/types';
-import type {WebClient} from '@slack/web-api'
+import type { WebClient } from '@slack/web-api';
+import { Logger } from '@slack/logger';
 import { AckFn, RespondFn } from '../utilities';
 
 /**
@@ -21,6 +22,7 @@ export interface SlackViewMiddlewareArgs<ViewActionType extends SlackViewAction 
   ack: ViewAckFn<ViewActionType>;
   respond: RespondFn;
   client: InstanceType<typeof WebClient>;
+  logger: Logger;
 }
 
 interface PlainTextElementOutput {

--- a/src/types/view/index.ts
+++ b/src/types/view/index.ts
@@ -1,4 +1,5 @@
 import { Block, KnownBlock, PlainTextElement, View } from '@slack/types';
+import type {WebClient} from '@slack/web-api'
 import { AckFn, RespondFn } from '../utilities';
 
 /**
@@ -19,6 +20,7 @@ export interface SlackViewMiddlewareArgs<ViewActionType extends SlackViewAction 
   body: ViewActionType;
   ack: ViewAckFn<ViewActionType>;
   respond: RespondFn;
+  client: InstanceType<typeof WebClient>;
 }
 
 interface PlainTextElementOutput {


### PR DESCRIPTION
###  Summary

`client` and `logger` are available as arguments when [listening to views](https://slack.dev/bolt-js/concepts#view-submissions).

Closes #1590 

### Requirements (place an `x` in each `[ ]`)

* [X] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [X] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).