### PR TITLE
Ack incoming event when unauthorized to prevent unack error

### DIFF
--- a/src/App.ts
+++ b/src/App.ts
@@ -890,6 +890,7 @@ export default class App<AppCustomContext extends StringIndexed = StringIndexed>
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const e = error as any;
         this.logger.warn('Authorization of incoming event did not succeed. No listeners will be called.');
+        await ack();
         e.code = ErrorCode.AuthorizationError;
         // disabling due to https://github.com/typescript-eslint/typescript-eslint/issues/1277
         // eslint-disable-next-line consistent-return


### PR DESCRIPTION
###  Summary

Currently, when an event is unAuthorized it does not ack, which causes an upstream error.

```
[WARN]  bolt-app Authorization of incoming event did not succeed. No listeners will be called.
[ERROR]   An incoming event was not acknowledged within 3 seconds. Ensure that the ack() argument is called in a listener.
```


### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).