### PR TITLE
Add rich_text_input block payload support

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@slack/logger": "^4.0.0",
     "@slack/oauth": "^2.6.1",
     "@slack/socket-mode": "^1.3.2",
-    "@slack/types": "^2.8.0",
+    "@slack/types": "^2.9.0",
     "@slack/web-api": "^6.7.1",
     "@types/express": "^4.16.1",
     "@types/promise.allsettled": "^1.0.3",

--- a/src/types/actions/block-action.ts
+++ b/src/types/actions/block-action.ts
@@ -1,4 +1,4 @@
-import { PlainTextElement, Confirmation, Option } from '@slack/types';
+import { PlainTextElement, Confirmation, Option, RichTextBlock } from '@slack/types';
 import { StringIndexed } from '../helpers';
 import { ViewOutput, ViewStateValue } from '../view';
 
@@ -24,7 +24,8 @@ export type BlockElementAction =
   | TimepickerAction
   | RadioButtonsAction
   | CheckboxesAction
-  | PlainTextInputAction;
+  | PlainTextInputAction
+  | RichTextInputAction;
 
 /**
  * Any action from Slack's interactive elements
@@ -207,10 +208,17 @@ export interface CheckboxesAction extends BasicElementAction<'checkboxes'> {
 }
 
 /**
- *  An action from a plain_text_input element (must use dispatch_action: true)
+ * An action from a plain_text_input element (must use dispatch_action: true)
  */
 export interface PlainTextInputAction extends BasicElementAction<'plain_text_input'> {
   value: string;
+}
+
+/**
+ * An action from a rich_text_input element (must use dispatch_action: true)
+ */
+export interface RichTextInputAction extends BasicElementAction<'rich_text_input'> {
+  rich_text_value: RichTextBlock;
 }
 
 /**

--- a/src/types/view/index.ts
+++ b/src/types/view/index.ts
@@ -1,4 +1,4 @@
-import { Block, KnownBlock, PlainTextElement, View } from '@slack/types';
+import { Block, KnownBlock, PlainTextElement, RichTextBlock, View } from '@slack/types';
 import { AckFn, RespondFn } from '../utilities';
 
 /**
@@ -143,6 +143,7 @@ export interface ViewStateValue {
   selected_channels?: string[];
   selected_users?: string[];
   selected_options?: ViewStateSelectedOption[];
+  rich_text_value?: RichTextBlock;
 }
 
 export interface ViewOutput {


### PR DESCRIPTION
###  Summary

This pull request adds missing changes on bolt-js side for https://github.com/slackapi/node-slack-sdk/pull/1643

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).