### PR TITLE
Add a type predicate for `CodedError`

### DIFF
--- a/src/App-built-in-middleware.spec.ts
+++ b/src/App-built-in-middleware.spec.ts
@@ -3,7 +3,7 @@ import sinon, { SinonSpy } from 'sinon';
 import { assert } from 'chai';
 import rewiremock from 'rewiremock';
 import { Override, mergeOverrides, createFakeLogger, delay } from './test-helpers';
-import { ErrorCode, UnknownError, AuthorizationError, CodedError } from './errors';
+import { ErrorCode, UnknownError, AuthorizationError, CodedError, isCodedError } from './errors';
 import {
   Receiver,
   ReceiverEvent,
@@ -354,9 +354,10 @@ describe('App built-in middleware and mechanism', () => {
       // Assert
       assert(fakeErrorHandler.calledOnce);
       const error = fakeErrorHandler.firstCall.args[0];
-      assert.instanceOf(error, Error);
+      assert.ok(isCodedError(error));
       assert(error.code === ErrorCode.MultipleListenerError);
-      assert.sameMembers(error.originals, errorsToThrow);
+      assert.isArray(error.originals);
+      if (error.originals) assert.sameMembers(error.originals, errorsToThrow);
     });
 
     it('should detect invalid event names', async () => {

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -10,6 +10,11 @@ export interface CodedError extends Error {
   res?: ServerResponse; // HTTPReceiverDeferredRequestError
 }
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function isCodedError(err: any): err is CodedError {
+  return 'code' in err;
+}
+
 export enum ErrorCode {
   AppInitializationError = 'slack_bolt_app_initialization_error',
   AuthorizationError = 'slack_bolt_authorization_error',


### PR DESCRIPTION
...fixing a typescript error that appeared in `main` somehow.

Not sure how this started happening... the [last commit to `main` 2 weeks ago passed CI just fine](https://github.com/slackapi/bolt-js/commit/65413b9bbe85976e78b93adfebccfc44ff884257). However, today `main` started failing the CI.

In any case, the issue seems to be in narrowing the type of errors returned in the error handler. I added a new [type predicate](https://www.typescriptlang.org/docs/handbook/2/narrowing.html#using-type-predicates) to help with the narrowing.