### PR TITLE
Add documentation for dynamic route parameters in custom routes

### DIFF
--- a/docs/_advanced/custom_routes.md
+++ b/docs/_advanced/custom_routes.md
@@ -28,7 +28,7 @@ const app = new App({
       method: ['GET'],
       handler: (req, res) => {
         res.writeHead(200);
-        res.end('Health check information displayed here!');
+        res.end('Things are going just fine!');
       },
     },
     {

--- a/docs/_advanced/custom_routes.md
+++ b/docs/_advanced/custom_routes.md
@@ -31,6 +31,14 @@ const app = new App({
         res.end('Health check information displayed here!');
       },
     },
+    {
+      path: '/music/:genre',
+      method: ['GET'],
+      handler: (req, res) => {
+        res.writeHead(200);
+        res.end(`Oh? ${req.params.genre}? That slaps!`);
+      },
+    },
   ],
 });
 

--- a/docs/_advanced/custom_routes.md
+++ b/docs/_advanced/custom_routes.md
@@ -10,7 +10,7 @@ As of `v3.7.0`, custom HTTP routes can be easily added by passing in an array of
 
 Each `CustomRoute` object must contain three properties: `path`, `method`, and `handler`. `method`, which corresponds to the HTTP verb, can be either a string or an array of strings.
 
