### PR TITLE
Remove legacy tag

### DIFF
--- a/docs/.ruby-version
+++ b/docs/.ruby-version
@@ -1,4 +1,4 @@
-2.7.4
+2.7.6
 
 # This version number should track the Ruby version used in production: https://pages.github.com/versions/.
 # If it is out of date, please update and send a PR with the change.

--- a/docs/_includes/sidebar.html
+++ b/docs/_includes/sidebar.html
@@ -81,16 +81,16 @@
     <a href="{{ site.url | append: site.baseurl | append: localized_base_url }}/concepts#steps">
       <li class="title">
         {{ site.t[page.lang].steps }}
-        <span class="label-legacy">
+        <!--UNCOMMENT AFTER GA <span class="label-legacy">
           {{ site.t[page.lang].legacy }}
-        </span>
+        </span> -->
       </li>
     </a>
     {% assign workflow_steps = site.steps | sort: "order" | where: "lang", page.lang %} {% for step in workflow_steps %}
       {% if step.slug != "steps-overview" %}
       <a href="{{ site.url | append: site.baseurl | append: localized_base_url }}/concepts#{{ step.slug }}">
         {% assign str = step.title %}
-        {% assign a = str | split: ' <span class="label-legacy">' %}
+        <!--UNCOMMENT AFTER GA {% assign a = str | split: ' <span class="label-legacy">' %} -->
         <li>
           {{ a[0] }}
         </li>

--- a/docs/_steps/adding_editing_workflow_step.md
+++ b/docs/_steps/adding_editing_workflow_step.md
@@ -1,5 +1,5 @@
 ---
-title: Adding or editing workflow steps <span class="label-legacy">LEGACY</span>
+title: Adding or editing workflow steps
 lang: en
 slug: adding-editing-steps
 order: 3

--- a/docs/_steps/creating_workflow_step.md
+++ b/docs/_steps/creating_workflow_step.md
@@ -1,5 +1,5 @@
 ---
-title: Creating workflow steps <span class="label-legacy">LEGACY</span>
+title: Creating workflow steps
 lang: en
 slug: creating-steps
 order: 2

--- a/docs/_steps/executing_workflow_steps.md
+++ b/docs/_steps/executing_workflow_steps.md
@@ -1,5 +1,5 @@
 ---
-title: Executing workflow steps <span class="label-legacy">LEGACY</span>
+title: Executing workflow steps
 lang: en
 slug: executing-steps
 order: 5

--- a/docs/_steps/saving_workflow_step.md
+++ b/docs/_steps/saving_workflow_step.md
@@ -1,5 +1,5 @@
 ---
-title: Saving step configurations <span class="label-legacy">LEGACY</span>
+title: Saving step configurations
 lang: en
 slug: saving-steps
 order: 4

--- a/docs/_steps/workflow_steps_overview.md
+++ b/docs/_steps/workflow_steps_overview.md
@@ -1,5 +1,5 @@
 ---
-title: Overview of Workflow Steps for apps <span class="label-legacy">LEGACY</span>
+title: Overview of Workflow Steps for apps
 lang: en
 slug: steps-overview
 order: 1
@@ -7,11 +7,11 @@ order: 1
 
 <div class="section-content">
 
-**⚠️ Workflow Steps from Apps are a legacy feature, not to be confused with workflows that are part of the next-gen beta. They are not interchangeable features. We encourage those who are currently publishing Workflow Steps from apps to join the beta - you can learn more about getting started with it [here](/bolt-js/future/getting-started).** 
+<!--UNCOMMENT AFTER GA **⚠️ Workflow Steps from Apps are a legacy feature, not to be confused with workflows that are part of the next-gen beta. They are not interchangeable features. We encourage those who are currently publishing Workflow Steps from apps to join the beta - you can learn more about getting started with it [here](/bolt-js/future/getting-started).** -->
 
 Workflow Steps from apps allow your app to create and process custom workflow steps that users can add using [Workflow Builder](https://api.slack.com/workflows).
 
-A workflow step is made up of three distinct user events: 
+A workflow step is made up of three distinct user events:
 
 - Adding or editing the step in a Workflow
 - Saving or updating the step's configuration


### PR DESCRIPTION
###  Summary

Temporarily remove the `legacy` tag until GA

Let discuss if this should be put in, from what I understood this feature was considered `legacy` in bolt land

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).