### PR TITLE
Update block suggestion payload to extend function context

### DIFF
--- a/src/types/block-suggestion/index.ts
+++ b/src/types/block-suggestion/index.ts
@@ -2,7 +2,7 @@ import { Option } from '@slack/types';
 import { StringIndexed, XOR } from '../helpers';
 import { AckFn } from '../utilities';
 import { ViewOutput } from '../view/index';
-import { FunctionExecutionContext } from '../functions';
+import { FunctionContext } from '../functions';
 
 /**
  * Arguments which listeners and middleware receive to process a Block Suggestions request from Slack
@@ -35,9 +35,8 @@ export type KnownBlockSuggestionsPayloadFromType<T extends string> = Extract<Sla
 /**
  * Block Suggestion payload model for next-gen interactivity
  */
-export interface BlockSuggestionPayload extends StringIndexed {
+export interface BlockSuggestionPayload extends FunctionContext {
   api_app_id: string;
-  bot_access_token?: string;
   channel?: {
     id: string;
     name: string;
@@ -46,7 +45,6 @@ export interface BlockSuggestionPayload extends StringIndexed {
     id: string;
     name: string;
   } | null;
-  function_data?: FunctionExecutionContext;
   message?: {
     app_id: string;
     blocks: {


### PR DESCRIPTION
###  Summary

Related comment for this PR: https://github.com/slackapi/bolt-js/pull/1645#pullrequestreview-1177754948

Updating the newly added next-gen block suggestion interactivity payload so it extends function context and no longer requires the `function_data` and `bot_access_token` params.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).