### PR TITLE
Add in blockAction handler to SlackFunction

### DIFF
--- a/src/SlackFunction.spec.ts
+++ b/src/SlackFunction.spec.ts
@@ -369,71 +369,71 @@ describe('SlackFunction module', () => {
         const shouldReject = async () => testFunc.runInteractivityHandlers(fakeArgs);
         assertNode.rejects(shouldReject);
       });
-    });
-    it('app.function.blockAction() should execute all provided callbacks', async () => {
-      const mockFunctionCallbackId = 'reverse_approval';
-      const { SlackFunction } = await importSlackFunctionModule(withMockValidManifestUtil(mockFunctionCallbackId));
-      const testFunc = new SlackFunction(mockFunctionCallbackId, async () => {});
-      const goodConstraints: ActionConstraints = {
-        action_id: 'my-action',
-      };
-      const mockHandler = async () => Promise.resolve();
-      const spy = sinon.spy(mockHandler);
-      const spy2 = sinon.spy(mockHandler);
-      // add blockAction handlers
-      testFunc.blockAction(goodConstraints, spy).blockAction(goodConstraints, spy2);
-
-      // set up event args
-      const fakeArgs = {
-        next: () => {},
-        payload: {
+      it('app.function.blockAction() should execute all provided callbacks', async () => {
+        const mockFunctionCallbackId = 'reverse_approval';
+        const { SlackFunction } = await importSlackFunctionModule(withMockValidManifestUtil(mockFunctionCallbackId));
+        const testFunc = new SlackFunction(mockFunctionCallbackId, async () => {});
+        const goodConstraints: ActionConstraints = {
           action_id: 'my-action',
-        },
-        body: {
-          function_data: {
-            execution_id: 'asdasdas',
+        };
+        const mockHandler = async () => Promise.resolve();
+        const spy = sinon.spy(mockHandler);
+        const spy2 = sinon.spy(mockHandler);
+        // add blockAction handlers
+        testFunc.blockAction(goodConstraints, spy).blockAction(goodConstraints, spy2);
+
+        // set up event args
+        const fakeArgs = {
+          next: () => {},
+          payload: {
+            action_id: 'my-action',
           },
-        },
-        client: {} as WebClient,
-      } as unknown as AnyMiddlewareArgs & AllMiddlewareArgs;
+          body: {
+            function_data: {
+              execution_id: 'asdasdas',
+            },
+          },
+          client: {} as WebClient,
+        } as unknown as AnyMiddlewareArgs & AllMiddlewareArgs;
 
-      // ensure handlers are both called
+        // ensure handlers are both called
 
-      await testFunc.runInteractivityHandlers(fakeArgs);
-      assert(spy.calledOnce);
-      assert(spy2.calledOnce);
-    });
-    it('app.function.blockAction() should error if a promise rejects', async () => {
-      const mockFunctionCallbackId = 'reverse_approval';
-      const { SlackFunction } = await importSlackFunctionModule(withMockValidManifestUtil(mockFunctionCallbackId));
-      const testFunc = new SlackFunction(mockFunctionCallbackId, async () => {});
-      const action_id = 'my-action';
-      const goodConstraints: ActionConstraints = {
-        action_id,
-      };
-      const mockHandler = async () => Promise.reject();
-      const spy = sinon.spy(mockHandler);
-      // add a blockAction handlers
-      testFunc.blockAction(goodConstraints, spy);
-
-      // set up event args
-      const fakeArgs = {
-        next: () => {},
-        payload: {
+        await testFunc.runInteractivityHandlers(fakeArgs);
+        assert(spy.calledOnce);
+        assert(spy2.calledOnce);
+      });
+      it('app.function.blockAction() should error if a promise rejects', async () => {
+        const mockFunctionCallbackId = 'reverse_approval';
+        const { SlackFunction } = await importSlackFunctionModule(withMockValidManifestUtil(mockFunctionCallbackId));
+        const testFunc = new SlackFunction(mockFunctionCallbackId, async () => {});
+        const action_id = 'my-action';
+        const goodConstraints: ActionConstraints = {
           action_id,
-        },
-        body: {
-          function_data: {
-            execution_id: 'asdasdas',
+        };
+        const mockHandler = async () => Promise.reject();
+        const spy = sinon.spy(mockHandler);
+        // add a blockAction handlers
+        testFunc.blockAction(goodConstraints, spy);
+
+        // set up event args
+        const fakeArgs = {
+          next: () => {},
+          payload: {
+            action_id,
           },
-        },
-        client: {} as WebClient,
-      } as unknown as AnyMiddlewareArgs & AllMiddlewareArgs;
+          body: {
+            function_data: {
+              execution_id: 'asdasdas',
+            },
+          },
+          client: {} as WebClient,
+        } as unknown as AnyMiddlewareArgs & AllMiddlewareArgs;
 
-      // ensure handler call rejects
+        // ensure handler call rejects
 
-      const shouldReject = async () => testFunc.runInteractivityHandlers(fakeArgs);
-      assertNode.rejects(shouldReject);
+        const shouldReject = async () => testFunc.runInteractivityHandlers(fakeArgs);
+        assertNode.rejects(shouldReject);
+      });
     });
   });
   describe('isFunctionExecutedEvent()', () => {

--- a/src/SlackFunction.spec.ts
+++ b/src/SlackFunction.spec.ts
@@ -200,6 +200,44 @@ describe('SlackFunction module', () => {
         assert.doesNotThrow(shouldNotThrow, SlackFunctionInitializationError);
       });
     });
