### PR TITLE
chore(3.17.1): Publish v3.17.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slack/bolt",
-  "version": "3.17.0",
+  "version": "3.17.1",
   "description": "A framework for building Slack apps, fast.",
   "author": "Slack Technologies, LLC",
   "license": "MIT",
@@ -41,10 +41,10 @@
   },
   "dependencies": {
     "@slack/logger": "^4.0.0",
-    "@slack/oauth": "^2.6.1",
-    "@slack/socket-mode": "^1.3.2",
+    "@slack/oauth": "^2.6.2",
+    "@slack/socket-mode": "^1.3.3",
     "@slack/types": "^2.11.0",
-    "@slack/web-api": "^6.11.0",
+    "@slack/web-api": "^6.11.2",
     "@types/express": "^4.16.1",
     "@types/promise.allsettled": "^1.0.3",
     "@types/tsscmp": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "@types/sinon": "^7.0.11",
     "@typescript-eslint/eslint-plugin": "^4.4.1",
     "@typescript-eslint/parser": "^4.4.0",
-    "chai": "^4.3.0",
+    "chai": "~4.3.0",
     "eslint": "^7.26.0",
     "eslint-config-airbnb-base": "^14.2.1",
     "eslint-config-airbnb-typescript": "^12.3.1",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "@types/sinon": "^7.0.11",
     "@typescript-eslint/eslint-plugin": "^4.4.1",
     "@typescript-eslint/parser": "^4.4.0",
-    "chai": "^4.2.0",
+    "chai": "^4.3.0",
     "eslint": "^7.26.0",
     "eslint-config-airbnb-base": "^14.2.1",
     "eslint-config-airbnb-typescript": "^12.3.1",


### PR DESCRIPTION
- bump package json version and @slack/web-api @slack/oauth and @slack/socket-mode versions to fix vulnerable depdendencies.

###  Summary

Fixes: https://github.com/slackapi/bolt-js/issues/2028

### Requirements (place an `x` in each `[ ]`)

* [x ] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x ] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).