### PR TITLE
Fix #1325 Added support for dynamic custom paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "@types/tsscmp": "^1.0.0",
     "axios": "^0.27.2",
     "express": "^4.16.4",
+    "path-to-regexp": "^6.2.1",
     "please-upgrade-node": "^3.2.0",
     "promise.allsettled": "^1.0.2",
     "raw-body": "^2.3.3",

--- a/src/receivers/HTTPReceiver.spec.ts
+++ b/src/receivers/HTTPReceiver.spec.ts
@@ -576,8 +576,10 @@ describe('HTTPReceiver', function () {
 
       it('should call custom route handler only if request matches multiple route paths and method including params', async function () {
         const HTTPReceiver = await importHTTPReceiver();
-        const customRoutes = [{ path: '/test/123', method: ['get', 'POST'], handler: sinon.fake() },
-          { path: '/test/:id', method: ['get', 'POST'], handler: sinon.fake.throws('Should not be used.') }];
+        const customRoutes = [
+          { path: '/test/123', method: ['get', 'POST'], handler: sinon.fake() },
+          { path: '/test/:id', method: ['get', 'POST'], handler: sinon.fake() },
+        ];
         const matchRegex = match(customRoutes[0].path, { decode: decodeURIComponent });
         const receiver = new HTTPReceiver({
           clientSecret: 'my-client-secret',
@@ -596,6 +598,41 @@ describe('HTTPReceiver', function () {
         fakeReq.method = 'GET';
         receiver.requestListener(fakeReq, fakeRes);
         assert(customRoutes[0].handler.calledWith({ ...fakeReq, params }, fakeRes));
+        assert(customRoutes[1].handler.notCalled);
+
+        fakeReq.method = 'POST';
+        receiver.requestListener(fakeReq, fakeRes);
+        assert(customRoutes[0].handler.calledWith({ ...fakeReq, params }, fakeRes));
+
+        fakeReq.method = 'UNHANDLED_METHOD';
+        assert.throws(() => receiver.requestListener(fakeReq, fakeRes), HTTPReceiverDeferredRequestError);
+      });
+
+      it('should call custom route handler only if request matches multiple route paths and method including params reverse order', async function () {
+        const HTTPReceiver = await importHTTPReceiver();
+        const customRoutes = [
+          { path: '/test/:id', method: ['get', 'POST'], handler: sinon.fake() },
+          { path: '/test/123', method: ['get', 'POST'], handler: sinon.fake() },
+        ];
+        const matchRegex = match(customRoutes[0].path, { decode: decodeURIComponent });
+        const receiver = new HTTPReceiver({
+          clientSecret: 'my-client-secret',
+          signingSecret: 'secret',
+          customRoutes,
+        });
+
+        const fakeReq: IncomingMessage = sinon.createStubInstance(IncomingMessage) as IncomingMessage;
+        const fakeRes: ServerResponse = sinon.createStubInstance(ServerResponse) as unknown as ServerResponse;
+
+        fakeReq.url = '/test/123';
+        const tempMatch = matchRegex(fakeReq.url);
+        if (!tempMatch) throw new Error('match failed');
+        const params : ParamsDictionary = tempMatch.params as ParamsDictionary;
+
+        fakeReq.method = 'GET';
+        receiver.requestListener(fakeReq, fakeRes);
+        assert(customRoutes[0].handler.calledWith({ ...fakeReq, params }, fakeRes));
+        assert(customRoutes[1].handler.notCalled);
 
         fakeReq.method = 'POST';
         receiver.requestListener(fakeReq, fakeRes);

--- a/src/receivers/HTTPReceiver.spec.ts
+++ b/src/receivers/HTTPReceiver.spec.ts
@@ -6,6 +6,8 @@ import { Logger, LogLevel } from '@slack/logger';
 import { EventEmitter } from 'events';
 import { InstallProvider } from '@slack/oauth';
 import { IncomingMessage, ServerResponse } from 'http';
+import { match } from 'path-to-regexp';
+import { ParamsDictionary } from 'express-serve-static-core';
 import { Override, mergeOverrides } from '../test-helpers';
 import {
   AppInitializationError,
@@ -485,6 +487,7 @@ describe('HTTPReceiver', function () {
       it('should call custom route handler only if request matches route path and method', async function () {
         const HTTPReceiver = await importHTTPReceiver();
         const customRoutes = [{ path: '/test', method: ['get', 'POST'], handler: sinon.fake() }];
+        const matchRegex = match(customRoutes[0].path, { decode: decodeURIComponent });
         const receiver = new HTTPReceiver({
           clientSecret: 'my-client-secret',
           signingSecret: 'secret',
@@ -495,14 +498,17 @@ describe('HTTPReceiver', function () {
         const fakeRes: ServerResponse = sinon.createStubInstance(ServerResponse) as unknown as ServerResponse;
 
         fakeReq.url = '/test';
+        const tempMatch = matchRegex(fakeReq.url);
+        if (!tempMatch) throw new Error('match failed');
+        const params : ParamsDictionary = tempMatch.params as ParamsDictionary;
 
         fakeReq.method = 'GET';
         receiver.requestListener(fakeReq, fakeRes);
-        assert(customRoutes[0].handler.calledWith(fakeReq, fakeRes));
+        assert(customRoutes[0].handler.calledWith({ ...fakeReq, params }, fakeRes));
 
         fakeReq.method = 'POST';
         receiver.requestListener(fakeReq, fakeRes);
-        assert(customRoutes[0].handler.calledWith(fakeReq, fakeRes));
+        assert(customRoutes[0].handler.calledWith({ ...fakeReq, params }, fakeRes));
 
         fakeReq.method = 'UNHANDLED_METHOD';
         assert.throws(() => receiver.requestListener(fakeReq, fakeRes), HTTPReceiverDeferredRequestError);
@@ -511,6 +517,7 @@ describe('HTTPReceiver', function () {
       it('should call custom route handler only if request matches route path and method, ignoring query params', async function () {
         const HTTPReceiver = await importHTTPReceiver();
         const customRoutes = [{ path: '/test', method: ['get', 'POST'], handler: sinon.fake() }];
+        const matchRegex = match(customRoutes[0].path, { decode: decodeURIComponent });
         const receiver = new HTTPReceiver({
           clientSecret: 'my-client-secret',
           signingSecret: 'secret',
@@ -521,14 +528,17 @@ describe('HTTPReceiver', function () {
         const fakeRes: ServerResponse = sinon.createStubInstance(ServerResponse) as unknown as ServerResponse;
 
         fakeReq.url = '/test?hello=world';
+        const tempMatch = matchRegex('/test');
+        if (!tempMatch) throw new Error('match failed');
+        const params : ParamsDictionary = tempMatch.params as ParamsDictionary;
 
         fakeReq.method = 'GET';
         receiver.requestListener(fakeReq, fakeRes);
-        assert(customRoutes[0].handler.calledWith(fakeReq, fakeRes));
+        assert(customRoutes[0].handler.calledWith({ ...fakeReq, params }, fakeRes));
 
         fakeReq.method = 'POST';
         receiver.requestListener(fakeReq, fakeRes);
-        assert(customRoutes[0].handler.calledWith(fakeReq, fakeRes));
+        assert(customRoutes[0].handler.calledWith({ ...fakeReq, params }, fakeRes));
 
         fakeReq.method = 'UNHANDLED_METHOD';
         assert.throws(() => receiver.requestListener(fakeReq, fakeRes), HTTPReceiverDeferredRequestError);
@@ -537,6 +547,7 @@ describe('HTTPReceiver', function () {
       it('should call custom route handler only if request matches route path and method including params', async function () {
         const HTTPReceiver = await importHTTPReceiver();
         const customRoutes = [{ path: '/test/:id', method: ['get', 'POST'], handler: sinon.fake() }];
+        const matchRegex = match(customRoutes[0].path, { decode: decodeURIComponent });
         const receiver = new HTTPReceiver({
           clientSecret: 'my-client-secret',
           signingSecret: 'secret',
@@ -547,14 +558,17 @@ describe('HTTPReceiver', function () {
         const fakeRes: ServerResponse = sinon.createStubInstance(ServerResponse) as unknown as ServerResponse;
 
         fakeReq.url = '/test/123';
+        const tempMatch = matchRegex(fakeReq.url);
+        if (!tempMatch) throw new Error('match failed');
+        const params : ParamsDictionary = tempMatch.params as ParamsDictionary;
 
         fakeReq.method = 'GET';
         receiver.requestListener(fakeReq, fakeRes);
-        assert(customRoutes[0].handler.calledWith(fakeReq, fakeRes));
+        assert(customRoutes[0].handler.calledWith({ ...fakeReq, params }, fakeRes));
 
         fakeReq.method = 'POST';
         receiver.requestListener(fakeReq, fakeRes);
-        assert(customRoutes[0].handler.calledWith(fakeReq, fakeRes));
+        assert(customRoutes[0].handler.calledWith({ ...fakeReq, params }, fakeRes));
 
         fakeReq.method = 'UNHANDLED_METHOD';
         assert.throws(() => receiver.requestListener(fakeReq, fakeRes), HTTPReceiverDeferredRequestError);

--- a/src/receivers/HTTPReceiver.ts
+++ b/src/receivers/HTTPReceiver.ts
@@ -6,7 +6,8 @@ import { Logger, ConsoleLogger, LogLevel } from '@slack/logger';
 import { InstallProvider, CallbackOptions, InstallProviderOptions, InstallURLOptions, InstallPathOptions } from '@slack/oauth';
 import { URL } from 'url';
 import { match } from 'path-to-regexp';
-
+import { ParamsDictionary } from 'express-serve-static-core';
+import { ParamsIncomingMessage } from './ParamsIncomingMessage';
 import { verifyRedirectOpts } from './verify-redirect-opts';
 import App from '../App';
 import { Receiver, ReceiverEvent } from '../types';
@@ -395,16 +396,19 @@ export default class HTTPReceiver implements Receiver {
     if (Object.keys(this.routes).length) {
       // Check if the request matches any of the custom routes
       let pathMatch : string | boolean = false;
+      let params : ParamsDictionary = {};
       Object.keys(this.routes).forEach((route) => {
         const matchRegex = match(route, { decode: decodeURIComponent });
         const tempMatch = matchRegex(path);
         if (tempMatch) {
           pathMatch = route;
-          req.params = tempMatch.params;
+          params = tempMatch.params as ParamsDictionary;
         }
       });
       const urlMatch = pathMatch && this.routes[pathMatch][method] !== undefined;
-      if (urlMatch && pathMatch) { return this.routes[pathMatch][method](req, res); }
+      if (urlMatch && pathMatch) {
+        return this.routes[pathMatch][method]({ ...req, params } as ParamsIncomingMessage, res);
+      }
     }
 
     // If the request did not match the previous conditions, an error is thrown. The error can be caught by

--- a/src/receivers/HTTPReceiver.ts
+++ b/src/receivers/HTTPReceiver.ts
@@ -398,6 +398,7 @@ export default class HTTPReceiver implements Receiver {
       let pathMatch : string | boolean = false;
       let params : ParamsDictionary = {};
       Object.keys(this.routes).forEach((route) => {
+        if (pathMatch) return;
         const matchRegex = match(route, { decode: decodeURIComponent });
         const tempMatch = matchRegex(path);
         if (tempMatch) {

--- a/src/receivers/ParamsIncomingMessage.ts
+++ b/src/receivers/ParamsIncomingMessage.ts
@@ -1,13 +1,8 @@
-import http from 'http';
+import { IncomingMessage } from 'http';
+import { ParamsDictionary } from 'express-serve-static-core';
 
-declare module 'http' {
-  interface IncomingMessage {
-    // eslint-disable-next-line @typescript-eslint/ban-types
-    params?: { [key: string]: string } | string[] | object | undefined;
-  }
-}
-
-export interface ParamsIncomingMessage extends http.IncomingMessage {
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export interface ParamsIncomingMessage extends IncomingMessage {
   /**
    * **Only valid for requests with path parameters.**
    *
@@ -16,5 +11,5 @@ export interface ParamsIncomingMessage extends http.IncomingMessage {
    * then `request.params` will be `{ id: '123' }`.
    */
   // eslint-disable-next-line @typescript-eslint/ban-types
-  params: { [key: string]: string } | string[] | object | undefined;
+  params?: ParamsDictionary;
 }

--- a/src/receivers/ParamsIncomingMessage.ts
+++ b/src/receivers/ParamsIncomingMessage.ts
@@ -1,0 +1,20 @@
+import http from 'http';
+
+declare module 'http' {
+  interface IncomingMessage {
+    // eslint-disable-next-line @typescript-eslint/ban-types
+    params?: { [key: string]: string } | string[] | object | undefined;
+  }
+}
+
+export interface ParamsIncomingMessage extends http.IncomingMessage {
+  /**
+   * **Only valid for requests with path parameters.**
+   *
+   * The path parameters of the request. For example, if the request URL is
+   * `/users/123`, and the route definition is `/users/:id`
+   * then `request.params` will be `{ id: '123' }`.
+   */
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  params: { [key: string]: string } | string[] | object | undefined;
+}

--- a/src/receivers/ParamsIncomingMessage.ts
+++ b/src/receivers/ParamsIncomingMessage.ts
@@ -1,7 +1,6 @@
 import { IncomingMessage } from 'http';
 import { ParamsDictionary } from 'express-serve-static-core';
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export interface ParamsIncomingMessage extends IncomingMessage {
   /**
    * **Only valid for requests with path parameters.**

--- a/src/receivers/ParamsIncomingMessage.ts
+++ b/src/receivers/ParamsIncomingMessage.ts
@@ -9,6 +9,5 @@ export interface ParamsIncomingMessage extends IncomingMessage {
    * `/users/123`, and the route definition is `/users/:id`
    * then `request.params` will be `{ id: '123' }`.
    */
-  // eslint-disable-next-line @typescript-eslint/ban-types
   params?: ParamsDictionary;
 }

--- a/src/receivers/SocketModeReceiver.spec.ts
+++ b/src/receivers/SocketModeReceiver.spec.ts
@@ -548,6 +548,48 @@ describe('SocketModeReceiver', function () {
         assert(fakeRes.end.called);
       });
 
+      it('should call custom route handler only if request matches multiple route paths and method including params', async function () {
+        // Arrange
+        const installProviderStub = sinon.createStubInstance(InstallProvider);
+        const overrides = mergeOverrides(
+          withHttpCreateServer(this.fakeCreateServer),
+          withHttpsCreateServer(sinon.fake.throws('Should not be used.')),
+        );
+        const SocketModeReceiver = await importSocketModeReceiver(overrides);
+        const customRoutes = [{ path: '/test/123', method: ['get', 'POST'], handler: sinon.fake() },
+          { path: '/test/:id', method: ['get', 'POST'], handler: sinon.fake.throws('Should not be used.') }];
+        const matchRegex = match(customRoutes[0].path, { decode: decodeURIComponent });
+
+        const receiver = new SocketModeReceiver({
+          appToken: 'my-secret',
+          customRoutes,
+        });
+        assert.isNotNull(receiver);
+        receiver.installer = installProviderStub as unknown as InstallProvider;
+
+        const fakeReq: IncomingMessage = sinon.createStubInstance(IncomingMessage) as IncomingMessage;
+        const fakeRes = { writeHead: sinon.fake(), end: sinon.fake() };
+
+        fakeReq.url = '/test/123';
+        const tempMatch = matchRegex(fakeReq.url);
+        if (!tempMatch) throw new Error('match failed');
+        const params : ParamsDictionary = tempMatch.params as ParamsDictionary;
+        fakeReq.headers = { host: 'localhost' };
+
+        fakeReq.method = 'GET';
+        await this.listener(fakeReq, fakeRes);
+        assert(customRoutes[0].handler.calledWith({ ...fakeReq, params }, fakeRes));
+
+        fakeReq.method = 'POST';
+        await this.listener(fakeReq, fakeRes);
+        assert(customRoutes[0].handler.calledWith({ ...fakeReq, params }, fakeRes));
+
+        fakeReq.method = 'UNHANDLED_METHOD';
+        await this.listener(fakeReq, fakeRes);
+        assert(fakeRes.writeHead.calledWith(404, sinon.match.object));
+        assert(fakeRes.end.called);
+      });
+
       it("should throw an error if customRoutes don't have the required keys", async function () {
         // Arrange
         const overrides = mergeOverrides(

--- a/src/receivers/SocketModeReceiver.spec.ts
+++ b/src/receivers/SocketModeReceiver.spec.ts
@@ -5,6 +5,8 @@ import rewiremock from 'rewiremock';
 import { Logger, LogLevel } from '@slack/logger';
 import { EventEmitter } from 'events';
 import { IncomingMessage, ServerResponse } from 'http';
+import { match } from 'path-to-regexp';
+import { ParamsDictionary } from 'express-serve-static-core';
 import { InstallProvider } from '@slack/oauth';
 import { SocketModeClient } from '@slack/socket-mode';
 import { Override, mergeOverrides } from '../test-helpers';
@@ -432,6 +434,7 @@ describe('SocketModeReceiver', function () {
         );
         const SocketModeReceiver = await importSocketModeReceiver(overrides);
         const customRoutes = [{ path: '/test', method: ['get', 'POST'], handler: sinon.fake() }];
+        const matchRegex = match(customRoutes[0].path, { decode: decodeURIComponent });
 
         const receiver = new SocketModeReceiver({
           appToken: 'my-secret',
@@ -444,15 +447,18 @@ describe('SocketModeReceiver', function () {
         const fakeRes = { writeHead: sinon.fake(), end: sinon.fake() };
 
         fakeReq.url = '/test';
+        const tempMatch = matchRegex(fakeReq.url);
+        if (!tempMatch) throw new Error('match failed');
+        const params : ParamsDictionary = tempMatch.params as ParamsDictionary;
         fakeReq.headers = { host: 'localhost' };
 
         fakeReq.method = 'GET';
         await this.listener(fakeReq, fakeRes);
-        assert(customRoutes[0].handler.calledWith(fakeReq, fakeRes));
+        assert(customRoutes[0].handler.calledWith({ ...fakeReq, params }, fakeRes));
 
         fakeReq.method = 'POST';
         await this.listener(fakeReq, fakeRes);
-        assert(customRoutes[0].handler.calledWith(fakeReq, fakeRes));
+        assert(customRoutes[0].handler.calledWith({ ...fakeReq, params }, fakeRes));
 
         fakeReq.method = 'UNHANDLED_METHOD';
         await this.listener(fakeReq, fakeRes);
@@ -469,6 +475,7 @@ describe('SocketModeReceiver', function () {
         );
         const SocketModeReceiver = await importSocketModeReceiver(overrides);
         const customRoutes = [{ path: '/test', method: ['get', 'POST'], handler: sinon.fake() }];
+        const matchRegex = match(customRoutes[0].path, { decode: decodeURIComponent });
 
         const receiver = new SocketModeReceiver({
           appToken: 'my-secret',
@@ -481,15 +488,18 @@ describe('SocketModeReceiver', function () {
         const fakeRes = { writeHead: sinon.fake(), end: sinon.fake() };
 
         fakeReq.url = '/test?hello=world';
+        const tempMatch = matchRegex('/test');
+        if (!tempMatch) throw new Error('match failed');
+        const params : ParamsDictionary = tempMatch.params as ParamsDictionary;
         fakeReq.headers = { host: 'localhost' };
 
         fakeReq.method = 'GET';
         await this.listener(fakeReq, fakeRes);
-        assert(customRoutes[0].handler.calledWith(fakeReq, fakeRes));
+        assert(customRoutes[0].handler.calledWith({ ...fakeReq, params }, fakeRes));
 
         fakeReq.method = 'POST';
         await this.listener(fakeReq, fakeRes);
-        assert(customRoutes[0].handler.calledWith(fakeReq, fakeRes));
+        assert(customRoutes[0].handler.calledWith({ ...fakeReq, params }, fakeRes));
 
         fakeReq.method = 'UNHANDLED_METHOD';
         await this.listener(fakeReq, fakeRes);
@@ -506,6 +516,7 @@ describe('SocketModeReceiver', function () {
         );
         const SocketModeReceiver = await importSocketModeReceiver(overrides);
         const customRoutes = [{ path: '/test/:id', method: ['get', 'POST'], handler: sinon.fake() }];
+        const matchRegex = match(customRoutes[0].path, { decode: decodeURIComponent });
 
         const receiver = new SocketModeReceiver({
           appToken: 'my-secret',
@@ -518,15 +529,18 @@ describe('SocketModeReceiver', function () {
         const fakeRes = { writeHead: sinon.fake(), end: sinon.fake() };
 
         fakeReq.url = '/test/123';
+        const tempMatch = matchRegex(fakeReq.url);
+        if (!tempMatch) throw new Error('match failed');
+        const params : ParamsDictionary = tempMatch.params as ParamsDictionary;
         fakeReq.headers = { host: 'localhost' };
 
         fakeReq.method = 'GET';
         await this.listener(fakeReq, fakeRes);
-        assert(customRoutes[0].handler.calledWith(fakeReq, fakeRes));
+        assert(customRoutes[0].handler.calledWith({ ...fakeReq, params }, fakeRes));
 
         fakeReq.method = 'POST';
         await this.listener(fakeReq, fakeRes);
-        assert(customRoutes[0].handler.calledWith(fakeReq, fakeRes));
+        assert(customRoutes[0].handler.calledWith({ ...fakeReq, params }, fakeRes));
 
         fakeReq.method = 'UNHANDLED_METHOD';
         await this.listener(fakeReq, fakeRes);

--- a/src/receivers/SocketModeReceiver.spec.ts
+++ b/src/receivers/SocketModeReceiver.spec.ts
@@ -497,6 +497,43 @@ describe('SocketModeReceiver', function () {
         assert(fakeRes.end.called);
       });
 
+      it('should call custom route handler only if request matches route path and method including params', async function () {
+        // Arrange
+        const installProviderStub = sinon.createStubInstance(InstallProvider);
+        const overrides = mergeOverrides(
+          withHttpCreateServer(this.fakeCreateServer),
+          withHttpsCreateServer(sinon.fake.throws('Should not be used.')),
+        );
+        const SocketModeReceiver = await importSocketModeReceiver(overrides);
+        const customRoutes = [{ path: '/test/:id', method: ['get', 'POST'], handler: sinon.fake() }];
+
+        const receiver = new SocketModeReceiver({
+          appToken: 'my-secret',
+          customRoutes,
+        });
+        assert.isNotNull(receiver);
+        receiver.installer = installProviderStub as unknown as InstallProvider;
+
+        const fakeReq: IncomingMessage = sinon.createStubInstance(IncomingMessage) as IncomingMessage;
+        const fakeRes = { writeHead: sinon.fake(), end: sinon.fake() };
+
+        fakeReq.url = '/test/123';
+        fakeReq.headers = { host: 'localhost' };
+
+        fakeReq.method = 'GET';
+        await this.listener(fakeReq, fakeRes);
+        assert(customRoutes[0].handler.calledWith(fakeReq, fakeRes));
+
+        fakeReq.method = 'POST';
+        await this.listener(fakeReq, fakeRes);
+        assert(customRoutes[0].handler.calledWith(fakeReq, fakeRes));
+
+        fakeReq.method = 'UNHANDLED_METHOD';
+        await this.listener(fakeReq, fakeRes);
+        assert(fakeRes.writeHead.calledWith(404, sinon.match.object));
+        assert(fakeRes.end.called);
+      });
+
       it("should throw an error if customRoutes don't have the required keys", async function () {
         // Arrange
         const overrides = mergeOverrides(

--- a/src/receivers/SocketModeReceiver.spec.ts
+++ b/src/receivers/SocketModeReceiver.spec.ts
@@ -556,8 +556,10 @@ describe('SocketModeReceiver', function () {
           withHttpsCreateServer(sinon.fake.throws('Should not be used.')),
         );
         const SocketModeReceiver = await importSocketModeReceiver(overrides);
-        const customRoutes = [{ path: '/test/123', method: ['get', 'POST'], handler: sinon.fake() },
-          { path: '/test/:id', method: ['get', 'POST'], handler: sinon.fake.throws('Should not be used.') }];
+        const customRoutes = [
+          { path: '/test/123', method: ['get', 'POST'], handler: sinon.fake() },
+          { path: '/test/:id', method: ['get', 'POST'], handler: sinon.fake() },
+        ];
         const matchRegex = match(customRoutes[0].path, { decode: decodeURIComponent });
 
         const receiver = new SocketModeReceiver({
@@ -579,6 +581,53 @@ describe('SocketModeReceiver', function () {
         fakeReq.method = 'GET';
         await this.listener(fakeReq, fakeRes);
         assert(customRoutes[0].handler.calledWith({ ...fakeReq, params }, fakeRes));
+        assert(customRoutes[1].handler.notCalled);
+
+        fakeReq.method = 'POST';
+        await this.listener(fakeReq, fakeRes);
+        assert(customRoutes[0].handler.calledWith({ ...fakeReq, params }, fakeRes));
+        assert(customRoutes[1].handler.notCalled);
+
+        fakeReq.method = 'UNHANDLED_METHOD';
+        await this.listener(fakeReq, fakeRes);
+        assert(fakeRes.writeHead.calledWith(404, sinon.match.object));
+        assert(fakeRes.end.called);
+      });
+
+      it('should call custom route handler only if request matches multiple route paths and method including params reverse order', async function () {
+        // Arrange
+        const installProviderStub = sinon.createStubInstance(InstallProvider);
+        const overrides = mergeOverrides(
+          withHttpCreateServer(this.fakeCreateServer),
+          withHttpsCreateServer(sinon.fake.throws('Should not be used.')),
+        );
+        const SocketModeReceiver = await importSocketModeReceiver(overrides);
+        const customRoutes = [
+          { path: '/test/:id', method: ['get', 'POST'], handler: sinon.fake() },
+          { path: '/test/123', method: ['get', 'POST'], handler: sinon.fake() },
+        ];
+        const matchRegex = match(customRoutes[0].path, { decode: decodeURIComponent });
+
+        const receiver = new SocketModeReceiver({
+          appToken: 'my-secret',
+          customRoutes,
+        });
+        assert.isNotNull(receiver);
+        receiver.installer = installProviderStub as unknown as InstallProvider;
+
+        const fakeReq: IncomingMessage = sinon.createStubInstance(IncomingMessage) as IncomingMessage;
+        const fakeRes = { writeHead: sinon.fake(), end: sinon.fake() };
+
+        fakeReq.url = '/test/123';
+        const tempMatch = matchRegex(fakeReq.url);
+        if (!tempMatch) throw new Error('match failed');
+        const params : ParamsDictionary = tempMatch.params as ParamsDictionary;
+        fakeReq.headers = { host: 'localhost' };
+
+        fakeReq.method = 'GET';
+        await this.listener(fakeReq, fakeRes);
+        assert(customRoutes[0].handler.calledWith({ ...fakeReq, params }, fakeRes));
+        assert(customRoutes[1].handler.notCalled);
 
         fakeReq.method = 'POST';
         await this.listener(fakeReq, fakeRes);

--- a/src/receivers/SocketModeReceiver.ts
+++ b/src/receivers/SocketModeReceiver.ts
@@ -6,13 +6,14 @@ import { Logger, ConsoleLogger, LogLevel } from '@slack/logger';
 import { InstallProvider, CallbackOptions, InstallProviderOptions, InstallURLOptions, InstallPathOptions } from '@slack/oauth';
 import { AppsConnectionsOpenResponse } from '@slack/web-api';
 import { match } from 'path-to-regexp';
+import { ParamsDictionary } from 'express-serve-static-core';
+import { ParamsIncomingMessage } from './ParamsIncomingMessage';
 import App from '../App';
 import { CodedError } from '../errors';
 import { Receiver, ReceiverEvent } from '../types';
 import { StringIndexed } from '../types/helpers';
 import { buildReceiverRoutes, ReceiverRoutes } from './custom-routes';
 import { verifyRedirectOpts } from './verify-redirect-opts';
-import { ParamsIncomingMessage } from './ParamsIncomingMessage';
 import {
   SocketModeFunctions as socketModeFunc,
   SocketModeReceiverProcessEventErrorHandlerArgs,
@@ -188,18 +189,19 @@ export default class SocketModeReceiver implements Receiver {
           // The URL object is only used to safely obtain the path to match
           const { pathname: path } = new URL(req.url as string, 'http://localhost');
           let pathMatch : string | boolean = false;
+          let params : ParamsDictionary = {};
           Object.keys(this.routes).forEach((route) => {
             const matchRegex = match(route, { decode: decodeURIComponent });
             const tempMatch = matchRegex(path);
             if (tempMatch) {
               pathMatch = route;
-              req.params = tempMatch.params;
+              params = tempMatch.params as ParamsDictionary;
             }
           });
 
           const urlMatch = pathMatch && this.routes[pathMatch][method] !== undefined;
           if (urlMatch && pathMatch) {
-            this.routes[pathMatch][method](req, res);
+            this.routes[pathMatch][method]({ ...req, params } as ParamsIncomingMessage, res);
             return;
           }
         }

--- a/src/receivers/SocketModeReceiver.ts
+++ b/src/receivers/SocketModeReceiver.ts
@@ -191,6 +191,7 @@ export default class SocketModeReceiver implements Receiver {
           let pathMatch : string | boolean = false;
           let params : ParamsDictionary = {};
           Object.keys(this.routes).forEach((route) => {
+            if (pathMatch) return;
             const matchRegex = match(route, { decode: decodeURIComponent });
             const tempMatch = matchRegex(path);
             if (tempMatch) {

--- a/src/receivers/custom-routes.ts
+++ b/src/receivers/custom-routes.ts
@@ -1,4 +1,4 @@
-import { IncomingMessage, ServerResponse } from 'http';
+import { ServerResponse } from 'http';
 import { CustomRouteInitializationError } from '../errors';
 import { ParamsIncomingMessage } from './ParamsIncomingMessage';
 
@@ -10,7 +10,7 @@ export interface CustomRoute {
 
 export interface ReceiverRoutes {
   [url: string]: {
-    [method: string]: (req: IncomingMessage, res: ServerResponse) => void;
+    [method: string]: (req: ParamsIncomingMessage, res: ServerResponse) => void;
   };
 }
 

--- a/src/receivers/custom-routes.ts
+++ b/src/receivers/custom-routes.ts
@@ -1,10 +1,11 @@
 import { IncomingMessage, ServerResponse } from 'http';
 import { CustomRouteInitializationError } from '../errors';
+import { ParamsIncomingMessage } from './ParamsIncomingMessage';
 
 export interface CustomRoute {
   path: string;
   method: string | string[];
-  handler: (req: IncomingMessage, res: ServerResponse) => void;
+  handler: (req: ParamsIncomingMessage, res: ServerResponse) => void;
 }
 
 export interface ReceiverRoutes {


### PR DESCRIPTION
###  Summary

Bugfix for #1325 

Following the guidance of [ExpressJS](https://expressjs.com/en/guide/routing.html#route-paths) and how they parse the route paths for dynamic parts I added [path-to-regexp](https://www.npmjs.com/package/path-to-regexp) and used path-to-regexp to match routes and insert path params to `req.params` similar to ExpressJS

This is my first contribution and I tried my best to add the appropriate unit tests to validate my edits, but am open to feedback.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).