+    describe('app.function.blockAction() adds a handler to interactivity handlers', () => {
+      it('should not error when valid handler constraints supplied', async () => {
+        const mockFunctionCallbackId = 'reverse_approval';
+        const { SlackFunction } = await importSlackFunctionModule(withMockValidManifestUtil(mockFunctionCallbackId));
+        const testFunc = new SlackFunction(mockFunctionCallbackId, async () => {});
+        const goodConstraints: ActionConstraints = {
+          action_id: '',
+        };
+        const shouldNotThrow = () => testFunc.blockAction(goodConstraints, async () => {});
+        assert.doesNotThrow(shouldNotThrow, SlackFunctionInitializationError);
+      });
+      it('should error when invalid handler constraints supplied', async () => {
+        const mockFunctionCallbackId = 'reverse_approval';
+        const { SlackFunction } = await importSlackFunctionModule(withMockValidManifestUtil(mockFunctionCallbackId));
+        const testFunc = new SlackFunction(mockFunctionCallbackId, async () => {});
+        const badConstraints = {
+          bad_id: '',
+          action_id: '',
+        } as ActionConstraints;
+        const shouldThrow = () => testFunc.blockAction(badConstraints, async () => {});
+        assert.throws(shouldThrow, SlackFunctionInitializationError);
+      });
+      it('should return the instance of slackfunction', async () => {
+        const mockFunctionCallbackId = 'reverse_approval';
+        const { SlackFunction } = await importSlackFunctionModule(withMockValidManifestUtil(mockFunctionCallbackId));
+        const testFunc = new SlackFunction(mockFunctionCallbackId, async () => {});
+        const goodConstraints: ActionConstraints = {
+          action_id: '',
+        };
+        const mockHandler = async () => {};
+        // expect that the return value of blockAction is a Slack function
+        assert.instanceOf(testFunc.blockAction(goodConstraints, mockHandler), SlackFunction);
+        // chained valid handlers should not error
+        const shouldNotThrow = () => testFunc.blockAction(goodConstraints, mockHandler)
+          .blockAction(goodConstraints, mockHandler);
+        assert.doesNotThrow(shouldNotThrow, SlackFunctionInitializationError);
+      });
+    });
     describe('runInteractivityHandlers', () => {
       it('app.function.action() should execute all provided callbacks', async () => {
         const mockFunctionCallbackId = 'reverse_approval';
@@ -331,6 +369,71 @@ describe('SlackFunction module', () => {
         const shouldReject = async () => testFunc.runInteractivityHandlers(fakeArgs);
         assertNode.rejects(shouldReject);
       });
+    });
+    it('app.function.blockAction() should execute all provided callbacks', async () => {
+      const mockFunctionCallbackId = 'reverse_approval';
+      const { SlackFunction } = await importSlackFunctionModule(withMockValidManifestUtil(mockFunctionCallbackId));
+      const testFunc = new SlackFunction(mockFunctionCallbackId, async () => {});
+      const goodConstraints: ActionConstraints = {
+        action_id: 'my-action',
+      };
+      const mockHandler = async () => Promise.resolve();
+      const spy = sinon.spy(mockHandler);
+      const spy2 = sinon.spy(mockHandler);
+      // add blockAction handlers
+      testFunc.blockAction(goodConstraints, spy).blockAction(goodConstraints, spy2);
+
+      // set up event args
+      const fakeArgs = {
+        next: () => {},
+        payload: {
+          action_id: 'my-action',
+        },
+        body: {
+          function_data: {
+            execution_id: 'asdasdas',
+          },
+        },
+        client: {} as WebClient,
+      } as unknown as AnyMiddlewareArgs & AllMiddlewareArgs;
+
+      // ensure handlers are both called
+
+      await testFunc.runInteractivityHandlers(fakeArgs);
+      assert(spy.calledOnce);
+      assert(spy2.calledOnce);
+    });
+    it('app.function.blockAction() should error if a promise rejects', async () => {
+      const mockFunctionCallbackId = 'reverse_approval';
+      const { SlackFunction } = await importSlackFunctionModule(withMockValidManifestUtil(mockFunctionCallbackId));
+      const testFunc = new SlackFunction(mockFunctionCallbackId, async () => {});
+      const action_id = 'my-action';
+      const goodConstraints: ActionConstraints = {
+        action_id,
+      };
+      const mockHandler = async () => Promise.reject();
+      const spy = sinon.spy(mockHandler);
+      // add a blockAction handlers
+      testFunc.blockAction(goodConstraints, spy);
+
+      // set up event args
+      const fakeArgs = {
+        next: () => {},
+        payload: {
+          action_id,
+        },
+        body: {
+          function_data: {
+            execution_id: 'asdasdas',
+          },
+        },
+        client: {} as WebClient,
+      } as unknown as AnyMiddlewareArgs & AllMiddlewareArgs;
+
+      // ensure handler call rejects
+
+      const shouldReject = async () => testFunc.runInteractivityHandlers(fakeArgs);
+      assertNode.rejects(shouldReject);
     });
   });
   describe('isFunctionExecutedEvent()', () => {

--- a/src/SlackFunction.ts
+++ b/src/SlackFunction.ts
@@ -156,7 +156,7 @@ export class SlackFunction {
   /**
    * Attach a block_actions interactivity handler to your SlackFunction
    *
-   * NOTE: blockActions() in this fileis a direct copy of this function
+   * NOTE: blockActions() in this file is a direct copy of this function
    * and any changes made here should also be made to that function.
    *
    * ```
@@ -210,7 +210,7 @@ export class SlackFunction {
    * consistency with having a blockSuggestion() function.
    *
    * NOTE: This function is a direct copy of the action() function and
-   * any changes made here should also be made to this function.
+   * any changes made there should also be made to this function.
    *
    * ```
    * Example:

--- a/src/SlackFunction.ts
+++ b/src/SlackFunction.ts
@@ -156,6 +156,9 @@ export class SlackFunction {
   /**
    * Attach a block_actions interactivity handler to your SlackFunction
    *
+   * NOTE: blockActions() in this fileis a direct copy of this function
+   * and any changes made here should also be made to that function.
+   *
    * ```
    * Example:
    * const actionHandler = async () => {};
@@ -202,13 +205,18 @@ export class SlackFunction {
   }
 
   /**
-   * Attach a block_actions interactivity handler to your SlackFunction
+   * Attach a block_actions interactivity handler to your SlackFunction.
+   * This function is added as an alias for the action() function to create
+   * consistency with having a blockSuggestion() function.
+   *
+   * NOTE: This function is a direct copy of the action() function and
+   * any changes made here should also be made to this function.
    *
    * ```
    * Example:
    * const actionHandler = async () => {};
    * const actionHandler1 = async () => {};
-   * myFunc.blockAction("id", actionHandler).action("id1", actionHandler1);
+   * myFunc.blockAction("id", actionHandler).blockAction("id1", actionHandler1);
    * ```
    *
    * @param actionIdOrConstraints Provide an action_id string
@@ -252,7 +260,6 @@ export class SlackFunction {
   /**
    * Attach a block_suggestion interactivity handler to your SlackFunction
    *
-   * ```
    * @param handler Provide a handler function
    * @returns SlackFunction instance
    */

--- a/src/SlackFunction.ts
+++ b/src/SlackFunction.ts
@@ -156,9 +156,6 @@ export class SlackFunction {
   /**
    * Attach a block_actions interactivity handler to your SlackFunction
    *
-   * NOTE: blockActions() in this file is a direct copy of this function
-   * and any changes made here should also be made to that function.
-   *
    * ```
    * Example:
    * const actionHandler = async () => {};
@@ -209,9 +206,6 @@ export class SlackFunction {
    * This function is added as an alias for the action() function to create
    * consistency with having a blockSuggestion() function.
    *
-   * NOTE: This function is a direct copy of the action() function and
-   * any changes made there should also be made to this function.
-   *
    * ```
    * Example:
    * const actionHandler = async () => {};
@@ -238,23 +232,7 @@ export class SlackFunction {
     actionIdOrConstraints: string | RegExp | Constraints,
     handler: Middleware<SlackActionMiddlewareArgs>,
   ): this {
-    // normalize constraints
-    const constraints: ActionConstraints = (
-      typeof actionIdOrConstraints === 'string' ||
-       util.types.isRegExp(actionIdOrConstraints)
-    ) ?
-      { action_id: actionIdOrConstraints } :
-      actionIdOrConstraints;
-
-    // declare our valid constraints keys
-    const validConstraintsKeys: ActionConstraintsKeys = ['action_id', 'block_id', 'callback_id', 'type'];
-    // cast to string array for convenience
-    const validConstraintsKeysAsStrings = validConstraintsKeys as string[];
-
-    errorIfInvalidConstraintKeys(constraints, validConstraintsKeysAsStrings, handler);
-
-    this.interactivityHandlers.push({ constraints, handler });
-    return this;
+    return this.action.apply(this, [actionIdOrConstraints, handler]);
   }
 
   /**

--- a/src/SlackFunction.ts
+++ b/src/SlackFunction.ts
@@ -202,6 +202,54 @@ export class SlackFunction {
   }
 
   /**
+   * Attach a block_actions interactivity handler to your SlackFunction
+   *
+   * ```
+   * Example:
+   * const actionHandler = async () => {};
+   * const actionHandler1 = async () => {};
+   * myFunc.blockAction("id", actionHandler).action("id1", actionHandler1);
+   * ```
+   *
+   * @param actionIdOrConstraints Provide an action_id string
+   * corresponding to the value supplied in your blocks or a
+   * constraint object of type ActionConstraints<SlackAction>
+   *
+   * ```
+   * Example:
+   * myFunc.blockAction({ type: "action_submission" });
+   * myFunc.blockAction({ action_id: "id" }, actionHandler);
+   * ```
+   * @param handler Provide a handler function
+   * @returns SlackFunction instance
+   */
+  public blockAction<
+     Action extends SlackAction = SlackAction,
+     Constraints extends ActionConstraints<Action> = ActionConstraints<Action>,
+   >(
+    actionIdOrConstraints: string | RegExp | Constraints,
+    handler: Middleware<SlackActionMiddlewareArgs>,
+  ): this {
+    // normalize constraints
+    const constraints: ActionConstraints = (
+      typeof actionIdOrConstraints === 'string' ||
+       util.types.isRegExp(actionIdOrConstraints)
+    ) ?
+      { action_id: actionIdOrConstraints } :
+      actionIdOrConstraints;
+
+    // declare our valid constraints keys
+    const validConstraintsKeys: ActionConstraintsKeys = ['action_id', 'block_id', 'callback_id', 'type'];
+    // cast to string array for convenience
+    const validConstraintsKeysAsStrings = validConstraintsKeys as string[];
+
+    errorIfInvalidConstraintKeys(constraints, validConstraintsKeysAsStrings, handler);
+
+    this.interactivityHandlers.push({ constraints, handler });
+    return this;
+  }
+
+  /**
    * Attach a block_suggestion interactivity handler to your SlackFunction
    *
    * ```


### PR DESCRIPTION
###  Summary

In https://github.com/slackapi/bolt-js/pull/1645 we introduced `SlackFunction.blockSuggestion()` as a handler for the `block_suggestions` event. While we already have a `.action()` handler for `block_actions`, we should also add in a `SlackFunction.blockAction()` handler to be consistent with this naming convention so folks can use either `.action()` or `.blockAction()` as they wish!

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).