### PR TITLE
Allow a custom `SocketModeReceiver` to be used with Socket Mode

### DIFF
--- a/src/App-basic-features.spec.ts
+++ b/src/App-basic-features.spec.ts
@@ -14,6 +14,7 @@ import {
 } from './types';
 import { ConversationStore } from './conversation-store';
 import App from './App';
+import SocketModeReceiver from './receivers/SocketModeReceiver';
 
 // Utility functions
 const noop = () => Promise.resolve(undefined);
@@ -264,7 +265,7 @@ describe('App basic features', () => {
         assert.propertyVal(error, 'code', ErrorCode.AppInitializationError);
       }
     });
-    it('should fail when both socketMode and receiver are specified', async () => {
+    it('should fail when both socketMode and a custom receiver are specified', async () => {
       // Arrange
       const fakeReceiver = new FakeReceiver();
       const MockApp = await importApp();
@@ -277,6 +278,23 @@ describe('App basic features', () => {
         // Assert
         assert.propertyVal(error, 'code', ErrorCode.AppInitializationError);
       }
+    });
+    it('should succeed when both socketMode and SocketModeReceiver are specified', async () => {
+      // Arrange
+      const fakeBotId = 'B_FAKE_BOT_ID';
+      const fakeBotUserId = 'U_FAKE_BOT_USER_ID';
+      const overrides = mergeOverrides(
+        withNoopAppMetadata(),
+        withSuccessfulBotUserFetchingWebClient(fakeBotId, fakeBotUserId),
+      );
+      const MockApp = await importApp(overrides);
+      const socketModeReceiver = new SocketModeReceiver({ appToken: '' });
+
+      // Act
+      const app = new MockApp({ token: '', signingSecret: '', socketMode: true, receiver: socketModeReceiver });
+
+      // Assert
+      assert.instanceOf(app, MockApp);
     });
     it('should initialize MemoryStore conversation store by default', async () => {
       // Arrange

--- a/src/App.ts
+++ b/src/App.ts
@@ -1177,10 +1177,7 @@ export default class App<AppCustomContext extends StringIndexed = StringIndexed>
   ): Receiver {
     if (receiver !== undefined) {
       // Custom receiver supplied
-      if (this.socketMode === true) {
-        // socketMode = true should result in SocketModeReceiver being used as receiver
-        // TODO: Add case for when socketMode = true and receiver = SocketModeReceiver
-        // as this should not result in an error
+      if (this.socketMode === true && !(receiver instanceof SocketModeReceiver)) {
         throw new AppInitializationError('You cannot supply a custom receiver when socketMode is set to true.');
       }
       return receiver;


### PR DESCRIPTION
###  Summary

This PR allows a custom `SocketModeReceiver` to be used with Socket Mode when initializing an app.

### Reviewers

These changes can be verified with the following snippets:

#### Socket Mode receiver

This should now work fine! The custom route at `http://localhost:3000/health` and the message response should both respond with something expected.

```js
/** Socket Mode receiver */
const receiver = new SocketModeReceiver({
    appToken: process.env.SLACK_APP_TOKEN,
    customRoutes: [
    {
      path: '/health',
      method: ['GET'],
      handler: (req, res) => {
        res.writeHead(200);
        res.end(`Things are going just fine at ${req.headers.host}!`);
      },
    },
  ]
});

/** App initialization */
const app = new App({
    token: process.env.SLACK_BOT_TOKEN,
    socketMode: true,
    appToken: process.env.SLACK_APP_TOKEN,
    logLevel: LogLevel.DEBUG,
    receiver
});

app.message('hello', async ({ say }) => {
  await say('hi!');
});

(async () => {
    await app.start(process.env.PORT || 3000);
    console.log("⚡️ Bolt app is running!");
})();
```

#### Express receiver

This will still error with an `AppInitializationError` trying to run the app.

```js
/** Express receiver */
const receiver = new ExpressReceiver({
    signingSecret: process.env.SLACK_SIGNING_SECRET,
});

receiver.router.use((req, res, next) => {
    console.log(`Request time: ${Date.now()}`);
    next();
})

receiver.router.get("/health", (req, res) => {
    res.writeHead(200);
    res.end(`Things are going just fine at ${req.headers.host}!`);
});

/** App initialization */
const app = new App({
    token: process.env.SLACK_BOT_TOKEN,
    socketMode: true,
    appToken: process.env.SLACK_APP_TOKEN,
    logLevel: LogLevel.DEBUG,
    receiver
});

app.message('hello', async ({ say }) => {
  await say('hi!');
});

(async () => {
    await app.start(process.env.PORT || 3000);
    console.log("⚡️ Bolt app is running!");
})();
```

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).