-Since `v3.13.0`, the default built-in receivers (`HTTPReceiver` and `SocketModeReceiver`) support dynamic route parameters like [Express.js does](https://expressjs.com/en/guide/routing.html#route-parameters). With this, you can capture positional values in the URL for use in your route's handler via `req.params`.
+Since `v3.12.3`, the default built-in receivers (`HTTPReceiver` and `SocketModeReceiver`) support dynamic route parameters like [Express.js does](https://expressjs.com/en/guide/routing.html#route-parameters). With this, you can capture positional values in the URL for use in your route's handler via `req.params`.
 
 To determine what port the custom HTTP route will be available on locally, you can specify an `installerOptions.port` property in the `App` constructor. Otherwise, it will default to port `3000`.
 </div>

--- a/docs/_advanced/custom_routes.md
+++ b/docs/_advanced/custom_routes.md
@@ -40,6 +40,9 @@ const app = new App({
       },
     },
   ],
+  installerOptions: {
+    port: 3001,
+  },
 });
 
 (async () => {

--- a/docs/_advanced/custom_routes.md
+++ b/docs/_advanced/custom_routes.md
@@ -10,7 +10,7 @@ As of `v3.7.0`, custom HTTP routes can be easily added by passing in an array of
 
 Each `CustomRoute` object must contain three properties: `path`, `method`, and `handler`. `method`, which corresponds to the HTTP verb, can be either a string or an array of strings.
 
-Since `v3.13.0`, dynamic [route parameters](https://expressjs.com/en/guide/routing.html#route-parameters) can capture positional values in the URL for use in your route's handler via `req.params`.
+Since `v3.13.0`, the default built-in receivers (`HTTPReceiver` and `SocketModeReceiver`) support dynamic route parameters like [Express.js does](https://expressjs.com/en/guide/routing.html#route-parameters). With this, you can capture positional values in the URL for use in your route's handler via `req.params`.
 
 To determine what port the custom HTTP route will be available on locally, you can specify an `installerOptions.port` property in the `App` constructor. Otherwise, it will default to port `3000`.
 </div>

--- a/docs/_advanced/custom_routes.md
+++ b/docs/_advanced/custom_routes.md
@@ -10,7 +10,7 @@ As of `v3.7.0`, custom HTTP routes can be easily added by passing in an array of
 
 Each `CustomRoute` object must contain three properties: `path`, `method`, and `handler`. `method`, which corresponds to the HTTP verb, can be either a string or an array of strings.
 
-Since `v3.12.3`, the default built-in receivers (`HTTPReceiver` and `SocketModeReceiver`) support dynamic route parameters like [Express.js does](https://expressjs.com/en/guide/routing.html#route-parameters). With this, you can capture positional values in the URL for use in your route's handler via `req.params`.
+Since `v3.13.0`, the default built-in receivers (`HTTPReceiver` and `SocketModeReceiver`) support dynamic route parameters like [Express.js does](https://expressjs.com/en/guide/routing.html#route-parameters). With this, you can capture positional values in the URL for use in your route's handler via `req.params`.
 
 To determine what port the custom HTTP route will be available on locally, you can specify an `installerOptions.port` property in the `App` constructor. Otherwise, it will default to port `3000`.
 </div>

--- a/docs/_advanced/custom_routes.md
+++ b/docs/_advanced/custom_routes.md
@@ -10,6 +10,8 @@ As of `v3.7.0`, custom HTTP routes can be easily added by passing in an array of
 
 Each `CustomRoute` object must contain three properties: `path`, `method`, and `handler`. `method`, which corresponds to the HTTP verb, can be either a string or an array of strings.
 
+Since `v3.13.0`, dynamic [route parameters](https://expressjs.com/en/guide/routing.html#route-parameters) can capture positional values in the URL for use in your route's handler via `req.params`.
+
 To determine what port the custom HTTP route will be available on locally, you can specify an `installerOptions.port` property in the `App` constructor. Otherwise, it will default to port `3000`.
 </div>
 

--- a/docs/_advanced/ja_custom_routes.md
+++ b/docs/_advanced/ja_custom_routes.md
@@ -10,7 +10,7 @@ order: 10
 
 各 `CustomRoute` オブジェクトには `path` 、 `method`、 `handler` という三つのプロパティが含まれていなければなりません。 HTTP メソッドに相当する `method` は文字列または文字列の配列です。
 
-`v3.12.3` からデフォルトの組み込みレシーバーである `HTTPReceiver` と `SocketModeReceiver` が、[Express.js](https://expressjs.com/en/guide/routing.html#route-parameters) が提供するものと同様な動的なルートパラメーターをサポートするようになりました。これによって URL 内に含まれる値を `req.params` の値として利用できるようになりました。
+`v3.13.0` からデフォルトの組み込みレシーバーである `HTTPReceiver` と `SocketModeReceiver` が、[Express.js](https://expressjs.com/en/guide/routing.html#route-parameters) が提供するものと同様な動的なルートパラメーターをサポートするようになりました。これによって URL 内に含まれる値を `req.params` の値として利用できるようになりました。
 
 カスタムの HTTP ルートがローカル環境でどのポートからアクセスできるかを指定するために `App` コンストラクターに `installerOptions.port` というプロパティを渡すことができます。指定しない場合は、デフォルトの `3000` ポートとなります。
 </div>

--- a/docs/_advanced/ja_custom_routes.md
+++ b/docs/_advanced/ja_custom_routes.md
@@ -10,6 +10,8 @@ order: 10
 
 各 `CustomRoute` オブジェクトには `path` 、 `method`、 `handler` という三つのプロパティが含まれていなければなりません。 HTTP メソッドに相当する `method` は文字列または文字列の配列です。
 
+`v3.13.0` からデフォルトの組み込みレシーバーである `HTTPReceiver` と `SocketModeReceiver` が、[Express.js](https://expressjs.com/en/guide/routing.html#route-parameters) が提供するものと同様な動的なルートパラメーターをサポートするようになりました。これによって URL 内に含まれる値を `req.params` の値として利用できるようになりました。
+
 カスタムの HTTP ルートがローカル環境でどのポートからアクセスできるかを指定するために `App` コンストラクターに `installerOptions.port` というプロパティを渡すことができます。指定しない場合は、デフォルトの `3000` ポートとなります。
 </div>
 

--- a/docs/_advanced/ja_custom_routes.md
+++ b/docs/_advanced/ja_custom_routes.md
@@ -28,10 +28,21 @@ const app = new App({
       method: ['GET'],
       handler: (req, res) => {
         res.writeHead(200);
-        res.end('Health check information displayed here!');
+        res.end('Things are going just fine!');
+      },
+    },
+    {
+      path: '/music/:genre',
+      method: ['GET'],
+      handler: (req, res) => {
+        res.writeHead(200);
+        res.end(`Oh? ${req.params.genre}? That slaps!`);
       },
     },
   ],
+  installerOptions: {
+    port: 3001,
+  },
 });
 
 (async () => {

--- a/docs/_advanced/ja_custom_routes.md
+++ b/docs/_advanced/ja_custom_routes.md
@@ -10,7 +10,7 @@ order: 10
 
 各 `CustomRoute` オブジェクトには `path` 、 `method`、 `handler` という三つのプロパティが含まれていなければなりません。 HTTP メソッドに相当する `method` は文字列または文字列の配列です。
 
-`v3.13.0` からデフォルトの組み込みレシーバーである `HTTPReceiver` と `SocketModeReceiver` が、[Express.js](https://expressjs.com/en/guide/routing.html#route-parameters) が提供するものと同様な動的なルートパラメーターをサポートするようになりました。これによって URL 内に含まれる値を `req.params` の値として利用できるようになりました。
+`v3.12.3` からデフォルトの組み込みレシーバーである `HTTPReceiver` と `SocketModeReceiver` が、[Express.js](https://expressjs.com/en/guide/routing.html#route-parameters) が提供するものと同様な動的なルートパラメーターをサポートするようになりました。これによって URL 内に含まれる値を `req.params` の値として利用できるようになりました。
 
 カスタムの HTTP ルートがローカル環境でどのポートからアクセスできるかを指定するために `App` コンストラクターに `installerOptions.port` というプロパティを渡すことができます。指定しない場合は、デフォルトの `3000` ポートとなります。
 </div>


### PR DESCRIPTION
###  Summary

This PR adds supporting documentation to [the "Adding custom HTTP routes" section](https://slack.dev/bolt-js/concepts#custom-routes) for the enhancements made in #1785. The documentation links out to the official Express documentation for more details, and provides a simple example to showcase this feature.

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).