### PR TITLE
Simplify reaction_added/removed event's item type

### DIFF
--- a/src/types/events/base-events.ts
+++ b/src/types/events/base-events.ts
@@ -651,6 +651,7 @@ export interface ReactionMessageItem {
   ts: string;
 }
 
+// This type is deprecated.
 export interface ReactionFileItem {
   type: 'file';
   channel: string;
@@ -671,7 +672,7 @@ export interface ReactionAddedEvent {
   user: string;
   reaction: string;
   item_user: string;
-  item: ReactionMessageItem | ReactionFileItem | ReactionFileCommentItem;
+  item: ReactionMessageItem;
   event_ts: string;
 }
 
@@ -680,7 +681,7 @@ export interface ReactionRemovedEvent {
   user: string;
   reaction: string;
   item_user: string;
-  item: ReactionMessageItem | ReactionFileItem | ReactionFileCommentItem;
+  item: ReactionMessageItem;
   event_ts: string;
 }
 

--- a/src/types/events/base-events.ts
+++ b/src/types/events/base-events.ts
@@ -651,7 +651,9 @@ export interface ReactionMessageItem {
   ts: string;
 }
 
-// This type is deprecated.
+/**
+ * @deprecated Slack applications no longer receive reaction events for files and file comments.
+ */
 export interface ReactionFileItem {
   type: 'file';
   channel: string;


### PR DESCRIPTION
###  Summary

This pull request improves TypeScript developer experience by updating "item" property type in reaction_added/removed event data types. WIth this change, developers can safely access `event.item.channel` in TS code. More importantly, they can use `say()` utlitity in listeners. Currently, `say()` can be resolved as `never` in TS as `event.item.channel` can be absent for file/file comment items while it never happens. Slack apps no longer receive reaction events for files and file comments. So, this change is safe enough to apply in a patch release.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).