### PR TITLE
Close HTTP response on unhandled request timeout

### DIFF
--- a/src/receivers/HTTPModuleFunctions.spec.ts
+++ b/src/receivers/HTTPModuleFunctions.spec.ts
@@ -318,6 +318,7 @@ describe('HTTPModuleFunctions', async () => {
           request,
           response,
         });
+        assert.isTrue(writeHead.calledWith(503));
       });
     });
   });

--- a/src/receivers/HTTPModuleFunctions.ts
+++ b/src/receivers/HTTPModuleFunctions.ts
@@ -219,11 +219,18 @@ export class HTTPModuleFunctions {
   // Developers can customize this behavior by passing unhandledRequestHandler to the constructor
   // Note that this method cannot be an async function to align with the implementation using setTimeout
   public static defaultUnhandledRequestHandler(args: ReceiverUnhandledRequestHandlerArgs): void {
-    const { logger } = args;
+    const { logger, response } = args;
     logger.error(
       'An incoming event was not acknowledged within 3 seconds. ' +
       'Ensure that the ack() argument is called in a listener.',
     );
+
+    // Check if the response has already been sent
+    if (!response.headersSent) {
+      // If not, set the status code and end the response to close the connection
+      response.writeHead(503); // Service Unavailable
+      response.end();
+    }
   }
 }
 


### PR DESCRIPTION
### Summary

This pull request fixes an issue where the `defaultUnhandledRequestHandler` does not close the HTTP response if an incoming event times out without being acknowledged. The current behavior can lead to open connections that consume server resources unnecessarily and may cause confusion for clients awaiting a response.

The proposed change ensures that the server responds with a 503 Service Unavailable status code and ends the response properly, signaling to the client that the event was not processed in time. This update enhances the robustness of the application by preventing potential resource leaks and clarifying the outcome of timed-out events.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
