### PR TITLE
Bump @slack/types version to ^2.8.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@slack/logger": "^3.0.0",
     "@slack/oauth": "^2.6.1",
     "@slack/socket-mode": "^1.3.0",
-    "@slack/types": "^2.7.0",
+    "@slack/types": "^2.8.0",
     "@slack/web-api": "^6.7.1",
     "@types/express": "^4.16.1",
     "@types/node": "20.1.0",


### PR DESCRIPTION
### Summary

This PR bumps the version of `@slack/types` to ^2.8.0 – [the current version](https://github.com/slackapi/node-slack-sdk/blob/main/packages/types/package.json).

### Notes

This bump was done to fix the following build error, however I now cannot replicate this with `@slack/types@2.7.0` so I am unsure of what actually caused this... However, this upgrade seems appropriate regardless 😃 

```sh
src/App.ts:1554:11 - error TS2322: Type 'RespondArguments | { text: string; }' is not assignable to type 'RespondArguments'.
  Type '{ text: string; }' is not assignable to type 'RespondArguments'.
    Property 'metadata' is missing in type '{ text: string; }' but required in type 'Pick<ChatPostMessageArguments, "metadata" | "mrkdwn" | "token" | "thread_ts" | "as_user" | "attachments" | "blocks" | "link_names
" | "parse" | "icon_emoji" | ... 4 more ... | "unfurl_media">'.

1554     const normalizedArgs: RespondArguments = typeof message === 'string' ? { text: message } : message;
               ~~~~~~~~~~~~~~


Found 1 error in src/App.ts:1554
```

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).