### PR TITLE
Socket mode using node v20

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@slack/oauth": "^2.6.1",
     "@slack/socket-mode": "^1.3.2",
     "@slack/types": "^2.8.0",
-    "@slack/web-api": "^6.9.0",
+    "@slack/web-api": "^6.7.1",
     "@types/express": "^4.16.1",
     "@types/promise.allsettled": "^1.0.3",
     "@types/tsscmp": "^1.0.0",


### PR DESCRIPTION
###  Summary

This PR aims to solve #1917

In Node v19.5.0: A successful `websocket.send` returns a `null` value, instead of `undefined`, since this project supports Node v20 this use case must be handled properly.

Luckily https://github.com/slackapi/node-slack-sdk/issues/1546 in the SocketModeClient resolves this issue, bumping `@slack/socket-mode: ^1.3.0` to `^1.3.2` should fix the issue

#### testing
1. follow the `README` instructions and install the [bolt-js-starter-template](https://github.com/slack-samples/bolt-js-starter-template)
2. Clone this repo and switch to the `socket-mode-using-node-v20` branch
3. Make sure you are using Node v19.5.0 or higher
4. In your `bolt-js-starter-template` project
    a. run `npm uninstall @slack/bolt`
    b. run `npm install /path/to/your/clone/bolt-js`
6. run `npm start`
7. In slack, execute the `/sample-command` of the template app

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).