### PR TITLE
release candidate: pull in socket-mode RC to test stability improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slack/bolt",
-  "version": "3.17.1",
+  "version": "3.17.2-rc.1",
   "description": "A framework for building Slack apps, fast.",
   "author": "Slack Technologies, LLC",
   "license": "MIT",
@@ -42,7 +42,7 @@
   "dependencies": {
     "@slack/logger": "^4.0.0",
     "@slack/oauth": "^2.6.2",
-    "@slack/socket-mode": "^1.3.3",
+    "@slack/socket-mode": "^1.3.5-rc.1",
     "@slack/types": "^2.11.0",
     "@slack/web-api": "^6.11.2",
     "@types/express": "^4.16.1",


### PR DESCRIPTION
Do not merge! Release candidate will be published to npm based on this branch/PR.

Integrates https://github.com/slackapi/node-slack-sdk/pull/1777

An attempt to alleviate the symptoms described in https://github.com/slackapi/node-slack-sdk/issues/1654 and https://github.com/slackapi/node-slack-sdk/issues/1771

Released as https://www.npmjs.com/package/@slack/bolt/v/3.17.2-rc.1