### PR TITLE
Fix #1758 Correct type definitions for `OptionGroups` and `*Options` types

### DIFF
--- a/src/types/options/index.ts
+++ b/src/types/options/index.ts
@@ -146,7 +146,7 @@ type OptionsAckFn<Source extends OptionsSource> = Source extends 'block_suggesti
   ? AckFn<XOR<BlockOptions, OptionGroups<BlockOptions>>>
   : Source extends 'interactive_message'
     ? AckFn<XOR<MessageOptions, OptionGroups<MessageOptions>>>
-    : AckFn<XOR<DialogOptions, OptionGroups<DialogOptions>>>;
+    : AckFn<XOR<DialogOptions, DialogOptionGroups<DialogOptions>>>;
 
 export interface BlockOptions {
   options: Option[];
@@ -155,11 +155,19 @@ export interface MessageOptions {
   options: Option[];
 }
 export interface DialogOptions {
-  options: Option[];
+  options: {
+    label: string;
+    value: string;
+  }[];
 }
 export interface OptionGroups<Options> {
   option_groups: ({
-    label: PlainTextElement;
+    label: PlainTextElement
+  } & Options)[];
+}
+export interface DialogOptionGroups<Options> {
+  option_groups: ({
+    label: string;
   } & Options)[];
 }
 

--- a/src/types/options/index.ts
+++ b/src/types/options/index.ts
@@ -1,4 +1,4 @@
-import { Option } from '@slack/types';
+import { Option, PlainTextElement } from '@slack/types';
 import { StringIndexed, XOR } from '../helpers';
 import { AckFn } from '../utilities';
 import { ViewOutput } from '../view/index';
@@ -152,20 +152,14 @@ export interface BlockOptions {
   options: Option[];
 }
 export interface MessageOptions {
-  options: {
-    text: string;
-    value: string;
-  }[];
+  options: Option[];
 }
 export interface DialogOptions {
-  options: {
-    label: string;
-    value: string;
-  }[];
+  options: Option[];
 }
 export interface OptionGroups<Options> {
   option_groups: ({
-    label: string;
+    label: PlainTextElement;
   } & Options)[];
 }
 

--- a/types-tests/options.test-d.ts
+++ b/types-tests/options.test-d.ts
@@ -1,4 +1,4 @@
-import { expectType, expectError } from 'tsd';
+import { expectType } from 'tsd';
 import {
   App,
   SlackOptions,
@@ -50,7 +50,7 @@ expectType<void>(
   app.options<'interactive_message'>({ callback_id: 'a' }, async ({ options, ack }) => {
     expectType<InteractiveMessageSuggestion>(options);
     // https://github.com/slackapi/bolt-js/issues/720
-    expectError(ack({ options: blockSuggestionOptions }));
+    ack({ options: blockSuggestionOptions });
     await Promise.resolve(options);
   }),
 );
@@ -60,7 +60,7 @@ expectType<void>(
     // FIXME: the type should be OptionsRequest<'interactive_message'>
     expectType<SlackOptions>(options);
     // https://github.com/slackapi/bolt-js/issues/720
-    expectError(ack({ options: blockSuggestionOptions }));
+    ack({ options: blockSuggestionOptions });
     await Promise.resolve(options);
   }),
 );
@@ -70,7 +70,7 @@ expectType<void>(
   app.options<'dialog_suggestion'>({ callback_id: 'a' }, async ({ options, ack }) => {
     expectType<DialogSuggestion>(options);
     // https://github.com/slackapi/bolt-js/issues/720
-    expectError(ack({ options: blockSuggestionOptions }));
+    ack({ options: blockSuggestionOptions });
     await Promise.resolve(options);
   }),
 );
