### PR TITLE
Add line numbers to docs

### DIFF
--- a/docs/.markdownlint.yml
+++ b/docs/.markdownlint.yml
@@ -1,0 +1,198 @@
+# Default state for all rules
+default: true
+
+# Path to configuration file to extend
+extends: null
+
+# MD001/heading-increment/header-increment - Heading levels should only increment by one level at a time
+MD001: false
+
+# MD002/first-heading-h1/first-header-h1 - First heading should be a top-level heading
+MD002:
+  # Heading level
+  level: 1
+
+# MD003/heading-style/header-style - Heading style
+MD003:
+  # Heading style
+  style: "consistent"
+
+# MD004/ul-style - Unordered list style
+MD004:
+  # List style
+  style: "consistent"
+
+# MD005/list-indent - Inconsistent indentation for list items at the same level
+MD005: true
+
+# MD006/ul-start-left - Consider starting bulleted lists at the beginning of the line
+MD006: true
+
+# MD007/ul-indent - Unordered list indentation
+MD007: false
+
+# MD009/no-trailing-spaces - Trailing spaces
+MD009:
+  # Spaces for line break
+  br_spaces: 2
+  # Allow spaces for empty lines in list items
+  list_item_empty_lines: false
+  # Include unnecessary breaks
+  strict: false
+
+# MD010/no-hard-tabs - Hard tabs
+MD010:
+  # Include code blocks
+  code_blocks: true
+  # Fenced code languages to ignore
+  ignore_code_languages: []
+  # Number of spaces for each hard tab
+  spaces_per_tab: 1
+
+# MD011/no-reversed-links - Reversed link syntax
+MD011: true
+
+# MD012/no-multiple-blanks - Multiple consecutive blank lines
+MD012:
+  # Consecutive blank lines
+  maximum: 1
+
+# MD013/line-length - Line length
+MD013: false
+
+# MD014/commands-show-output - Dollar signs used before commands without showing output
+MD014: true
+
+# MD018/no-missing-space-atx - No space after hash on atx style heading
+MD018: true
+
+# MD019/no-multiple-space-atx - Multiple spaces after hash on atx style heading
+MD019: true
+
+# MD020/no-missing-space-closed-atx - No space inside hashes on closed atx style heading
+MD020: true
+
+# MD021/no-multiple-space-closed-atx - Multiple spaces inside hashes on closed atx style heading
+MD021: true
+
+# MD022/blanks-around-headings/blanks-around-headers - Headings should be surrounded by blank lines
+MD022: false
+
+# MD023/heading-start-left/header-start-left - Headings must start at the beginning of the line
+MD023: true
+
+# MD024/no-duplicate-heading/no-duplicate-header - Multiple headings with the same content
+MD024: false
+
+# MD025/single-title/single-h1 - Multiple top-level headings in the same document
+MD025: false
+
+# MD026/no-trailing-punctuation - Trailing punctuation in heading
+MD026:
+  # Punctuation characters
+  punctuation: ".,;:!。，；：！"
+
+# MD027/no-multiple-space-blockquote - Multiple spaces after blockquote symbol
+MD027: true
+
+# MD028/no-blanks-blockquote - Blank line inside blockquote
+MD028: true
+
+# MD029/ol-prefix - Ordered list item prefix
+MD029: false
+
+# MD030/list-marker-space - Spaces after list markers
+MD030: false
+
+# MD031/blanks-around-fences - Fenced code blocks should be surrounded by blank lines
+MD031:
+  # Include list items
+  list_items: true
+
+# MD032/blanks-around-lists - Lists should be surrounded by blank lines
+MD032: true
+
+# MD033/no-inline-html - Inline HTML
+MD033: false
+
+# MD034/no-bare-urls - Bare URL used
+MD034: true
+
+# MD035/hr-style - Horizontal rule style
+MD035:
+  # Horizontal rule style
+  style: "consistent"
+
+# MD036/no-emphasis-as-heading/no-emphasis-as-header - Emphasis used instead of a heading
+MD036: false
+  # Punctuation characters
+  # punctuation: ".,;:!?。，；：！？"
+
+# MD037/no-space-in-emphasis - Spaces inside emphasis markers
+MD037: true
+
+# MD038/no-space-in-code - Spaces inside code span elements
+MD038: true
+
+# MD039/no-space-in-links - Spaces inside link text
+MD039: true
+
+# MD040/fenced-code-language - Fenced code blocks should have a language specified
+MD040: false
+
+# MD041/first-line-heading/first-line-h1 - First line in a file should be a top-level heading
+MD041:
+  # Heading level
+  level: 1
+  # RegExp for matching title in front matter
+  front_matter_title: "^\\s*title\\s*[:=]"
+
+# MD042/no-empty-links - No empty links
+MD042: true
+
+# MD043/required-headings/required-headers - Required heading structure
+MD043: false
+
+# MD044/proper-names - Proper names should have the correct capitalization
+MD044:
+  # List of proper names
+  names: []
+  # Include code blocks
+  code_blocks: true
+  # Include HTML elements
+  html_elements: true
+
+# MD045/no-alt-text - Images should have alternate text (alt text)
+MD045: true
+
+# MD046/code-block-style - Code block style
+MD046:
+  # Block style
+  style: "consistent"
+
+# MD047/single-trailing-newline - Files should end with a single newline character
+MD047: true
+
+# MD048/code-fence-style - Code fence style
+MD048:
+  # Code fence style
+  style: "consistent"
+
+# MD049/emphasis-style - Emphasis style should be consistent
+MD049:
+  # Emphasis style should be consistent
+  style: "consistent"
+
+# MD050/strong-style - Strong style should be consistent
+MD050:
+  # Strong style should be consistent
+  style: "consistent"
+
+# MD051/link-fragments - Link fragments should be valid
+MD051: false
+
+# MD052/reference-links-images - Reference links and images should use a label that is defined
+MD052: true
+
+# MD053/link-image-reference-definitions - Link and image reference definitions should be needed
+MD053: true

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -73,6 +73,9 @@ google_tag_manager: GTM-KFZ5MK7
 markdown: kramdown
 kramdown:
   parse_block_html: true
