### PR TITLE
Add in `block_suggestion` interactivity handler support

### DIFF
--- a/src/App.ts
+++ b/src/App.ts
@@ -61,7 +61,7 @@ import {
   WorkflowStepEdit,
   SubscriptionInteraction,
   FunctionExecutedEvent,
-  SlackOptions,
+  SlackBlockSuggestion,
 } from './types';
 import { IncomingEventType, getTypeAndConversation, assertNever } from './helpers';
 import { CodedError, asCodedError, AppInitializationError, MultipleListenerError, ErrorCode, InvalidCustomPropertyError } from './errors';
@@ -170,10 +170,10 @@ export interface ViewConstraints {
   type?: 'view_closed' | 'view_submission';
 }
 
-export interface OptionsConstraints<C extends SlackOptions = SlackOptions> {
-  type?: C['type'];
-  block_id?: C extends SlackOptions ? string | RegExp : never;
-  action_id?: C extends SlackOptions ? string | RegExp : never;
+export interface BlockSuggestionConstraints<B extends SlackBlockSuggestion = SlackBlockSuggestion> {
+  type?: B['type'];
+  block_id?: B extends SlackBlockSuggestion ? string | RegExp : never;
+  action_id?: B extends SlackBlockSuggestion ? string | RegExp : never;
 }
 
 // Passed internally to the handleError method
@@ -1547,11 +1547,8 @@ function buildSource<IsEnterpriseInstall extends boolean>(
       // When the app is installed using org-wide deployment, team property will be null
       if (
         typeof bodyAsActionOrOptionsOrViewActionOrShortcut.team !== 'undefined' &&
-        bodyAsActionOrOptionsOrViewActionOrShortcut.team !== null &&
-        'enterprise_id' in bodyAsActionOrOptionsOrViewActionOrShortcut.team
+        bodyAsActionOrOptionsOrViewActionOrShortcut.team !== null
       ) {
-        // TODO: Added null check in if statement, but check
-        // if there's a better way to bypass this Typescript error for enterprise_id
         return bodyAsActionOrOptionsOrViewActionOrShortcut.team.enterprise_id;
       }
 

--- a/src/App.ts
+++ b/src/App.ts
@@ -61,6 +61,7 @@ import {
   WorkflowStepEdit,
   SubscriptionInteraction,
   FunctionExecutedEvent,
+  SlackOptions,
 } from './types';
 import { IncomingEventType, getTypeAndConversation, assertNever } from './helpers';
 import { CodedError, asCodedError, AppInitializationError, MultipleListenerError, ErrorCode, InvalidCustomPropertyError } from './errors';
@@ -167,6 +168,12 @@ export interface ShortcutConstraints<S extends SlackShortcut = SlackShortcut> {
 export interface ViewConstraints {
   callback_id?: string | RegExp;
   type?: 'view_closed' | 'view_submission';
+}
+
+export interface OptionsConstraints<C extends SlackOptions = SlackOptions> {
+  type?: C['type'];
+  block_id?: C extends SlackOptions ? string | RegExp : never;
+  action_id?: C extends SlackOptions ? string | RegExp : never;
 }
 
 // Passed internally to the handleError method
@@ -1540,8 +1547,11 @@ function buildSource<IsEnterpriseInstall extends boolean>(
       // When the app is installed using org-wide deployment, team property will be null
       if (
         typeof bodyAsActionOrOptionsOrViewActionOrShortcut.team !== 'undefined' &&
-        bodyAsActionOrOptionsOrViewActionOrShortcut.team !== null
+        bodyAsActionOrOptionsOrViewActionOrShortcut.team !== null &&
+        'enterprise_id' in bodyAsActionOrOptionsOrViewActionOrShortcut.team
       ) {
+        // TODO: Added null check in if statement, but check
+        // if there's a better way to bypass this Typescript error for enterprise_id
         return bodyAsActionOrOptionsOrViewActionOrShortcut.team.enterprise_id;
       }
 

--- a/src/SlackFunction.spec.ts
+++ b/src/SlackFunction.spec.ts
@@ -389,4 +389,5 @@ describe('SlackFunction utils', () => {
       assert.equal(res.fnKeys?.includes('reverse_approval'), false);
     });
   });
+  // TODO: Add unit tests for options
 });

