### PR TITLE
Fix #1512 Remove say from SlackShortcutMiddlewareArgs for GlobalSho…

### DIFF
--- a/src/types/shortcuts/index.ts
+++ b/src/types/shortcuts/index.ts
@@ -20,7 +20,7 @@ export interface SlackShortcutMiddlewareArgs<Shortcut extends SlackShortcut = Sl
   payload: Shortcut;
   shortcut: this['payload'];
   body: this['payload'];
-  say: SayFn;
+  say: Shortcut extends MessageShortcut ? SayFn : undefined;
   respond: RespondFn;
   ack: AckFn<void>;
 }

--- a/types-tests/shortcut.test-d.ts
+++ b/types-tests/shortcut.test-d.ts
@@ -31,7 +31,7 @@ expectType<void>(app.shortcut<MessageShortcut>({}, async ({ shortcut, say }) => 
   await Promise.resolve(shortcut);
 }));
 
-// If shortcut is parameterized with GlobalShortcut, say argument in callback should be type never
+// If shortcut is parameterized with GlobalShortcut, say argument in callback should be type undefined
 expectType<void>(app.shortcut<GlobalShortcut>({}, async ({ shortcut, say }) => {
   expectType<undefined>(say);
   await Promise.resolve(shortcut);

--- a/types-tests/shortcut.test-d.ts
+++ b/types-tests/shortcut.test-d.ts
@@ -1,5 +1,5 @@
 import { expectError, expectType } from 'tsd';
-import { App, MessageShortcut } from '../';
+import { App, GlobalShortcut, MessageShortcut, SayFn } from '../';
 
 const app = new App({ token: 'TOKEN', signingSecret: 'Signing Secret' });
 
@@ -17,5 +17,22 @@ expectType<void>(app.shortcut({ type: 'message_action' }, async ({ shortcut }) =
 // If shortcut is parameterized with MessageShortcut, shortcut argument in callback should be type MessageShortcut
 expectType<void>(app.shortcut<MessageShortcut>({}, async ({ shortcut }) => {
   expectType<MessageShortcut>(shortcut);
+  await Promise.resolve(shortcut);
+}));
+
+expectType<void>(app.shortcut({}, async ({ shortcut, say }) => {
+  expectType<SayFn | undefined>(say);
+  await Promise.resolve(shortcut);
+}));
+
+// If shortcut is parameterized with MessageShortcut, say argument in callback should be type SayFn
+expectType<void>(app.shortcut<MessageShortcut>({}, async ({ shortcut, say }) => {
+  expectType<SayFn>(say);
+  await Promise.resolve(shortcut);
+}));
+
+// If shortcut is parameterized with GlobalShortcut, say argument in callback should be type never
+expectType<void>(app.shortcut<GlobalShortcut>({}, async ({ shortcut, say }) => {
+  expectType<undefined>(say);
   await Promise.resolve(shortcut);
 }));


### PR DESCRIPTION
###  Summary

This pull request resolves #1512 by removing `say` from the `SlackShortcutMiddlewareArgs` type for GlobalShortcuts. Global shortcuts are not associated with a conversation, so global shortcut listeners are not passed a `say` function.

### Details

Global shortcuts are not [associated with a conversation](https://github.com/mlauter/bolt-js/blob/fix-1512/src/helpers.ts#L84-L88) (the payloads do not have a channel id), so [no say function is set in listenerArgs](https://github.com/mlauter/bolt-js/blob/ac69a361675db50672444aa77f1b2140f8e456a3/src/App.ts#L1017-L1020) for them.

Message shortcuts are [associated with a conversation](https://github.com/mlauter/bolt-js/blob/fix-1512/src/helpers.ts#L89-L95), so listeners do receive the `say` function.

This change uses a conditional type to set the type of `say` to `SayFn` for a message shortcut's `SlackShortcutMiddlewareArgs` but `undefined` otherwise.

### Testing

- Automated tests are passing. 
- I've added two new type tests for this change. I'm a new contributor though, and I was unsure looking at the test suite whether there are other tests you'd like to see added.
- I set up a dummy slack app and linked my working copy of the bolt-js repo to confirm that the types work as expected:

```typescript
// No type errors
app.shortcut<MessageShortcut>(
  'shortcut_echo',
  async ({ ack, payload, say }) => {
    ack();
    say(payload.message);
    console.log(payload);
  },
);

// Type error
app.shortcut<GlobalShortcut>('wave', async ({ ack, payload, say }) => {
  ack();
  say('hi'); // Cannot invoke an object which is possibly 'undefined'.ts(2722) (parameter) say: undefined
  console.log(payload);
});

// Type error -- caller must verify that say exists
app.shortcut('wave', async ({ ack, payload, say }) => {
  ack();
  say('hi'); // Cannot invoke an object which is possibly 'undefined'.ts(2722) (parameter) say: SayFn | undefined
  console.log(payload);
});
```

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).