### PR TITLE
Add flag to `AwsLambdaReceiver` to enable/disable signature verification

### DIFF
--- a/src/receivers/AwsLambdaReceiver.spec.ts
+++ b/src/receivers/AwsLambdaReceiver.spec.ts
@@ -542,6 +542,42 @@ describe('AwsLambdaReceiver', function () {
     );
     assert.equal(response.statusCode, 401);
   });
+
+  it('does not perform signature verification if signature verification flag is set to false', async () => {
+    const awsReceiver = new AwsLambdaReceiver({
+      signingSecret: '',
+      signatureVerification: false,
+      logger: noopLogger,
+    });
+    const handler = awsReceiver.toHandler();
+    const awsEvent = {
+      resource: '/slack/events',
+      path: '/slack/events',
+      httpMethod: 'POST',
+      headers: {
+        Accept: 'application/json,*/*',
+        'Content-Type': 'application/json',
+        Host: 'xxx.execute-api.ap-northeast-1.amazonaws.com',
+        'User-Agent': 'Slackbot 1.0 (+https://api.slack.com/robots)',
+        'X-Slack-Request-Timestamp': 'far back dude',
+        'X-Slack-Signature': 'very much invalid',
+      },
+      multiValueHeaders: {},
+      queryStringParameters: null,
+      multiValueQueryStringParameters: null,
+      pathParameters: null,
+      stageVariables: null,
+      requestContext: {},
+      body: urlVerificationBody,
+      isBase64Encoded: false,
+    };
+    const response = await handler(
+      awsEvent,
+      {},
+      (_error, _result) => {},
+    );
+    assert.equal(response.statusCode, 200);
+  });
 });
 
 // Composable overrides

--- a/src/receivers/AwsLambdaReceiver.ts
+++ b/src/receivers/AwsLambdaReceiver.ts
@@ -44,6 +44,9 @@ export interface AwsLambdaReceiverOptions {
    * The Slack Signing secret to be used as an input to signature verification to ensure that requests are coming from
    * Slack.
    *
+   * If the {@link signatureVerification} flag is set to `false`, this can be set to any value as signature verification
+   * using this secret will not be performed.
+   *
    * @see {@link https://api.slack.com/authentication/verifying-requests-from-slack#about} for details about signing secrets
    */
   signingSecret: string;

--- a/src/receivers/AwsLambdaReceiver.ts
+++ b/src/receivers/AwsLambdaReceiver.ts
@@ -40,10 +40,38 @@ export interface AwsResponse {
 export type AwsHandler = (event: AwsEvent, context: any, callback: AwsCallback) => Promise<AwsResponse>;
 
 export interface AwsLambdaReceiverOptions {
-  signingSecret?: string;
+  /**
+   * The Slack Signing secret to be used as an input to signature verification to ensure that requests are coming from
+   * Slack.
+   *
+   * @see {@link https://api.slack.com/authentication/verifying-requests-from-slack#about} for details about signing secrets
+   */
+  signingSecret: string;
+  /**
+   * The {@link Logger} for the receiver
+   *
+   * @default ConsoleLogger
+   */
   logger?: Logger;
+  /**
+   * The {@link LogLevel} to be used for the logger.
+   *
+   * @default LogLevel.INFO
+   */
   logLevel?: LogLevel;
+  /**
+   * Flag that determines whether Bolt should {@link https://api.slack.com/authentication/verifying-requests-from-slack|verify Slack's signature on incoming requests}.
+   *
+   * @default true
+   */
   signatureVerification?: boolean;
+  /**
+   * Optional `function` that can extract custom properties from an incoming receiver event
+   * @param request The API Gateway event {@link AwsEvent}
+   * @returns An object containing custom properties
+   *
+   * @default noop
+   */
   customPropertiesExtractor?: (request: AwsEvent) => StringIndexed;
 }
 
@@ -65,7 +93,7 @@ export default class AwsLambdaReceiver implements Receiver {
   private customPropertiesExtractor: (request: AwsEvent) => StringIndexed;
 
   public constructor({
-    signingSecret = '',
+    signingSecret,
     logger = undefined,
     logLevel = LogLevel.INFO,
     signatureVerification = true,


### PR DESCRIPTION
###  Summary

Resolves https://github.com/slackapi/bolt-js/issues/2104

This adds a flag to the `AwsLambdaReceiver` so that signature verification can be disabled, similar to the `HTTPReceiver`. This allows callers to disable signature verification if they already have something upstream of their Lambda function using the Bolt SDK performing signature verification.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).