### PR TITLE
📝 Improve doc: remove double quotes from hash key

### DIFF
--- a/docs/_basic/ja_listening_responding_options.md
+++ b/docs/_basic/ja_listening_responding_options.md
@@ -24,16 +24,16 @@ app.options('external_action', async ({ options, ack }) => {
     // ack 応答 するために options 配列に情報をプッシュ
     for (const result of results) {
       options.push({
-        "text": {
-          "type": "plain_text",
-          "text": result.label
+        text: {
+          type: "plain_text",
+          text: result.label
         },
-        "value": result.value
+        value: result.value
       });
     }
 
     await ack({
-      "options": options
+      options: options
     });
   } else {
     await ack();

--- a/docs/_basic/ja_publishing_views.md
+++ b/docs/_basic/ja_publishing_views.md
@@ -21,20 +21,20 @@ app.event('app_home_opened', async ({ event, client, logger }) => {
       user_id: event.user,
       view: {
         // ホームタブはあらかじめアプリ設定ページで有効にしておく必要があります
-        "type": "home",
-        "blocks": [
+        type: "home",
+        blocks: [
           {
-            "type": "section",
-            "text": {
-              "type": "mrkdwn",
-              "text": "*Welcome home, <@" + event.user + "> :house:*"
+            type: "section",
+            text: {
+              type: "mrkdwn",
+              text: "*Welcome home, <@" + event.user + "> :house:*"
             }
           },
           {
-            "type": "section",
-            "text": {
-              "type": "mrkdwn",
-              "text": "Learn how home tabs can be more useful and interactive <https://api.slack.com/surfaces/tabs/using|*in the documentation*>."
+            type: "section",
+            text: {
+              type: "mrkdwn",
+              text: "Learn how home tabs can be more useful and interactive <https://api.slack.com/surfaces/tabs/using|*in the documentation*>."
             }
           }
         ]

--- a/docs/_basic/listening_responding_options.md
+++ b/docs/_basic/listening_responding_options.md
@@ -26,16 +26,16 @@ app.options('external_action', async ({ options, ack }) => {
     // Collect information in options array to send in Slack ack response
     for (const result of results) {
       options.push({
-        "text": {
-          "type": "plain_text",
-          "text": result.label
+        text: {
+          type: "plain_text",
+          text: result.label
         },
-        "value": result.value
+        value: result.value
       });
     }
 
     await ack({
-      "options": options
+      options: options
     });
   } else {
     await ack();

--- a/docs/_basic/publishing_views.md
+++ b/docs/_basic/publishing_views.md
@@ -21,20 +21,20 @@ app.event('app_home_opened', async ({ event, client, logger }) => {
       user_id: event.user,
       view: {
         // Home tabs must be enabled in your app configuration page under "App Home"
-        "type": "home",
-        "blocks": [
+        type: "home",
+        blocks: [
           {
-            "type": "section",
-            "text": {
-              "type": "mrkdwn",
-              "text": "*Welcome home, <@" + event.user + "> :house:*"
+            type: "section",
+            text: {
+              type: "mrkdwn",
+              text: "*Welcome home, <@" + event.user + "> :house:*"
             }
           },
           {
-            "type": "section",
-            "text": {
-              "type": "mrkdwn",
-              "text": "Learn how home tabs can be more useful and interactive <https://api.slack.com/surfaces/tabs/using|*in the documentation*>."
+            type: "section",
+            text: {
+              type: "mrkdwn",
+              text: "Learn how home tabs can be more useful and interactive <https://api.slack.com/surfaces/tabs/using|*in the documentation*>."
             }
           }
         ]


### PR DESCRIPTION
###  Summary

This PR is improving docs 📝 
Remove double quotes from hash key, aligned with other sample code 😄 

before

```javascript
          {
            "type": "section",
            "text": {
              "type": "mrkdwn",
              "text": "*Welcome home, <@" + event.user + "> :house:*"
            }
          },
```

after

```javascript
          {
            type: "section",
            text: {
              type: "mrkdwn",
              text: "*Welcome home, <@" + event.user + "> :house:*"
            }
          },
```

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).