### PR TITLE
Prevent sending response headers if already sent in default error han…

### DIFF
--- a/src/receivers/HTTPModuleFunctions.ts
+++ b/src/receivers/HTTPModuleFunctions.ts
@@ -193,7 +193,8 @@ export class HTTPModuleFunctions {
 
     // Check if the response headers have already been sent
     if (response.headersSent) {
-      logger.error('Headers already sent, cannot send another response');
+      logger.error('An unhandled error occurred after ack() called in a listener');
+      logger.debug(`Error details: ${error}, storedResponse: ${storedResponse}`);
       return false;
     }
 

--- a/src/receivers/HTTPModuleFunctions.ts
+++ b/src/receivers/HTTPModuleFunctions.ts
@@ -190,6 +190,13 @@ export class HTTPModuleFunctions {
     args: ReceiverProcessEventErrorHandlerArgs,
   ): Promise<boolean> {
     const { error, response, logger, storedResponse } = args;
+
+    // Check if the response headers have already been sent
+    if (response.headersSent) {
+      logger.error('Headers already sent, cannot send another response');
+      return false;
+    }
+
     if ('code' in error) {
     // CodedError has code: string
       const errorCode = (error as CodedError).code;


### PR DESCRIPTION
### Summary

This pull request introduces a safeguard in the `defaultProcessEventErrorHandler` to prevent attempts to send HTTP response headers after they have already been transmitted. This situation can occur when `ack()` is invoked before an error is thrown during event processing, leading to potential conflicts in the response handling.

The goal of this PR is to enhance the robustness of the error handling mechanism by ensuring that the server does not encounter `ERR_HTTP_HEADERS_SENT` errors, which can disrupt the normal flow of Slack event processing. By checking the `response.headersSent` flag before setting headers or ending the response, we maintain the integrity of the HTTP transaction and provide a more reliable experience for developers using Bolt.js.

### Example Scenario

Consider a custom event handler that acknowledges an event and then performs an asynchronous operation which fails:


```javascript
app.event('custom_event', async ({ ack, say }) => {
  try {
    await ack();
    // An asynchronous operation that may fail
    await someAsyncOperation();
    await say('Event processed successfully!');
  } catch (error) {
    // Error handling logic that might inadvertently try to re-ack or send a response
    console.error('An error occurred:', error);
    // If the following statement crashes, it will cause a server crash
    // because the headers have already been sent when ack() was called.
    await performCleaning();
  }
});
``` 

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