@@ -103,7 +103,7 @@ expectType<void>(
       }
 
       await ack({
-        "options": options
+        "options": options 
       });
     } else {
       await ack();

--- a/types-tests/options.test-d.ts
+++ b/types-tests/options.test-d.ts
@@ -1,4 +1,4 @@
-import { expectType } from 'tsd';
+import { expectType, expectError } from 'tsd';
 import {
   App,
   SlackOptions,
@@ -60,7 +60,7 @@ expectType<void>(
     // FIXME: the type should be OptionsRequest<'interactive_message'>
     expectType<SlackOptions>(options);
     // https://github.com/slackapi/bolt-js/issues/720
-    ack({ options: blockSuggestionOptions });
+    expectError(ack({ options: blockSuggestionOptions }));
     await Promise.resolve(options);
   }),
 );
@@ -70,7 +70,7 @@ expectType<void>(
   app.options<'dialog_suggestion'>({ callback_id: 'a' }, async ({ options, ack }) => {
     expectType<DialogSuggestion>(options);
     // https://github.com/slackapi/bolt-js/issues/720
-    ack({ options: blockSuggestionOptions });
+    expectError(ack({ options: blockSuggestionOptions }));
     await Promise.resolve(options);
   }),
 );

--- a/types-tests/options.test-d.ts
+++ b/types-tests/options.test-d.ts
@@ -103,7 +103,7 @@ expectType<void>(
       }
 
       await ack({
-        "options": options 
+        "options": options
       });
     } else {
       await ack();

--- a/types-tests/options.test-d.ts
+++ b/types-tests/options.test-d.ts
@@ -49,7 +49,6 @@ expectType<void>(
 expectType<void>(
   app.options<'interactive_message'>({ callback_id: 'a' }, async ({ options, ack }) => {
     expectType<InteractiveMessageSuggestion>(options);
-    // https://github.com/slackapi/bolt-js/issues/720
     ack({ options: blockSuggestionOptions });
     await Promise.resolve(options);
   }),


### PR DESCRIPTION
###  Summary

This PR corrects the type definitions for the `OptionGroups` type by enforcing a `PlainTextElement` type for the `label` of `OptionGroups` and `Option[]` for `options` of `MessageOptions`. Fixes #1758 by removing compilation errors when using these types.

### Reviewers

With the changes in this PR, verify that the code sample in the linked issue compiles without error.

To inspect this change in Slack, create the following command (and add it to a testing app) to test the noted sample. Verify text appears after typing "plain_text" in the selector.

<details>
<summary>Example app.options typing</summary>

To properly compile the related example, `ack` must be typed with a `block_suggestion` or `interactive_message` middleware type like so:

```diff
- app.options('someCallbackId', async ({ ack }) => {
+ app.options('someCallbackId', async ({ ack }: SlackOptionsMiddlewareArgs<'block_suggestion'>) => {
```

</details>

<details>
<summary>Example command code</summary>

```typescript
app.command('/ticket', async ({ ack, body, client }: SlackCommandMiddlewareArgs  & { client: WebClient }) => {
  await ack();

  try {
    const result = await client.views.open({
      trigger_id: body.trigger_id,
      view: {
        type: 'modal',
        callback_id: 'someCallbackId',
        title: {
          type: 'plain_text',
          text: 'Selections'
        },
        blocks: [
          {
            type: "section",
            block_id: "selector",
            text: {
              type: "mrkdwn",
              text: "Do you like plain text?"
            },
            accessory: {
              action_id: "option_callback",
              type: "external_select",
              placeholder: {
                type: "plain_text",
                text: "plain_text?"
              }
            }
          },
        ],
      }
    });
    console.log("yay!");
  }
  catch (error) {
    console.error("oops:", error);
  }
});
```

</details>


### Notes

- One test no longer expects an error for `interactive_message`! There is another `app.options` test still expecting an error when using a `{ type: 'interactive_message' }` parameter, and I am unsure if this is correct behavior. The `FIXME` comment above suggests that the type should be `OptionsRequest<'interactive_message'>`, however this is a deprecated type.
- The generic `Option` is used for `*Options` instead of a `PlainTextOption` or `MrkdwnOption` since the type of `Option` might differ by `OptionGroups` – see the differences in the `text` section for [the `Options` object](https://api.slack.com/reference/block-kit/composition-objects#option).
- Filtering of options in these groupings seems to not work... I am curious if there is already an issue to track this? 🤔 

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).