### PR TITLE
Reword migrate beta documentation

### DIFF
--- a/docs/_future/deploy_your_app.md
+++ b/docs/_future/deploy_your_app.md
@@ -21,7 +21,7 @@ In this guide, you will find the steps needed to prepare and deploy your app to 
 
 ### Before you begin {#before-you-begin}
 
-Before you can deploy a Bolt app to Heroku, you'll need a working Bolt app. If you haven't created one yet, [go ahead and make one](/bolt-js/future/getting-started#create-app)! If you already have an app and want features of the next-generation platform, check out the [Bolt for JavaScript migration guide](/bolt-js/future/migrate-existing-app).
+Before you can deploy a Bolt app to Heroku, you'll need a working Bolt app. If you haven't created one yet, [go ahead and make one](/bolt-js/future/getting-started#create-app)! If you already have an app and want features of the next-generation platform, check out the [Bolt for JavaScript setup guide](/bolt-js/future/setup-existing-app).
 
 Additionally, you will need to have at least one Trigger created for your application to confirm that your application has successfully deployed to Heroku. If you haven't created one yet, you can learn about [the different types of Triggers](/bolt-js/future/triggers#types) and [how to create a Trigger](/bolt-js/future/triggers#create) for tapping into your Workflows.
 

--- a/docs/_future/getting_started_future.md
+++ b/docs/_future/getting_started_future.md
@@ -36,7 +36,7 @@ If you'd like to deploy your app with Slack infrastructure, consider building yo
 
 To build a next-generation app with Bolt for JavaScript, you'll first need to get the Slack CLI set up on your machine. You can follow the [Quickstart Guide](https://api.slack.com/future/quickstart) to get instructions on how to manually or automatically install it based on your operating system. 
 
-Since we won't be using Deno to build or migrate our next-generation app, you can skip any instructions related to installing Deno or creating an app using a Deno template. Once you've logged into the CLI using `slack login` and verified your login using `slack auth list`, you can proceed with the instructions in this guide.
+Since we won't be using Deno to build or setup an existing next-generation app, you can skip any instructions related to installing Deno or creating an app using a Deno template. Once you've logged into the CLI using `slack login` and verified your login using `slack auth list`, you can proceed with the instructions in this guide.
 
 > 💡 When logging into a workspace using the CLI, we recommend using a workspace where you won't disrupt real work getting done. Currently the new Slack Platform beta is only available for workspaces on a paid plan.
 
@@ -57,7 +57,7 @@ In order to use the next-generation platform features, you'll need to accept a T
 > 💡 You must be an admin of your workspace to be able to access the Workspace Settings and accept the Terms of Service.
 
 
-Congratulations! You're now ready to start building using the [next-generation Platform](/bolt-js/future/getting-started#next-gen). 🎉 You can now proceed with either creating a new app by following the instructions below or [migrating an existing app](/bolt-js/future/migrate-existing-app).
+Congratulations! You're now ready to start building using the [next-generation Platform](/bolt-js/future/getting-started#next-gen). 🎉 You can now proceed with either creating a new app by following the instructions below or [setting up an existing app](/bolt-js/future/setup-existing-app).
 
 ---
 

--- a/docs/_future/migrate_existing_app.md
+++ b/docs/_future/migrate_existing_app.md
@@ -1,16 +1,16 @@
 ---
-title: Migrate an existing app
+title: Setup an existing app
 order: 9
-slug: migrate-existing-app
+slug: setup-existing-app
 lang: en
 layout: tutorial
-permalink: /future/migrate-existing-app
+permalink: /future/setup-existing-app
 ---
 
-# Migrate an existing app <span class="label-beta">BETA</span>
+# Setup an existing app <span class="label-beta">BETA</span>
 
 <div class="section-content">
-If you have an existing Slack app written with Bolt for JavaScript that you'd like to migrate to the [next-generation platform](/bolt-js/future/getting-started#next-gen), this guide is for you!
+If you would like to setup an existing Slack app with the beta tools from the [next-generation platform](/bolt-js/future/getting-started#next-gen), this guide is for you!
 </div>
 
 If you do not have an existing Bolt for JavaScript application but are looking to get started with the [next-gen platform](/bolt-js/future/getting-started#next-gen), check out the [Getting Started](/bolt-js/future/getting-started) guide.

--- a/docs/_future/request_time_off_tutorial.md
+++ b/docs/_future/request_time_off_tutorial.md
@@ -18,7 +18,7 @@ When you’re finished, you’ll have this ⚡️[Bolt for JavaScript Request Ti
 
 If you'd like to create a simpler next-generation Bolt for JavaScript application or are looking to quickstart with a simple template, follow the [Getting Started guide](/bolt-js/future/getting-started#create-app).
 
-If you already have an existing Bolt for JavaScript application that you'd like to migrate to the next-generation platform, check out the [Migration guide](/bolt-js/future/migrate-existing-app) instead.
+If you already have an existing Bolt for JavaScript application that you'd like to setup an existing app with the next-generation platform, check out the [Setup guide](/bolt-js/future/setup-existing-app) instead.
 </div>
 
 ---

--- a/docs/_future/setup_existing_app.md
+++ b/docs/_future/setup_existing_app.md
@@ -4,6 +4,7 @@ order: 9
 slug: setup-existing-app
 lang: en
 layout: tutorial
+redirect_from: /future/migrate-existing-app
 permalink: /future/setup-existing-app
 ---
 


### PR DESCRIPTION
###  Summary

This PR rewords the beta platform doc "Migrate an existing app" to "Setup an existing app" to better describe that the steps involved in the section are intended to help existing apps to set up the CLI tool, get their manifest locally, and get started with the local development via the CLI.  

### Requirements (place an `x` in each `[ ]`)

* [ x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).