### PR TITLE
Fix context.team_id for view interactions in a Slack Connect channel

### DIFF
--- a/src/App-basic-features.spec.ts
+++ b/src/App-basic-features.spec.ts
@@ -1176,8 +1176,9 @@ describe('App basic features', () => {
           authorize: sinon.fake.resolves(dummyAuthorizationResult),
         });
 
-        app.view('view-id', async ({ ack, context }) => {
+        app.view('view-id', async ({ ack, context, view }) => {
           assert.equal('T-installed-workspace', context.teamId);
+          assert.notEqual('T-installed-workspace', view.team_id);
           await ack();
         });
         app.error(fakeErrorHandler);

--- a/src/App-basic-features.spec.ts
+++ b/src/App-basic-features.spec.ts
@@ -1150,11 +1150,66 @@ describe('App basic features', () => {
         ];
 
         // Act
-        await Promise.all(receiverEvents.map((event) => fakeReceiver.sendEvent(event)));
+        await Promise.all(
+          receiverEvents.map((event) => fakeReceiver.sendEvent(event)),
+        );
 
         // Assert
         assert.isTrue(fakeLogger.info.called);
         assert.isTrue(ackInMiddlewareCalled);
+      });
+    });
+
+    describe('context', () => {
+      it('should be able to use the app_installed_team_id when provided by the payload', async () => {
+        // Arrange
+        const fakeAxiosPost = sinon.fake.resolves({});
+        overrides = buildOverrides([
+          withNoopWebClient(),
+          withAxiosPost(fakeAxiosPost),
+        ]);
+        const MockApp = await importApp(overrides);
+
+        // Act
+        const app = new MockApp({
+          receiver: fakeReceiver,
+          authorize: sinon.fake.resolves(dummyAuthorizationResult),
+        });
+
+        app.view('view-id', async ({ ack, context }) => {
+          assert.equal('T-installed-workspace', context.teamId);
+          await ack();
+        });
+        app.error(fakeErrorHandler);
+
+        let ackCalled = false;
+
+        const receiverEvent = {
+          ack: async () => {
+            ackCalled = true;
+          },
+          body: {
+            type: 'view_submission',
+            team: {},
+            user: {},
+            view: {
+              id: 'V111',
+              type: 'modal',
+              callback_id: 'view-id',
+              state: {},
+              title: {},
+              close: {},
+              submit: {},
+              app_installed_team_id: 'T-installed-workspace',
+            },
+          },
+        };
+
+        // Act
+        await fakeReceiver.sendEvent(receiverEvent);
+
+        // Assert
+        assert.isTrue(ackCalled);
       });
     });
   });

--- a/src/App.ts
+++ b/src/App.ts
@@ -1385,6 +1385,9 @@ function buildSource<IsEnterpriseInstall extends boolean>(
     };
 
     if (type === IncomingEventType.ViewAction) {
+      // view_submission/closed payloads can have `view.app_installed_team_id` when a modal view that was opened
+      // in a different workspace via some operations inside a Slack Connect channel.
+
       const bodyAsView = body as SlackViewMiddlewareArgs['body'];
 
       if (bodyAsView.view.app_installed_team_id) {

--- a/src/App.ts
+++ b/src/App.ts
@@ -1402,12 +1402,12 @@ function buildSource<IsEnterpriseInstall extends boolean>(
       type === IncomingEventType.Options ||
       type === IncomingEventType.Shortcut
     ) {
-      const bodyAsActionOrOptionsOrOrShortcut = body as (
+      const bodyAsActionOrOptionsOrShortcut = body as (
         | SlackActionMiddlewareArgs
         | SlackOptionsMiddlewareArgs
         | SlackShortcutMiddlewareArgs
       )['body'];
-      return parseTeamId(bodyAsActionOrOptionsOrOrShortcut);
+      return parseTeamId(bodyAsActionOrOptionsOrShortcut);
     }
 
     return assertNever(type);


### PR DESCRIPTION
###  Summary

This pull request resolves a bug where context.team_id can be invalid for view interactions (view_submission / view_closed) in a Slack Connect channel, which was reported at #1614 

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).