### PR TITLE
Upload code coverage reports using the Codecov GitHub Action

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -30,6 +30,7 @@ jobs:
     - run: npm run build
     - run: npm test
     - name: Upload coverage to Codecov
+      if: matrix.node-version == '20.x'
       uses: codecov/codecov-action@v3
       with:
         directory: coverage

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -29,4 +29,3 @@ jobs:
       run: ./node_modules/.bin/eslint -v
     - run: npm run build
     - run: npm test
-    - run: npm run coverage

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -29,3 +29,9 @@ jobs:
       run: ./node_modules/.bin/eslint -v
     - run: npm run build
     - run: npm test
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v3
+      with:
+        directory: coverage
+        fail_ci_if_error: true
+        verbose: true

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "mocha": "TS_NODE_PROJECT=tsconfig.json nyc mocha --config .mocharc.json \"src/**/*.spec.ts\"",
     "test": "npm run lint && npm run mocha && npm run test:types",
     "test:types": "tsd",
-    "coverage": "codecov",
     "watch": "npx nodemon --watch 'src' --ext 'ts' --exec npm run build"
   },
   "repository": "slackapi/bolt",
@@ -65,7 +64,6 @@
     "@typescript-eslint/eslint-plugin": "^4.4.1",
     "@typescript-eslint/parser": "^4.4.0",
     "chai": "^4.2.0",
-    "codecov": "^3.2.0",
     "eslint": "^7.26.0",
     "eslint-config-airbnb-base": "^14.2.1",
     "eslint-config-airbnb-typescript": "^12.3.1",


### PR DESCRIPTION
###  Summary

This PR replaces [the `codecov` package](https://www.npmjs.com/package/codecov), which has been deprecated, with [the Codecov GitHub Action](https://github.com/marketplace/actions/codecov) to hopefully report the uploaded coverage statuses.

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).