### PR TITLE
Upgrade the OAuth module to the latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   },
   "dependencies": {
     "@slack/logger": "^3.0.0",
-    "@slack/oauth": "^2.6.0",
+    "@slack/oauth": "^2.6.1",
     "@slack/socket-mode": "^1.3.0",
     "@slack/types": "^2.7.0",
     "@slack/web-api": "^6.7.1",

--- a/src/App.ts
+++ b/src/App.ts
@@ -378,7 +378,7 @@ export default class App<AppCustomContext extends StringIndexed = StringIndexed>
         failure: (error, _installOptions, _req, res) => {
           this.logger.debug(error);
           res.writeHead(500, { 'Content-Type': 'text/html' });
-          res.end(`<html><body><h1>OAuth failed!</h1><div>${error}</div></body></html>`);
+          res.end(`<html><body><h1>OAuth failed!</h1><div>${escapeHtml(error.code)}</div></body></html>`);
         },
       };
     }
@@ -1561,6 +1561,17 @@ function buildRespondFn(
 const eventTypesToSkipAuthorize = ['app_uninstalled', 'tokens_revoked'];
 function isEventTypeToSkipAuthorize(eventType: string) {
   return eventTypesToSkipAuthorize.includes(eventType);
+}
+
+function escapeHtml(input: string | undefined | null): string {
+  if (input) {
+    return input.replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#x27;');
+  }
+  return '';
 }
 
 // ----------------------------


### PR DESCRIPTION
###  Summary

This pull request upgrades the OAuth module to the latest (https://github.com/slackapi/node-slack-sdk/pull/1605) and add HTML escape code for the developer mode. Since there is actually no possible way to inject parameters to the web page content generated by bolt-js, we don't need to release a new patch version immediately. This upgrade is just for preventing future issues.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).