### PR TITLE
Bump .ruby-version from 2.7.1 to 2.7.4

### DIFF
--- a/docs/.ruby-version
+++ b/docs/.ruby-version
@@ -1,4 +1,4 @@
-2.7.1
+2.7.4
 
 # This version number should track the Ruby version used in production: https://pages.github.com/versions/.
 # If it is out of date, please update and send a PR with the change.


### PR DESCRIPTION
###  Summary

To track [the version of Ruby used in production](https://pages.github.com/versions/), the docs version was bumped to 2.7.4.

As a note: the local development environment continues to perform as expected after this upgrade.

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).