### PR TITLE
Add missing user object member to type BlockAction

### DIFF
--- a/src/types/actions/block-action.ts
+++ b/src/types/actions/block-action.ts
@@ -219,6 +219,7 @@ export interface BlockAction<ElementAction extends BasicElementAction = BlockEle
   user: {
     id: string;
     name: string;
+    username: string;
     team_id?: string; // undocumented
   };
   channel?: {


### PR DESCRIPTION
###  Summary

Adds missing string type member to `user` object in `BlockAction` type. Fixes (issue 1909)[https://github.com/slackapi/bolt-js/issues/1909]

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).