### PR TITLE
Typo in docs -> future -> beta TOS link

### DIFF
--- a/docs/_future/app_manifests.md
+++ b/docs/_future/app_manifests.md
@@ -82,7 +82,7 @@ The properties in the manifest are:
 | `longDescription` | String | ✅ Yes | (Optional) A more detailed description of your application |
 | `icon` | String | ❌ No | A relative path to an image asset to use for the app's icon. Your app's profile picture that will appear in the Slack client |
 | `backgroundColor` | String | ✅ Yes | (Optional) A six digit combination of numbers and letters (the hexadecimal color code) that make up the color of your app background e.g., "#000000" is the color black |
-| `botScopes` | Array<string> | ✅ Yes | A list of [scopes](/scopes), or permissions, the app's functions require |
+| `botScopes` | Array<string> | ✅ Yes | A list of [scopes](https://api.slack.com/scopes), or permissions, the app's functions require |
 | `functions` | Array | ✅ Yes | (Optional) A list of all functions your app will use |
 | `workflows` | Array | ✅ Yes | (Optional) A list of all workflows your app will use |
 | `outgoingDomains` | Array<string> | ✅ Yes | (Optional) If your app communicates to any external domains, list them here. Note that the outgoing domains are only restricted if the workspace has Admin approved apps on e.g., myapp.tld |

--- a/docs/_future/getting_started_future.md
+++ b/docs/_future/getting_started_future.md
@@ -50,7 +50,7 @@ Make sure your machine has the most recent version of [Node](https://nodejs.org/
 
 #### Accept the Beta Terms of Service {#accept-tos}
 
-In order to use the next-generation platform features, you'll need to accept a Terms of Service (TOS) for Slack Platform Beta in your Workspace Settings [here](https://slack.com/admin/settings#hermes_permissionfs).
+In order to use the next-generation platform features, you'll need to accept a Terms of Service (TOS) for Slack Platform Beta in your Workspace Settings [here](https://slack.com/admin/settings#hermes_permissions).
 
 > 💡 You must be an admin of your workspace to be able to access the Workspace Settings and accept the Terms of Service.
 


### PR DESCRIPTION
###  Summary

Fix typo in beta docs

### Requirements (place an `x` in each `[ ]`)

* [x ] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [ x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).