### PR TITLE
Fix #1819 Add metadata to response_url params

### DIFF
--- a/src/types/utilities.spec.ts
+++ b/src/types/utilities.spec.ts
@@ -12,4 +12,15 @@ describe('RespondArguments', () => {
     };
     assert.exists(args);
   });
+  it('has metadata', () => {
+    const args: RespondArguments = {
+      response_type: 'in_channel',
+      text: 'Hey!',
+      metadata: {
+        event_type: 'test-event',
+        event_payload: { foo: 'bar' },
+      },
+    };
+    assert.exists(args);
+  });
 });

--- a/src/types/utilities.ts
+++ b/src/types/utilities.ts
@@ -9,6 +9,7 @@ type ChatPostMessageArgumentsKnownKeys =
   | 'as_user'
   | 'attachments'
   | 'blocks'
+  | 'metadata'
   | 'icon_emoji'
   | 'icon_url'
   | 'link_names'


### PR DESCRIPTION
###  Summary

This pull request resolves #1819

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).