### PR TITLE
Update outdated documents related on AWS Lambda

### DIFF
--- a/docs/_deployments/aws-lambda.md
+++ b/docs/_deployments/aws-lambda.md
@@ -147,7 +147,7 @@ const app = new App({
 });
 ```
 
-Finally, at the bottom of your app, update the [source code that starts the HTTP server](https://github.com/slackapi/bolt-js-getting-started-app/blob/main/app.js#L40-L45) to now respond to an AWS Lambda function event:
+Finally, at the bottom of your app, update the [source code that starts the HTTP server](https://github.com/slackapi/bolt-js-getting-started-app/blob/main/app.js#L47-L52) to now respond to an AWS Lambda function event:
 
 ```javascript
 // Handle the Lambda function event

--- a/docs/_deployments/ja_aws-lambda.md
+++ b/docs/_deployments/ja_aws-lambda.md
@@ -146,7 +146,7 @@ const app = new App({
 });
 ```
 
-最後に、アプリのソースコードの末尾にある [HTTP サーバーを起動する部分](https://github.com/slackapi/bolt-js-getting-started-app/blob/main/app.js#L40-L45)を編集して、AWS Lambda 関数のイベントに応答するようにします。
+最後に、アプリのソースコードの末尾にある [HTTP サーバーを起動する部分](https://github.com/slackapi/bolt-js-getting-started-app/blob/main/app.js#L47-L52)を編集して、AWS Lambda 関数のイベントに応答するようにします。
 
 ```javascript
 // Lambda 関数のイベントを処理します
@@ -211,6 +211,7 @@ npm install --save-dev serverless-offline
 ```zsh
 serverless offline --noPrependStageInUrl
 ```
+
 > 🏌️ Pro-tip: 別のターミナルで上記のコマンドを実行しておくことで、ターミナル上でアプリのコードを変更することができます。コードの変更を保存する度、アプリは自動的にリロードされます。
 
 次に、ngrok を使って Slack のイベントをローカルマシンに転送します。


### PR DESCRIPTION
###  Summary

> Replace hyperlinks which pointing outdated lines on AWS Lambda documents

Recently, I tried to migrate my bolt.js application from just instance to serverless.

So I read AWS Lambda document and found outdated hyperlinks.

In this commit (https://github.com/slackapi/bolt-js-getting-started-app/commit/4c29a21438b40f0cbca71ece0d39b356dfcf88d5#), some comments are added so anchor(https://github.com/slackapi/bolt-js/blame/main/docs/_deployments/aws-lambda.md#L150) pointed wrong lines.

So I replaced the anchor to latest line I think.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).