### PR TITLE
Fix #1805 Include headers in the request object of custom route handlers

### DIFF
--- a/docs/_advanced/custom_routes.md
+++ b/docs/_advanced/custom_routes.md
@@ -28,7 +28,7 @@ const app = new App({
       method: ['GET'],
       handler: (req, res) => {
         res.writeHead(200);
-        res.end('Things are going just fine!');
+        res.end(`Things are going just fine at ${req.headers.host}!`);
       },
     },
     {

--- a/docs/_advanced/ja_custom_routes.md
+++ b/docs/_advanced/ja_custom_routes.md
@@ -28,7 +28,7 @@ const app = new App({
       method: ['GET'],
       handler: (req, res) => {
         res.writeHead(200);
-        res.end('Things are going just fine!');
+        res.end(`Things are going just fine at ${req.headers.host}!`);
       },
     },
     {

--- a/src/receivers/HTTPReceiver.spec.ts
+++ b/src/receivers/HTTPReceiver.spec.ts
@@ -504,11 +504,13 @@ describe('HTTPReceiver', function () {
 
         fakeReq.method = 'GET';
         receiver.requestListener(fakeReq, fakeRes);
-        assert(customRoutes[0].handler.calledWith({ ...fakeReq, params }, fakeRes));
+        let message = Object.assign(fakeReq, { params });
+        assert(customRoutes[0].handler.calledWith(message, fakeRes));
 
         fakeReq.method = 'POST';
         receiver.requestListener(fakeReq, fakeRes);
-        assert(customRoutes[0].handler.calledWith({ ...fakeReq, params }, fakeRes));
+        message = Object.assign(fakeReq, { params });
+        assert(customRoutes[0].handler.calledWith(message, fakeRes));
 
         fakeReq.method = 'UNHANDLED_METHOD';
         assert.throws(() => receiver.requestListener(fakeReq, fakeRes), HTTPReceiverDeferredRequestError);
@@ -534,11 +536,13 @@ describe('HTTPReceiver', function () {
 
         fakeReq.method = 'GET';
         receiver.requestListener(fakeReq, fakeRes);
-        assert(customRoutes[0].handler.calledWith({ ...fakeReq, params }, fakeRes));
+        let message = Object.assign(fakeReq, { params });
+        assert(customRoutes[0].handler.calledWith(message, fakeRes));
 
         fakeReq.method = 'POST';
         receiver.requestListener(fakeReq, fakeRes);
-        assert(customRoutes[0].handler.calledWith({ ...fakeReq, params }, fakeRes));
+        message = Object.assign(fakeReq, { params });
+        assert(customRoutes[0].handler.calledWith(message, fakeRes));
 
         fakeReq.method = 'UNHANDLED_METHOD';
         assert.throws(() => receiver.requestListener(fakeReq, fakeRes), HTTPReceiverDeferredRequestError);
@@ -564,11 +568,13 @@ describe('HTTPReceiver', function () {
 
         fakeReq.method = 'GET';
         receiver.requestListener(fakeReq, fakeRes);
-        assert(customRoutes[0].handler.calledWith({ ...fakeReq, params }, fakeRes));
+        let message = Object.assign(fakeReq, { params });
+        assert(customRoutes[0].handler.calledWith(message, fakeRes));
 
         fakeReq.method = 'POST';
         receiver.requestListener(fakeReq, fakeRes);
-        assert(customRoutes[0].handler.calledWith({ ...fakeReq, params }, fakeRes));
+        message = Object.assign(fakeReq, { params });
+        assert(customRoutes[0].handler.calledWith(message, fakeRes));
 
         fakeReq.method = 'UNHANDLED_METHOD';
         assert.throws(() => receiver.requestListener(fakeReq, fakeRes), HTTPReceiverDeferredRequestError);
@@ -597,12 +603,14 @@ describe('HTTPReceiver', function () {
 
         fakeReq.method = 'GET';
         receiver.requestListener(fakeReq, fakeRes);
-        assert(customRoutes[0].handler.calledWith({ ...fakeReq, params }, fakeRes));
+        let message = Object.assign(fakeReq, { params });
+        assert(customRoutes[0].handler.calledWith(message, fakeRes));
         assert(customRoutes[1].handler.notCalled);
 
         fakeReq.method = 'POST';
         receiver.requestListener(fakeReq, fakeRes);
-        assert(customRoutes[0].handler.calledWith({ ...fakeReq, params }, fakeRes));
+        message = Object.assign(fakeReq, { params });
+        assert(customRoutes[0].handler.calledWith(message, fakeRes));
 
         fakeReq.method = 'UNHANDLED_METHOD';
         assert.throws(() => receiver.requestListener(fakeReq, fakeRes), HTTPReceiverDeferredRequestError);
@@ -631,12 +639,14 @@ describe('HTTPReceiver', function () {
 
         fakeReq.method = 'GET';
         receiver.requestListener(fakeReq, fakeRes);
-        assert(customRoutes[0].handler.calledWith({ ...fakeReq, params }, fakeRes));
+        let message = Object.assign(fakeReq, { params });
+        assert(customRoutes[0].handler.calledWith(message, fakeRes));
         assert(customRoutes[1].handler.notCalled);
 
         fakeReq.method = 'POST';
         receiver.requestListener(fakeReq, fakeRes);
-        assert(customRoutes[0].handler.calledWith({ ...fakeReq, params }, fakeRes));
+        message = Object.assign(fakeReq, { params });
+        assert(customRoutes[0].handler.calledWith(message, fakeRes));
 
         fakeReq.method = 'UNHANDLED_METHOD';
         assert.throws(() => receiver.requestListener(fakeReq, fakeRes), HTTPReceiverDeferredRequestError);

--- a/src/receivers/HTTPReceiver.spec.ts
+++ b/src/receivers/HTTPReceiver.spec.ts
@@ -504,13 +504,13 @@ describe('HTTPReceiver', function () {
 
         fakeReq.method = 'GET';
         receiver.requestListener(fakeReq, fakeRes);
-        let message = Object.assign(fakeReq, { params });
-        assert(customRoutes[0].handler.calledWith(message, fakeRes));
+        let expectedMessage = Object.assign(fakeReq, { params });
+        assert(customRoutes[0].handler.calledWith(expectedMessage, fakeRes));
 
         fakeReq.method = 'POST';
         receiver.requestListener(fakeReq, fakeRes);
-        message = Object.assign(fakeReq, { params });
-        assert(customRoutes[0].handler.calledWith(message, fakeRes));
+        expectedMessage = Object.assign(fakeReq, { params });
+        assert(customRoutes[0].handler.calledWith(expectedMessage, fakeRes));
 
         fakeReq.method = 'UNHANDLED_METHOD';
         assert.throws(() => receiver.requestListener(fakeReq, fakeRes), HTTPReceiverDeferredRequestError);
@@ -536,13 +536,13 @@ describe('HTTPReceiver', function () {
 
         fakeReq.method = 'GET';
         receiver.requestListener(fakeReq, fakeRes);
-        let message = Object.assign(fakeReq, { params });
-        assert(customRoutes[0].handler.calledWith(message, fakeRes));
+        let expectedMessage = Object.assign(fakeReq, { params });
+        assert(customRoutes[0].handler.calledWith(expectedMessage, fakeRes));
 
         fakeReq.method = 'POST';
         receiver.requestListener(fakeReq, fakeRes);
-        message = Object.assign(fakeReq, { params });
-        assert(customRoutes[0].handler.calledWith(message, fakeRes));
+        expectedMessage = Object.assign(fakeReq, { params });
+        assert(customRoutes[0].handler.calledWith(expectedMessage, fakeRes));
 
         fakeReq.method = 'UNHANDLED_METHOD';
         assert.throws(() => receiver.requestListener(fakeReq, fakeRes), HTTPReceiverDeferredRequestError);
@@ -568,13 +568,13 @@ describe('HTTPReceiver', function () {
 
         fakeReq.method = 'GET';
         receiver.requestListener(fakeReq, fakeRes);
-        let message = Object.assign(fakeReq, { params });
-        assert(customRoutes[0].handler.calledWith(message, fakeRes));
+        let expectedMessage = Object.assign(fakeReq, { params });
+        assert(customRoutes[0].handler.calledWith(expectedMessage, fakeRes));
 
         fakeReq.method = 'POST';
         receiver.requestListener(fakeReq, fakeRes);
-        message = Object.assign(fakeReq, { params });
-        assert(customRoutes[0].handler.calledWith(message, fakeRes));
+        expectedMessage = Object.assign(fakeReq, { params });
+        assert(customRoutes[0].handler.calledWith(expectedMessage, fakeRes));
 
         fakeReq.method = 'UNHANDLED_METHOD';
         assert.throws(() => receiver.requestListener(fakeReq, fakeRes), HTTPReceiverDeferredRequestError);
@@ -603,14 +603,14 @@ describe('HTTPReceiver', function () {
 
         fakeReq.method = 'GET';
         receiver.requestListener(fakeReq, fakeRes);
-        let message = Object.assign(fakeReq, { params });
-        assert(customRoutes[0].handler.calledWith(message, fakeRes));
+        let expectedMessage = Object.assign(fakeReq, { params });
+        assert(customRoutes[0].handler.calledWith(expectedMessage, fakeRes));
         assert(customRoutes[1].handler.notCalled);
 
         fakeReq.method = 'POST';
         receiver.requestListener(fakeReq, fakeRes);
-        message = Object.assign(fakeReq, { params });
-        assert(customRoutes[0].handler.calledWith(message, fakeRes));
+        expectedMessage = Object.assign(fakeReq, { params });
+        assert(customRoutes[0].handler.calledWith(expectedMessage, fakeRes));
 
         fakeReq.method = 'UNHANDLED_METHOD';
         assert.throws(() => receiver.requestListener(fakeReq, fakeRes), HTTPReceiverDeferredRequestError);
@@ -639,14 +639,14 @@ describe('HTTPReceiver', function () {
 
         fakeReq.method = 'GET';
         receiver.requestListener(fakeReq, fakeRes);
-        let message = Object.assign(fakeReq, { params });
-        assert(customRoutes[0].handler.calledWith(message, fakeRes));
+        let expectedMessage = Object.assign(fakeReq, { params });
+        assert(customRoutes[0].handler.calledWith(expectedMessage, fakeRes));
         assert(customRoutes[1].handler.notCalled);
 
         fakeReq.method = 'POST';
         receiver.requestListener(fakeReq, fakeRes);
-        message = Object.assign(fakeReq, { params });
-        assert(customRoutes[0].handler.calledWith(message, fakeRes));
+        expectedMessage = Object.assign(fakeReq, { params });
+        assert(customRoutes[0].handler.calledWith(expectedMessage, fakeRes));
 
         fakeReq.method = 'UNHANDLED_METHOD';
         assert.throws(() => receiver.requestListener(fakeReq, fakeRes), HTTPReceiverDeferredRequestError);

--- a/src/receivers/HTTPReceiver.ts
+++ b/src/receivers/HTTPReceiver.ts
@@ -393,22 +393,15 @@ export default class HTTPReceiver implements Receiver {
     }
 
     // Handle custom routes
-    if (Object.keys(this.routes).length) {
-      // Check if the request matches any of the custom routes
-      let pathMatch : string | boolean = false;
-      let params : ParamsDictionary = {};
-      Object.keys(this.routes).forEach((route) => {
-        if (pathMatch) return;
-        const matchRegex = match(route, { decode: decodeURIComponent });
-        const tempMatch = matchRegex(path);
-        if (tempMatch) {
-          pathMatch = route;
-          params = tempMatch.params as ParamsDictionary;
-        }
-      });
-      const urlMatch = pathMatch && this.routes[pathMatch][method] !== undefined;
-      if (urlMatch && pathMatch) {
-        return this.routes[pathMatch][method]({ ...req, params } as ParamsIncomingMessage, res);
+    const routes = Object.keys(this.routes);
+    for (let i = 0; i < routes.length; i += 1) {
+      const route = routes[i];
+      const matchRegex = match(route, { decode: decodeURIComponent });
+      const pathMatch = matchRegex(path);
+      if (pathMatch && this.routes[route][method] !== undefined) {
+        const params = pathMatch.params as ParamsDictionary;
+        const message: ParamsIncomingMessage = Object.assign(req, { params });
+        return this.routes[route][method](message, res);
       }
     }
 

--- a/src/receivers/SocketModeReceiver.spec.ts
+++ b/src/receivers/SocketModeReceiver.spec.ts
@@ -454,11 +454,13 @@ describe('SocketModeReceiver', function () {
 
         fakeReq.method = 'GET';
         await this.listener(fakeReq, fakeRes);
-        assert(customRoutes[0].handler.calledWith({ ...fakeReq, params }, fakeRes));
+        let message = Object.assign(fakeReq, { params });
+        assert(customRoutes[0].handler.calledWith(message, fakeRes));
 
         fakeReq.method = 'POST';
         await this.listener(fakeReq, fakeRes);
-        assert(customRoutes[0].handler.calledWith({ ...fakeReq, params }, fakeRes));
+        message = Object.assign(fakeReq, { params });
+        assert(customRoutes[0].handler.calledWith(message, fakeRes));
 
         fakeReq.method = 'UNHANDLED_METHOD';
         await this.listener(fakeReq, fakeRes);
@@ -495,11 +497,13 @@ describe('SocketModeReceiver', function () {
 
         fakeReq.method = 'GET';
         await this.listener(fakeReq, fakeRes);
-        assert(customRoutes[0].handler.calledWith({ ...fakeReq, params }, fakeRes));
+        let message = Object.assign(fakeReq, { params });
+        assert(customRoutes[0].handler.calledWith(message, fakeRes));
 
         fakeReq.method = 'POST';
         await this.listener(fakeReq, fakeRes);
-        assert(customRoutes[0].handler.calledWith({ ...fakeReq, params }, fakeRes));
+        message = Object.assign(fakeReq, { params });
+        assert(customRoutes[0].handler.calledWith(message, fakeRes));
 
         fakeReq.method = 'UNHANDLED_METHOD';
         await this.listener(fakeReq, fakeRes);
@@ -536,11 +540,13 @@ describe('SocketModeReceiver', function () {
 
         fakeReq.method = 'GET';
         await this.listener(fakeReq, fakeRes);
-        assert(customRoutes[0].handler.calledWith({ ...fakeReq, params }, fakeRes));
+        let message = Object.assign(fakeReq, { params });
+        assert(customRoutes[0].handler.calledWith(message, fakeRes));
 
         fakeReq.method = 'POST';
         await this.listener(fakeReq, fakeRes);
-        assert(customRoutes[0].handler.calledWith({ ...fakeReq, params }, fakeRes));
+        message = Object.assign(fakeReq, { params });
+        assert(customRoutes[0].handler.calledWith(message, fakeRes));
 
         fakeReq.method = 'UNHANDLED_METHOD';
         await this.listener(fakeReq, fakeRes);
@@ -580,12 +586,14 @@ describe('SocketModeReceiver', function () {
 
         fakeReq.method = 'GET';
         await this.listener(fakeReq, fakeRes);
-        assert(customRoutes[0].handler.calledWith({ ...fakeReq, params }, fakeRes));
+        let message = Object.assign(fakeReq, params);
+        assert(customRoutes[0].handler.calledWith(message, fakeRes));
         assert(customRoutes[1].handler.notCalled);
 
         fakeReq.method = 'POST';
         await this.listener(fakeReq, fakeRes);
-        assert(customRoutes[0].handler.calledWith({ ...fakeReq, params }, fakeRes));
+        message = Object.assign(fakeReq, params);
+        assert(customRoutes[0].handler.calledWith(message, fakeRes));
         assert(customRoutes[1].handler.notCalled);
 
         fakeReq.method = 'UNHANDLED_METHOD';
@@ -626,12 +634,14 @@ describe('SocketModeReceiver', function () {
 
         fakeReq.method = 'GET';
         await this.listener(fakeReq, fakeRes);
-        assert(customRoutes[0].handler.calledWith({ ...fakeReq, params }, fakeRes));
+        let message = Object.assign(fakeReq, params);
+        assert(customRoutes[0].handler.calledWith(message, fakeRes));
         assert(customRoutes[1].handler.notCalled);
 
         fakeReq.method = 'POST';
         await this.listener(fakeReq, fakeRes);
-        assert(customRoutes[0].handler.calledWith({ ...fakeReq, params }, fakeRes));
+        message = Object.assign(fakeReq, params);
+        assert(customRoutes[0].handler.calledWith(message, fakeRes));
 
         fakeReq.method = 'UNHANDLED_METHOD';
         await this.listener(fakeReq, fakeRes);

--- a/src/receivers/SocketModeReceiver.spec.ts
+++ b/src/receivers/SocketModeReceiver.spec.ts
@@ -454,13 +454,13 @@ describe('SocketModeReceiver', function () {
 
         fakeReq.method = 'GET';
         await this.listener(fakeReq, fakeRes);
-        let message = Object.assign(fakeReq, { params });
-        assert(customRoutes[0].handler.calledWith(message, fakeRes));
+        let expectedMessage = Object.assign(fakeReq, { params });
+        assert(customRoutes[0].handler.calledWith(expectedMessage, fakeRes));
 
         fakeReq.method = 'POST';
         await this.listener(fakeReq, fakeRes);
-        message = Object.assign(fakeReq, { params });
-        assert(customRoutes[0].handler.calledWith(message, fakeRes));
+        expectedMessage = Object.assign(fakeReq, { params });
+        assert(customRoutes[0].handler.calledWith(expectedMessage, fakeRes));
 
         fakeReq.method = 'UNHANDLED_METHOD';
         await this.listener(fakeReq, fakeRes);
@@ -497,13 +497,13 @@ describe('SocketModeReceiver', function () {
 
         fakeReq.method = 'GET';
         await this.listener(fakeReq, fakeRes);
-        let message = Object.assign(fakeReq, { params });
-        assert(customRoutes[0].handler.calledWith(message, fakeRes));
+        let expectedMessage = Object.assign(fakeReq, { params });
+        assert(customRoutes[0].handler.calledWith(expectedMessage, fakeRes));
 
         fakeReq.method = 'POST';
         await this.listener(fakeReq, fakeRes);
-        message = Object.assign(fakeReq, { params });
-        assert(customRoutes[0].handler.calledWith(message, fakeRes));
+        expectedMessage = Object.assign(fakeReq, { params });
+        assert(customRoutes[0].handler.calledWith(expectedMessage, fakeRes));
 
         fakeReq.method = 'UNHANDLED_METHOD';
         await this.listener(fakeReq, fakeRes);
@@ -540,13 +540,13 @@ describe('SocketModeReceiver', function () {
 
         fakeReq.method = 'GET';
         await this.listener(fakeReq, fakeRes);
-        let message = Object.assign(fakeReq, { params });
-        assert(customRoutes[0].handler.calledWith(message, fakeRes));
+        let expectedMessage = Object.assign(fakeReq, { params });
+        assert(customRoutes[0].handler.calledWith(expectedMessage, fakeRes));
 
         fakeReq.method = 'POST';
         await this.listener(fakeReq, fakeRes);
-        message = Object.assign(fakeReq, { params });
-        assert(customRoutes[0].handler.calledWith(message, fakeRes));
+        expectedMessage = Object.assign(fakeReq, { params });
+        assert(customRoutes[0].handler.calledWith(expectedMessage, fakeRes));
 
         fakeReq.method = 'UNHANDLED_METHOD';
         await this.listener(fakeReq, fakeRes);
@@ -586,14 +586,14 @@ describe('SocketModeReceiver', function () {
 
         fakeReq.method = 'GET';
         await this.listener(fakeReq, fakeRes);
-        let message = Object.assign(fakeReq, params);
-        assert(customRoutes[0].handler.calledWith(message, fakeRes));
+        let expectedMessage = Object.assign(fakeReq, params);
+        assert(customRoutes[0].handler.calledWith(expectedMessage, fakeRes));
         assert(customRoutes[1].handler.notCalled);
 
         fakeReq.method = 'POST';
         await this.listener(fakeReq, fakeRes);
-        message = Object.assign(fakeReq, params);
-        assert(customRoutes[0].handler.calledWith(message, fakeRes));
+        expectedMessage = Object.assign(fakeReq, params);
+        assert(customRoutes[0].handler.calledWith(expectedMessage, fakeRes));
         assert(customRoutes[1].handler.notCalled);
 
         fakeReq.method = 'UNHANDLED_METHOD';
@@ -634,14 +634,14 @@ describe('SocketModeReceiver', function () {
 
         fakeReq.method = 'GET';
         await this.listener(fakeReq, fakeRes);
-        let message = Object.assign(fakeReq, params);
-        assert(customRoutes[0].handler.calledWith(message, fakeRes));
+        let expectedMessage = Object.assign(fakeReq, params);
+        assert(customRoutes[0].handler.calledWith(expectedMessage, fakeRes));
         assert(customRoutes[1].handler.notCalled);
 
         fakeReq.method = 'POST';
         await this.listener(fakeReq, fakeRes);
-        message = Object.assign(fakeReq, params);
-        assert(customRoutes[0].handler.calledWith(message, fakeRes));
+        expectedMessage = Object.assign(fakeReq, params);
+        assert(customRoutes[0].handler.calledWith(expectedMessage, fakeRes));
 
         fakeReq.method = 'UNHANDLED_METHOD';
         await this.listener(fakeReq, fakeRes);

--- a/src/receivers/SocketModeReceiver.ts
+++ b/src/receivers/SocketModeReceiver.ts
@@ -188,22 +188,17 @@ export default class SocketModeReceiver implements Receiver {
           // NOTE: the domain and scheme are irrelevant here.
           // The URL object is only used to safely obtain the path to match
           const { pathname: path } = new URL(req.url as string, 'http://localhost');
-          let pathMatch : string | boolean = false;
-          let params : ParamsDictionary = {};
-          Object.keys(this.routes).forEach((route) => {
-            if (pathMatch) return;
+          const routes = Object.keys(this.routes);
+          for (let i = 0; i < routes.length; i += 1) {
+            const route = routes[i];
             const matchRegex = match(route, { decode: decodeURIComponent });
-            const tempMatch = matchRegex(path);
-            if (tempMatch) {
-              pathMatch = route;
-              params = tempMatch.params as ParamsDictionary;
+            const pathMatch = matchRegex(path);
+            if (pathMatch && this.routes[route][method] !== undefined) {
+              const params = pathMatch.params as ParamsDictionary;
+              const message: ParamsIncomingMessage = Object.assign(req, { params });
+              this.routes[route][method](message, res);
+              return;
             }
-          });
-
-          const urlMatch = pathMatch && this.routes[pathMatch][method] !== undefined;
-          if (urlMatch && pathMatch) {
-            this.routes[pathMatch][method]({ ...req, params } as ParamsIncomingMessage, res);
-            return;
           }
         }
 


### PR DESCRIPTION
### Summary

The changes in this PR assign `req.headers` to the request object in handlers of custom routes and adds an example to the docs. Fixes #1805.

### Reviewers

With the changes on this branch, verify that request headers are displayed in static and dynamic routes using both Socket Mode and HTTP. You can check this by navigating to these routes with the following code:

* `http://localhost:3000/health`
* `http://localhost:3000/music/jazz`

```typescript
const app = new App({
  token: process.env.SLACK_BOT_TOKEN,
  appToken: process.env.SLACK_APP_TOKEN,
  // signingSecret: process.env.SLACK_SIGNING_SECRET,
  socketMode: true,
  customRoutes: [
    {
      method: "GET",
      path: "/health",
      handler: (req, res) => {
        console.log("req.headers: ", req.headers);
        console.log("req.headers.host: ", req.headers.host);
        console.log("req.params: ", req.params);
        res.writeHead(200);
        res.end(`Things are going just fine at ${req.headers.host}!`);
      }
    },
    {
      method: "GET",
      path: "/music/:genre",
      handler: (req, res) => {
        console.log("req.headers: ", req.headers);
        console.log("req.headers.host: ", req.headers.host);
        res.writeHead(200);
        res.end(`Oh? ${req.params.genre}?`);
      }
    }
  ],
});

(async () => {
  await app.start(3000);
  console.log('⚡️ Bolt app is running!');
})();
```

### Diagnostic notes

For those curious about the changes, some findings are below. This was a neat exploration into [the `Symbol` object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol) and how objects are spread! So...

Access to certain attributes of the `req` object (such as `req.headers`) was lost in the spread operator in the line below:

```typescript
this.routes[pathMatch][method]({ ...req, params } as ParamsIncomingMessage, res);
```

However, similar attributes would appear when logging the `req` object, just in a `Symbol` form, like so:

```typescript
console.log(req);
//   ...
//   [Symbol(kHeaders)]: {
//     host: 'localhost:3000',
//     'sec-fetch-site': 'none',
//     connection: 'keep-alive',
//     'upgrade-insecure-requests': '1',
//     'sec-fetch-mode': 'navigate',
//     accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
//     'user-agent': '...',
//     'accept-language': 'en-US,en;q=0.9',
//     'sec-fetch-dest': 'document',
//     'accept-encoding': 'gzip, deflate'
//   },
//   ...
```

As a result of being represented as symbols, these weren't expanded by the spread operator. From [the MDN docs](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol):

> Symbols are [...] hidden from any mechanisms other code will typically use to access the object.

So this was causing the `{ ...req, params }` object to not include all attributes of `req`!

To include the missing attributes and the `params` object, a call to `Object.assign()` was used instead:

```typescript
const message: ParamsIncomingMessage = Object.assign(req, { params });
this.routes[route][method](message, res);
```

This [`Object.assign()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/assign) method "copies all enumerable own properties", which includes these symbols and no longer requires a type assertion, so the `req.headers` attribute returns!

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).