### PR TITLE
Add missing null unions for plain text and static select block action…

### DIFF
--- a/src/types/actions/block-action.ts
+++ b/src/types/actions/block-action.ts
@@ -55,7 +55,7 @@ export interface StaticSelectAction extends BasicElementAction<'static_select'> 
   selected_option: {
     text: PlainTextElement;
     value: string;
-  };
+  } | null;
   initial_option?: Option;
   placeholder?: PlainTextElement;
   confirm?: Confirmation;
@@ -199,7 +199,7 @@ export interface CheckboxesAction extends BasicElementAction<'checkboxes'> {
  *  An action from a plain_text_input element (must use dispatch_action: true)
  */
 export interface PlainTextInputAction extends BasicElementAction<'plain_text_input'> {
-  value: string;
+  value: string | null;
 }
 
 /**


### PR DESCRIPTION
… types

###  Summary

Add the missing type definitions to fix Issue 1914 https://github.com/slackapi/bolt-js/issues/1914

### Requirements (place an `x` in each `[ ]`)

* [X] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [X] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).