### PR TITLE
🔼 Update actions/checkout, actions/setup-node to v3

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -19,9 +19,9 @@ jobs:
         node-version: [12.x, 14.x, 16.x]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v3
       with:
         node-version: ${{ matrix.node-version }}
     - run: npm install


### PR DESCRIPTION
###  Summary

This PR is to update GitHub Actions for resolving annotation ⬆️ 

ref: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/

current annotation example
https://github.com/slackapi/bolt-js/actions/runs/3723607402

<img width="530" alt="image" src="https://user-images.githubusercontent.com/38120991/208390919-e344a54e-20ab-4ccf-82ec-921a269afb14.png">

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).