### PR TITLE
Expose user ID in context

### DIFF
--- a/src/App.ts
+++ b/src/App.ts
@@ -132,6 +132,7 @@ export interface AuthorizeResult {
   userToken?: string; // used by `say` (overridden by botToken)
   botId?: string; // required for `ignoreSelf` global middleware
   botUserId?: string; // optional but allows `ignoreSelf` global middleware be more filter more than just message events
+  userId?: string;
   teamId?: string;
   enterpriseId?: string;
   // TODO: for better type safety, we may want to revisit this
@@ -901,6 +902,11 @@ export default class App<AppCustomContext extends StringIndexed = StringIndexed>
           },
         });
       }
+    }
+
+    // Try to set userId from AuthorizeResult before using one from source
+    if (authorizeResult.userId === undefined && source.userId !== undefined) {
+      authorizeResult.userId = source.userId;
     }
 
     // Try to set teamId from AuthorizeResult before using one from source

--- a/src/types/middleware.ts
+++ b/src/types/middleware.ts
@@ -57,6 +57,10 @@ export interface Context extends StringIndexed {
    */
   botUserId?: string;
   /**
+   * User ID.
+   */
+  userId?: string;
+  /**
    * Workspace ID.
    */
   teamId?: string;


### PR DESCRIPTION
###  Summary

Getting the user ID is as important as getting the team ID. Since every Slack action is mostly performed by a user, and we already have [logic to extract the user ID from the event's body](https://github.com/slackapi/bolt-js/blob/main/src/App.ts#L1466), we can expose it on the `context` object like we expose the team ID.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).