--- a/src/SlackFunction.spec.ts
+++ b/src/SlackFunction.spec.ts
@@ -261,7 +261,8 @@ describe('SlackFunction module', () => {
           client: {} as WebClient,
         } as unknown as AnyMiddlewareArgs & AllMiddlewareArgs;
 
-        // ensure handlers are not
+        // ensure handler call rejects
+
         const shouldReject = async () => testFunc.runInteractivityHandlers(fakeArgs);
         assertNode.rejects(shouldReject);
       });
@@ -325,7 +326,8 @@ describe('SlackFunction module', () => {
           client: {} as WebClient,
         } as unknown as AnyMiddlewareArgs & AllMiddlewareArgs;
 
-        // ensure handlers are not
+        // ensure handler call rejects
+
         const shouldReject = async () => testFunc.runInteractivityHandlers(fakeArgs);
         assertNode.rejects(shouldReject);
       });

--- a/src/SlackFunction.spec.ts
+++ b/src/SlackFunction.spec.ts
@@ -192,7 +192,7 @@ describe('SlackFunction module', () => {
           action_id: '',
         };
         const mockHandler = async () => {};
-        // expect that the return value of action is a Slack function
+        // expect that the return value of blockSuggestion is a Slack function
         assert.instanceOf(testFunc.blockSuggestion(goodConstraints, mockHandler), SlackFunction);
         // chained valid handlers should not error
         const shouldNotThrow = () => testFunc.blockSuggestion(goodConstraints, mockHandler)

--- a/src/SlackFunction.spec.ts
+++ b/src/SlackFunction.spec.ts
@@ -275,7 +275,7 @@ describe('SlackFunction module', () => {
         const mockHandler = async () => Promise.resolve();
         const spy = sinon.spy(mockHandler);
         const spy2 = sinon.spy(mockHandler);
-        // add an action handlers
+        // add blockSuggestion handlers
         testFunc.blockSuggestion(goodConstraints, spy).blockSuggestion(goodConstraints, spy2);
 
         // set up event args
@@ -308,7 +308,7 @@ describe('SlackFunction module', () => {
         };
         const mockHandler = async () => Promise.reject();
         const spy = sinon.spy(mockHandler);
-        // add an action handlers
+        // add a blockSuggestion handler
         testFunc.blockSuggestion(goodConstraints, spy);
 
         // set up event args

--- a/src/SlackFunction.spec.ts
+++ b/src/SlackFunction.spec.ts
@@ -25,7 +25,7 @@ import {
 
 import { FunctionExecutionContext } from './types/functions';
 import { SlackFunctionInitializationError } from './errors';
-import { ActionConstraints, OptionsConstraints, ViewConstraints } from './App';
+import { ActionConstraints, BlockSuggestionConstraints, ViewConstraints } from './App';
 
 export default async function importSlackFunctionModule(overrides: Override = {}): Promise<typeof import('./SlackFunction')> {
   return rewiremock.module(() => import('./SlackFunction'), overrides);
@@ -167,7 +167,7 @@ describe('SlackFunction module', () => {
         const mockFunctionCallbackId = 'reverse_approval';
         const { SlackFunction } = await importSlackFunctionModule(withMockValidManifestUtil(mockFunctionCallbackId));
         const testFunc = new SlackFunction(mockFunctionCallbackId, async () => {});
-        const goodConstraints: OptionsConstraints = {
+        const goodConstraints: BlockSuggestionConstraints = {
           action_id: '',
         };
         const shouldNotThrow = () => testFunc.blockSuggestion(goodConstraints, async () => {});
@@ -180,7 +180,7 @@ describe('SlackFunction module', () => {
         const badConstraints = {
           bad_id: '',
           action_id: '',
-        } as OptionsConstraints;
+        } as BlockSuggestionConstraints;
         const shouldThrow = () => testFunc.blockSuggestion(badConstraints, async () => {});
         assert.throws(shouldThrow, SlackFunctionInitializationError);
       });
@@ -188,7 +188,7 @@ describe('SlackFunction module', () => {
         const mockFunctionCallbackId = 'reverse_approval';
         const { SlackFunction } = await importSlackFunctionModule(withMockValidManifestUtil(mockFunctionCallbackId));
         const testFunc = new SlackFunction(mockFunctionCallbackId, async () => {});
-        const goodConstraints: OptionsConstraints = {
+        const goodConstraints: BlockSuggestionConstraints = {
           action_id: '',
         };
         const mockHandler = async () => {};
@@ -270,7 +270,7 @@ describe('SlackFunction module', () => {
         const mockFunctionCallbackId = 'reverse_approval';
         const { SlackFunction } = await importSlackFunctionModule(withMockValidManifestUtil(mockFunctionCallbackId));
         const testFunc = new SlackFunction(mockFunctionCallbackId, async () => {});
-        const goodConstraints: OptionsConstraints = {
+        const goodConstraints: BlockSuggestionConstraints = {
           action_id: 'my-action',
         };
         const mockHandler = async () => Promise.resolve();
@@ -304,7 +304,7 @@ describe('SlackFunction module', () => {
         const { SlackFunction } = await importSlackFunctionModule(withMockValidManifestUtil(mockFunctionCallbackId));
         const testFunc = new SlackFunction(mockFunctionCallbackId, async () => {});
         const action_id = 'my-action';
-        const goodConstraints: OptionsConstraints = {
+        const goodConstraints: BlockSuggestionConstraints = {
           action_id,
         };
         const mockHandler = async () => Promise.reject();

--- a/src/SlackFunction.ts
+++ b/src/SlackFunction.ts
@@ -9,14 +9,14 @@ import {
   SlackEventMiddlewareArgs,
   SlackViewAction,
   SlackViewMiddlewareArgs,
-  SlackOptions,
-  SlackOptionsMiddlewareArgs,
+  SlackBlockSuggestion,
+  SlackBlockSuggestionsMiddlewareArgs,
 } from './types';
 
 import {
   ActionConstraints,
   ViewConstraints,
-  OptionsConstraints,
+  BlockSuggestionConstraints,
 } from './App';
 
 import {
@@ -48,21 +48,21 @@ export interface CompleteFunctionArgs {
 export type AllSlackFunctionExecutedMiddlewareArgs =
 SlackFunctionExecutedMiddlewareArgs &
 SlackActionMiddlewareArgs &
-SlackOptionsMiddlewareArgs &
+SlackBlockSuggestionsMiddlewareArgs &
 AllMiddlewareArgs;
 
 interface FunctionInteractivityMiddleware {
   constraints: FunctionInteractivityConstraints,
   handler: Middleware<SlackActionMiddlewareArgs> |
   Middleware<SlackViewMiddlewareArgs> |
-  Middleware<SlackOptionsMiddlewareArgs>;
+  Middleware<SlackBlockSuggestionsMiddlewareArgs>;
 }
 
-type FunctionInteractivityConstraints = ActionConstraints | ViewConstraints | OptionsConstraints;
+type FunctionInteractivityConstraints = ActionConstraints | ViewConstraints | BlockSuggestionConstraints;
 // an array of Action constraints keys as strings
 type ActionConstraintsKeys = Extract<(keyof ActionConstraints), string>[];
 type ViewConstraintsKeys = Extract<(keyof ViewConstraints), string>[];
-type OptionsConstraintsKeys = Extract<(keyof OptionsConstraints), string>[];
+type BlockSuggestionConstraintsKeys = Extract<(keyof BlockSuggestionConstraints), string>[];
 
 interface SlackFnValidateResult { pass: boolean, msg?: string }
 export interface ManifestDefinitionResult {
@@ -208,18 +208,15 @@ export class SlackFunction {
    * @param handler Provide a handler function
    * @returns SlackFunction instance
    */
-  // TODO: Slack Options pass in here
-  // Examine Options middleware
-  // and define options constraints that are similar to ActionConstraints
   public blockSuggestion<
-    Options extends SlackOptions = SlackOptions,
-    Constraints extends OptionsConstraints<Options> = OptionsConstraints<Options>,
+    BlockSuggestion extends SlackBlockSuggestion = SlackBlockSuggestion,
+    Constraints extends BlockSuggestionConstraints<BlockSuggestion> = BlockSuggestionConstraints<BlockSuggestion>,
   >(
     actionIdOrConstraints: string | RegExp | Constraints,
-    handler: Middleware<SlackOptionsMiddlewareArgs>,
+    handler: Middleware<SlackBlockSuggestionsMiddlewareArgs>,
   ): this {
     // normalize constraints
-    const constraints: OptionsConstraints = (
+    const constraints: BlockSuggestionConstraints = (
       typeof actionIdOrConstraints === 'string' ||
       util.types.isRegExp(actionIdOrConstraints)
     ) ?
@@ -227,7 +224,7 @@ export class SlackFunction {
       actionIdOrConstraints;
 
     // declare our valid constraints keys
-    const validConstraintsKeys: OptionsConstraintsKeys = ['action_id', 'block_id', 'type'];
+    const validConstraintsKeys: BlockSuggestionConstraintsKeys = ['action_id', 'block_id', 'type'];
     // cast to string array for convenience
     const validConstraintsKeysAsStrings = validConstraintsKeys as string[];
 
@@ -511,7 +508,7 @@ export function errorIfInvalidConstraintKeys(
   validKeys: string[],
   handler: Middleware<SlackActionMiddlewareArgs> |
   Middleware<SlackViewMiddlewareArgs<SlackViewAction>> |
-  Middleware<SlackOptionsMiddlewareArgs>,
+  Middleware<SlackBlockSuggestionsMiddlewareArgs>,
 ): void {
   const invalidKeys = Object.keys(constraints).filter(
     (key) => !validKeys.includes(key),

--- a/src/types/block-suggestion/index.spec.ts
+++ b/src/types/block-suggestion/index.spec.ts
@@ -1,0 +1,169 @@
+import { assert } from 'chai';
+import { BlockSuggestionPayload } from './index';
+
+describe('External data source block suggestion event types', () => {
+  it('should be compatible with non-enterprise block_suggestion payloads', () => {
+    const payload: BlockSuggestionPayload = {
+      type: 'block_suggestion',
+      team: {
+        id: 'test_team_id',
+        domain: 'test_team',
+      },
+      enterprise: null,
+      user: {
+        id: 'user_id',
+        name: 'user_name',
+        team_id: 'test_team_id',
+      },
+      channel: {
+        id: 'channel_id',
+        name: 'directmessage',
+      },
+      message: {
+        bot_id: 'bot_id',
+        type: 'message',
+        text: 'Enter an inspirational quote.',
+        user: 'user_id_2',
+        ts: '1667917196.579049',
+        app_id: 'app_id',
+        blocks: [
+          {
+            type: 'header',
+            block_id: '3qxZz',
+            text: {
+              type: 'plain_text',
+              text: 'Enter an inspirational quote',
+              emoji: true,
+            },
+          },
+          {
+            type: 'input',
+            block_id: 'ext_select_block',
+            label: {
+              type: 'plain_text',
+              text: 'Inspirational Quote',
+              emoji: true,
+            },
+            optional: true,
+            dispatch_action: false,
+            element: {
+              type: 'external_select',
+              action_id: 'ext_select_input',
+              placeholder: {
+                type: 'plain_text',
+                text: 'Inspire',
+                emoji: true,
+              },
+            },
+          },
+        ],
+        team: 'test_team_id',
+      },
+      container: {
+        type: 'message',
+        message_ts: '1667917196.579049',
+        channel_id: 'channel_id',
+        is_ephemeral: false,
+      },
+      api_app_id: 'app_id',
+      action_id: 'ext_select_input',
+      block_id: 'ext_select_block',
+      value: 'base',
+      function_data: {
+        execution_id: 'function_execution_id',
+        function: {
+          callback_id: 'review_approval',
+        },
+        inputs: {
+          recipient: 'recipient_user_id',
+          sender: 'sender_user_id',
+        },
+      },
+      bot_access_token: 'xwfp-bot-access-token',
+    };
+    assert.equal(payload.action_id, 'ext_select_input');
+    assert.equal(payload.value, 'base');
+  });
+  it('should be compatible with enterprise block_suggestion payloads', () => {
+    const payload: BlockSuggestionPayload = {
+      type: 'block_suggestion',
+      team: null,
+      enterprise: {
+        id: 'enterprise_id',
+        name: 'enterprise grid',
+      },
+      user: {
+        id: 'user_id',
+        name: 'user_name',
+        team_id: 'test_team_id',
+      },
+      channel: {
+        id: 'channel_id',
+        name: 'directmessage',
+      },
+      message: {
+        bot_id: 'bot_id',
+        type: 'message',
+        text: 'Enter an inspirational quote.',
+        user: 'user_id_2',
+        ts: '1667924878.557759',
+        app_id: 'app_id',
+        blocks: [
+          {
+            type: 'header',
+            block_id: 'nyk',
+            text: {
+              type: 'plain_text',
+              text: 'Enter an inspirational quote.',
+              emoji: true,
+            },
+          },
+          {
+            type: 'input',
+            block_id: 'ext_select_block',
+            label: {
+              type: 'plain_text',
+              text: 'Inspirational Quote',
+              emoji: true,
+            },
+            optional: true,
+            dispatch_action: false,
+            element: {
+              type: 'external_select',
+              action_id: 'ext_select_input',
+              placeholder: {
+                type: 'plain_text',
+                text: 'Inspire',
+                emoji: true,
+              },
+            },
+          },
+        ],
+        team: 'test_team_id',
+      },
+      container: {
+        type: 'message',
+        message_ts: '1667924878.557759',
+        channel_id: 'channel_id',
+        is_ephemeral: false,
+      },
+      api_app_id: 'app_id',
+      action_id: 'ext_select_input',
+      block_id: 'ext_select_block',
+      value: 'and',
+      function_data: {
+        execution_id: 'function_execution_id',
+        function: {
+          callback_id: 'review_approval',
+        },
+        inputs: {
+          recipient: 'recipient_user_id',
+          sender: 'sender_user_id',
+        },
+      },
+      bot_access_token: 'xwfp-bot-access-token',
+    };
+    assert.equal(payload.action_id, 'ext_select_input');
+    assert.equal(payload.value, 'and');
+  });
+});

--- a/src/types/block-suggestion/index.ts
+++ b/src/types/block-suggestion/index.ts
@@ -1,0 +1,109 @@
+import { Option } from '@slack/types';
+import { StringIndexed, XOR } from '../helpers';
+import { AckFn } from '../utilities';
+import { ViewOutput } from '../view/index';
+import { FunctionExecutionContext } from '../functions';
+
+/**
+ * Arguments which listeners and middleware receive to process a Block Suggestions request from Slack
+ */
+export interface SlackBlockSuggestionsMiddlewareArgs<Source extends BlockSuggestionsSource = BlockSuggestionsSource> {
+  payload: BlockSuggestionsPayloadFromType<Source>;
+  body: this['payload'];
+  options: this['payload'];
+  ack: BlockSuggestionsAckFn;
+}
+
+/**
+ * The source that comprises of Block Suggestions Requests.
+ */
+export type BlockSuggestionsSource = 'block_suggestion';
+
+export type SlackBlockSuggestion = BlockSuggestionPayload;
+
+export interface BasicBlockSuggestionsPayload<Type extends string = string> {
+  type: Type;
+  value: string;
+}
+
+export type BlockSuggestionsPayloadFromType<T extends string> = KnownBlockSuggestionsPayloadFromType<T> extends never
+  ? BasicBlockSuggestionsPayload<T>
+  : KnownBlockSuggestionsPayloadFromType<T>;
+
+export type KnownBlockSuggestionsPayloadFromType<T extends string> = Extract<SlackBlockSuggestion, { type: T }>;
+
+/**
+ * Block Suggestion payload model for next-gen interactivity
+ */
+export interface BlockSuggestionPayload extends StringIndexed {
+  api_app_id: string;
+  bot_access_token?: string;
+  channel?: {
+    id: string;
+    name: string;
+  };
+  enterprise: {
+    id: string;
+    name: string;
+  } | null;
+  function_data?: FunctionExecutionContext;
+  message?: {
+    app_id: string;
+    blocks: {
+      block_id: string;
+      type: string;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      [key: string]: any;
+    }[];
+    bot_id: string;
+    is_locked?: boolean;
+    latest_reply?: string;
+    metadata?: {
+      event_type: string;
+      event_payload: {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        [key: string]: any;
+      };
+    };
+    reply_count?: number;
+    reply_users?: string[];
+    reply_users_count?: number;
+    team: string;
+    text: string;
+    thread_ts?: string;
+    ts: string;
+    type: 'message';
+    user: string;
+  };
+  team: {
+    domain: string;
+    id: string;
+  } | null;
+  user: {
+    id: string;
+    name: string;
+    team_id: string;
+  };
+  value: string;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  [key: string]: any;
+  container: StringIndexed;
+  // exists for blocks in either a modal or a home tab
+  view?: ViewOutput;
+}
+
+/**
+ * Type function which given a Block Suggestion `Source` returns a corresponding type for the `ack()` function. The
+ * function is used to fulfill the options request from a listener or middleware.
+ */
+type BlockSuggestionsAckFn = AckFn<XOR<BlockSuggestionOptions, BlockSuggestionOptionGroups<BlockSuggestionOptions>>>;
+
+export interface BlockSuggestionOptions {
+  options: Option[];
+}
+
+export interface BlockSuggestionOptionGroups<Options> {
+  option_groups: ({
+    label: string;
+  } & Options)[];
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -8,3 +8,4 @@ export * from './view';
 export * from './receiver';
 export * from './shortcuts';
 export * from './subscription';
+export * from './block-suggestion';

--- a/src/types/options/index.ts
+++ b/src/types/options/index.ts
@@ -32,7 +32,10 @@ export type OptionsPayloadFromType<T extends string> = KnownOptionsPayloadFromTy
 export type KnownOptionsPayloadFromType<T extends string> = Extract<SlackOptions, { type: T }>;
 
 /**
- * external data source in blocks
+ * external data source in blocks - this BlockSuggestion differs from
+ * the new Block Suggestion type defined in src/types/block-suggestion,
+ * as this one is intended for legacy use, while the new type is intended
+ * for next-gen interactivity handler use.
  */
 export interface BlockSuggestion extends StringIndexed {
   type: 'block_suggestion';

--- a/src/types/options/index.ts
+++ b/src/types/options/index.ts
@@ -36,63 +36,36 @@ export type KnownOptionsPayloadFromType<T extends string> = Extract<SlackOptions
  */
 export interface BlockSuggestion extends StringIndexed {
   type: 'block_suggestion';
-  action_id: string;
-  api_app_id: string;
   block_id: string;
-  channel?: {
-    id: string;
-    name: string;
-  };
-  is_enterprise_install?: boolean;
-  enterprise?: {
-    id: string;
-    name: string;
-  };
-  message?: {
-    app_id: string;
-    blocks: {
-      block_id: string;
-      type: string;
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      [key: string]: any;
-    }[];
-    is_locked: boolean;
-    latest_reply?: string;
-    metadata?: {
-      event_type: string;
-      event_payload: {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        [key: string]: any;
-      };
-    };
-    reply_count: number;
-    reply_users: string[];
-    reply_users_count: number;
-    team: string;
-    text: string;
-    thread_ts: string;
-    ts: string;
-    type: 'message';
-    user: string;
-  };
+  action_id: string;
+  value: string;
+
+  api_app_id: string;
   team: {
     id: string;
     domain: string;
     enterprise_id?: string;
     enterprise_name?: string;
   } | null;
-  token?: string; // legacy verification token
+  channel?: {
+    id: string;
+    name: string;
+  };
   user: {
     id: string;
     name: string;
     team_id?: string;
   };
-  value: string;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  [key: string]: any;
+  token: string; // legacy verification token
   container: StringIndexed;
   // exists for blocks in either a modal or a home tab
   view?: ViewOutput;
+  // exists for enterprise installs
+  is_enterprise_install?: boolean;
+  enterprise?: {
+    id: string;
+    name: string;
+  };
 }
 
 /**

--- a/src/types/options/index.ts
+++ b/src/types/options/index.ts
@@ -36,36 +36,62 @@ export type KnownOptionsPayloadFromType<T extends string> = Extract<SlackOptions
  */
 export interface BlockSuggestion extends StringIndexed {
   type: 'block_suggestion';
-  block_id: string;
   action_id: string;
-  value: string;
-
   api_app_id: string;
+  block_id: string;
+  channel?: {
+    id: string;
+    name: string;
+  };
+  is_enterprise_install?: boolean;
+  enterprise?: {
+    id: string;
+    name: string;
+  } | null;
+  message?: {
+    app_id: string;
+    blocks: {
+      block_id: string;
+      type: string;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      [key: string]: any;
+    }[];
+    is_locked: boolean;
+    latest_reply?: string;
+    metadata?: {
+      event_type: string;
+      event_payload: {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        [key: string]: any;
+      };
+    };
+    reply_count: number;
+    reply_users: string[];
+    reply_users_count: number;
+    team: string;
+    text: string;
+    thread_ts: string;
+    ts: string;
+    type: 'message';
+    user: string;
+  };
   team: {
     id: string;
     domain: string;
     enterprise_id?: string;
     enterprise_name?: string;
   } | null;
-  channel?: {
-    id: string;
-    name: string;
-  };
   user: {
     id: string;
     name: string;
     team_id?: string;
   };
-  token: string; // legacy verification token
+  value: string;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  [key: string]: any;
   container: StringIndexed;
   // exists for blocks in either a modal or a home tab
   view?: ViewOutput;
-  // exists for enterprise installs
-  is_enterprise_install?: boolean;
-  enterprise?: {
-    id: string;
-    name: string;
-  };
 }
 
 /**

--- a/src/types/options/index.ts
+++ b/src/types/options/index.ts
@@ -81,6 +81,7 @@ export interface BlockSuggestion extends StringIndexed {
     enterprise_id?: string;
     enterprise_name?: string;
   } | null;
+  token?: string; // legacy verification token
   user: {
     id: string;
     name: string;

--- a/src/types/options/index.ts
+++ b/src/types/options/index.ts
@@ -47,7 +47,7 @@ export interface BlockSuggestion extends StringIndexed {
   enterprise?: {
     id: string;
     name: string;
-  } | null;
+  };
   message?: {
     app_id: string;
     blocks: {


### PR DESCRIPTION
###  Summary

This PR mirrors Fil's work in https://github.com/slackapi/deno-slack-sdk/pull/116 to add interactivity support for `block_suggestions` in Bolt JS. This PR accomplishes this through adding a `blockSuggestion` function that can be chained from a SlackFunction object, for example:
```js
const requestApprovalFunc = new SlackFunction(ApprovalFunction.id, notifyApprover);

requestApprovalFunc
  .blockSuggestion({ action_id: "ext_select_input" }, blockSuggestionHandler)
  .action('approve_request', approveActionHandler)
  .action({ action_id: /deny_*.+/ }, denyActionHandler)
```
This PR also mirrors a lot of Sarah's work in https://github.com/slackapi/bolt-js/pull/1567!

**Testing**
1. Pull down this branch `ah-add-block-suggestions`
2. In a new tab or Terminal window, create a new Bolt JS test app using Bolt JS Request Time Off template - `slack create -t slack-samples/bolt-js-request-time-off`
3. Create a symlink - run `npm link` in the `bolt-js` repo
4. Point symlink to `@slack/bolt` package in your test app - run `npm link @slack/bolt` in your test app. Now the code from this branch will be available on your test app! ✨ 
5. Create a trigger for your test app: `slack create trigger --trigger-def "triggers/link-shortcut.json"`
6. In your test app's `listeners/functions/request-approval.js` file, add the following to the Block Kit within the `notifyApprover` function's call to `client.chat.postMessage`:
```js
        {
          type: "input",
          block_id: "ext_select_block",
          optional: true,
          element: {
            type: "external_select",
            action_id: "ext_select_input",
            placeholder: {
              type: "plain_text",
              text: "Inspire",
            },
          },
          label: {
            type: "plain_text",
            text: "Inspirational Quote",
          },
        },
```
7. Add in a `blockSuggestionHandler` function into `request-approval.js`:
```js
async function blockSuggestionHandler ({ ack, body, client }) {
  console.log('BLOCK SUGGESTION HANDLER, ', JSON.stringify(body, null, 2));

  // Fetch an inspirational quote
  const apiResp = await fetch("https://api.quotable.io/quotes");
  const quotes = await apiResp.json();

  let suggestions = [];

  quotes.results.forEach(quote => {
    if (quote.content.toLowerCase().includes(body.value)) {
      suggestions.push({value: `${quote._id}`, text: {type:"plain_text", text: quote.content.slice(0,70)}})
    }
  })

  console.log('Returning', suggestions.length, 'quotes');

  const opts = {
    "options": suggestions
  }

  await ack(opts);
}
```
8. Test the `blockSuggestion` function by adding any of the following to the `requestApprovalFunc` at the bottom of the file like so:
```js
requestApprovalFunc
  .blockSuggestion({ action_id: "ext_select_input" }, blockSuggestionHandler)
  .action('approve_request', approveActionHandler) // Support Regex
  .action({ action_id: /deny_*.+/ }, denyActionHandler) // Support constraint object
```

```js
// Other parameter combos to try:
  .blockSuggestion({ block_id: "ext_select_block", action_id: "ext_select_input" }, blockSuggestionHandler)
  .blockSuggestion({ type: "block_suggestion" }, blockSuggestionHandler)
  .blockSuggestion({ action_id: /ext_*.+/ }, blockSuggestionHandler)
  .blockSuggestion("ext_select_input", blockSuggestionHandler)
```

Then, run the trigger. You will receive a message from the application and you will be able to search for quotes using the suggestion dropdown. To pull up valid results, you can type in keywords `and` or `let`. View the demo below:
![block-suggestions-gif-better-lol](https://user-images.githubusercontent.com/12901850/199532351-f96a4cf6-592f-4b38-bbf6-ad79afd08cef.gif)


**Open TODOs for this PR (other than addressing feedback)**
* [x] Add in unit tests
* [ ] Make sure `block_suggestions` schema looks right and update any existing unit tests that don't align with this schema

**TODOs after this PR**
* [ ] Add in a `blockActions` function support to create consistency with the `blockSuggestion` naming schema

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).