+  syntax_highlighter_opts:
+    block:
+      line_numbers: true
 plugins:
   - jemoji
   - jekyll-redirect-from

--- a/docs/assets/style.css
+++ b/docs/assets/style.css
@@ -300,25 +300,43 @@ span.beta {
 pre {
   background-color: var(--light-grey) !important;
   background-image: none;
-  padding: 2em;
+  padding: 1em 1.5em;
   border: 1px solid var(--soft-grey);
+  margin: 0;
   border-radius: 1em;
 }
 
-code {
-  border-radius: 8px;
-  background-color: var(--light-grey);
-  padding: 2px 7px;
-  border: 1px solid var(--soft-grey);
+/* Code block with column numbers */
+pre.highlight {
+  line-height: 2em;
+  overflow-x: auto;
 }
 
-pre code {
-  font-size: 0.85em !important;
+pre.highlight code span {
+  padding: 0;
+  margin: 0;
+  height: 0;
 }
 
-a code {
-  color: var(--blue);
+pre.highlight code pre {
+  padding: 0;
+  border: 0;
+  font-size: 0.9em;
+  overflow: visible;
 }
+
+table.rouge-table, td.rouge-code, td.rouge-gutter  {
+  padding: 0;
+  border: 0;
+  margin: 0;
+}
+
+td.rouge-gutter {
+  padding-right: 1em;
+  user-select: none;
+  color: var(--dark-grey);
+}
+/* End Code block with column numbers */
 
 .content .section-wrapper .section-content {
   grid-area: body;


### PR DESCRIPTION
###  Summary

This PR introduces line numbers in code block (this is present in the bolt-python docs) 

BEFORE
<img width="1986" alt="Screenshot 2023-04-04 at 3 19 01 PM" src="https://user-images.githubusercontent.com/25348381/229898073-c63797e7-30e6-4a2f-8ed7-d0d259d2f511.png">

AFTER
<img width="1974" alt="Screenshot 2023-04-04 at 3 20 35 PM" src="https://user-images.githubusercontent.com/25348381/229898128-2af07612-171a-416c-a8e5-a5f3e7f72114.png">

I like the line numbers, let me know what you think, this PR is subjective
 

__Also adds a markdown linter config file__

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).