### PR TITLE
Update ci-build.yml - add codecov upload token

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -33,6 +33,7 @@ jobs:
       if: matrix.node-version == '20.x'
       uses: codecov/codecov-action@v3
       with:
+        token: ${{ secrets.CODECOV_TOKEN }}
         directory: coverage
         fail_ci_if_error: true
         verbose: true


### PR DESCRIPTION
Adds repository upload token to git action

###  Summary
Public repositories shouldn't technically require a token to upload to codecov. However, we are seeing failing this PR for example [here](https://github.com/slackapi/bolt-js/actions/runs/6224559668/job/16894925980?pr=1951). Per recommendation [here](https://community.codecov.com/t/upload-issues-unable-to-locate-build-via-github-actions-api/3954), adding an explicit token to see whether that makes the situation better. 

Describe the goal of this PR. Mention any related Issue numbers.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).