### PR TITLE
Add in update to AWS Lambda guide to make ExpressReceiver config more clear

### DIFF
--- a/docs/_deployments/aws-lambda.md
+++ b/docs/_deployments/aws-lambda.md
@@ -121,7 +121,7 @@ Update the [source code that imports your modules](https://github.com/slackapi/b
 const { App, AwsLambdaReceiver } = require('@slack/bolt');
 ```
 
-> 💡  If you are planning on implementing authentication with OAuth, as of today you need to use the [`ExpressReceiver`](https://github.com/slackapi/bolt-js/blob/main/src/receivers/ExpressReceiver.ts). When using other receivers with that are not the AwsLambdaReceiver, please note that the `processBeforeResponse: true` property is required to be passed in to your receiver initialization.
+> 💡  If you are planning on implementing authentication with OAuth, as of today you need to use the [`ExpressReceiver`](https://github.com/slackapi/bolt-js/blob/main/src/receivers/ExpressReceiver.ts). Additionally, when using other receivers with that are not the AwsLambdaReceiver, please note that the `processBeforeResponse: true` property is required to be passed in to your receiver initialization.
 
 Then update the [source code that initializes your Bolt app](https://github.com/slackapi/bolt-js-getting-started-app/blob/4c29a21438b40f0cbca71ece0d39b356dfcf88d5/app.js#L10-L14) to create a custom receiver using AwsLambdaReceiver:
 

--- a/docs/_deployments/aws-lambda.md
+++ b/docs/_deployments/aws-lambda.md
@@ -121,7 +121,7 @@ Update the [source code that imports your modules](https://github.com/slackapi/b
 const { App, AwsLambdaReceiver } = require('@slack/bolt');
 ```
 
-> 💡  If you are planning on implementing authentication with OAuth, as of today you need to use the [`ExpressReceiver`](https://github.com/slackapi/bolt-js/blob/main/src/receivers/ExpressReceiver.ts). Additionally, when using other receivers with that are not the `AwsLambdaReceiver`, please note that the `processBeforeResponse: true` property is required to be passed in to your receiver initialization.
+> 💡  If implementing authentication with OAuth, you must use the [`ExpressReceiver`](https://github.com/slackapi/bolt-js/blob/main/src/receivers/ExpressReceiver.ts). Please note that when using `ExpressReceiver`, the `processBeforeResponse: true` property is required during initialization to avoid latency issues.
 
 Then update the [source code that initializes your Bolt app](https://github.com/slackapi/bolt-js-getting-started-app/blob/4c29a21438b40f0cbca71ece0d39b356dfcf88d5/app.js#L10-L14) to create a custom receiver using AwsLambdaReceiver:
 

--- a/docs/_deployments/aws-lambda.md
+++ b/docs/_deployments/aws-lambda.md
@@ -121,7 +121,7 @@ Update the [source code that imports your modules](https://github.com/slackapi/b
 const { App, AwsLambdaReceiver } = require('@slack/bolt');
 ```
 
-> 💡  If you are planning on implementing authentication with OAuth, as of today you need to use the [`ExpressReceiver`](https://github.com/slackapi/bolt-js/blob/main/src/receivers/ExpressReceiver.ts).
+> 💡  If you are planning on implementing authentication with OAuth, as of today you need to use the [`ExpressReceiver`](https://github.com/slackapi/bolt-js/blob/main/src/receivers/ExpressReceiver.ts). When using other receivers with that are not the AwsLambdaReceiver, please note that the `processBeforeResponse: true` property is required to be passed in to your receiver initialization.
 
 Then update the [source code that initializes your Bolt app](https://github.com/slackapi/bolt-js-getting-started-app/blob/4c29a21438b40f0cbca71ece0d39b356dfcf88d5/app.js#L10-L14) to create a custom receiver using AwsLambdaReceiver:
 

--- a/docs/_deployments/aws-lambda.md
+++ b/docs/_deployments/aws-lambda.md
@@ -121,7 +121,7 @@ Update the [source code that imports your modules](https://github.com/slackapi/b
 const { App, AwsLambdaReceiver } = require('@slack/bolt');
 ```
 
-> 💡  If you are planning on implementing authentication with OAuth, as of today you need to use the [`ExpressReceiver`](https://github.com/slackapi/bolt-js/blob/main/src/receivers/ExpressReceiver.ts). Additionally, when using other receivers with that are not the AwsLambdaReceiver, please note that the `processBeforeResponse: true` property is required to be passed in to your receiver initialization.
+> 💡  If you are planning on implementing authentication with OAuth, as of today you need to use the [`ExpressReceiver`](https://github.com/slackapi/bolt-js/blob/main/src/receivers/ExpressReceiver.ts). Additionally, when using other receivers with that are not the `AwsLambdaReceiver`, please note that the `processBeforeResponse: true` property is required to be passed in to your receiver initialization.
 
 Then update the [source code that initializes your Bolt app](https://github.com/slackapi/bolt-js-getting-started-app/blob/4c29a21438b40f0cbca71ece0d39b356dfcf88d5/app.js#L10-L14) to create a custom receiver using AwsLambdaReceiver:
 


### PR DESCRIPTION
###  Summary

Doc update to make documentation more clear about `ExpressReceiver` configuration settings. See issue https://github.com/slackapi/bolt-js/issues/1643 for more info.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).