### PR TITLE
Include an example of using middleware with the `ExpressReceiver`

### DIFF
--- a/docs/_advanced/custom_routes.md
+++ b/docs/_advanced/custom_routes.md
@@ -57,7 +57,7 @@ const app = new App({
 </summary>
 
 <div class="secondary-content" markdown="0">
-Adding custom HTTP routes is quite straightforward when using Bolt’s built-in ExpressReceiver. Since `v2.1.0`, `ExpressReceiver` added a `router` property, which exposes the Express [Router](http://expressjs.com/en/4x/api.html#router) on which additional routes can be added.
+Adding custom HTTP routes is quite straightforward when using Bolt’s built-in ExpressReceiver. Since `v2.1.0`, `ExpressReceiver` added a `router` property, which exposes the Express [Router](http://expressjs.com/en/4x/api.html#router) on which additional routes and middleware can be added.
 </div>
 
 ```javascript
@@ -76,6 +76,12 @@ const app = new App({
 app.event('message', async ({ event, client }) => {
   // Do some slack-specific stuff here
   await client.chat.postMessage(...);
+});
+
+// Middleware methods execute on every web request
+receiver.router.use((req, res, next) => {
+  console.log(`Request time: ${Date.now()}`);
+  next();
 });
 
 // Other web requests are methods on receiver.router

--- a/docs/_advanced/ja_custom_routes.md
+++ b/docs/_advanced/ja_custom_routes.md
@@ -78,6 +78,11 @@ app.event('message', async ({ event, client }) => {
   await client.chat.postMessage(...);
 });
 
+receiver.router.use((req, res, next) => {
+  console.log(`Request time: ${Date.now()}`);
+  next();
+});
+
 // それ以外の Web リクエストの処理は receiver.router のメソッドで定義
 receiver.router.post('/secret-page', (req, res) => {
   // ここでは Express のリクエストやレスポンスをそのまま扱う
@@ -86,7 +91,7 @@ receiver.router.post('/secret-page', (req, res) => {
 
 (async () => {
   await app.start();
-  console.log('⚡️ Bolt app started'');
+  console.log('⚡️ Bolt app started');
 })();
 ```
 </details>


### PR DESCRIPTION
### Summary

This PR adds an example of using middleware in web requests with the `ExpressReceiver` to the custom routes documentation.

### Notes

- As always, very open to any suggestions, changes, removals, or additions.
- Any help with the translations would also be very appreciated!

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).