### PR TITLE
docs: fixed duplicative header links in reference

### DIFF
--- a/docs/_tutorials/reference.md
+++ b/docs/_tutorials/reference.md
@@ -13,24 +13,24 @@ This guide is intended to detail the Bolt interface–including listeners and th
 </div>
 
 - [App interface and configuration](#app-interface-and-configuration)
-  - [Listener functions {#listener-functions}](#listener-functions-listener-functions)
-    - [Methods {#methods}](#methods-methods)
+  - [Listener functions](#listener-functions)
+    - [Methods](#methods)
       - [Constraint objects](#constraint-objects)
-    - [Listener function arguments {#listener-function-arguments}](#listener-function-arguments-listener-function-arguments)
+    - [Listener function arguments](#listener-function-arguments)
       - [Body and payload references](#body-and-payload-references)
-    - [Difference from listener middleware {#difference-from-listener-middleware}](#difference-from-listener-middleware-difference-from-listener-middleware)
-  - [Initialization options  {#initialization-options}](#initialization-options--initialization-options)
-    - [Receiver options {#receiver-options}](#receiver-options-receiver-options)
-    - [App options {#app-options}](#app-options-app-options)
-  - [Framework error types {#framework-error-types}](#framework-error-types-framework-error-types)
-    - [Client errors {#client-errors}](#client-errors-client-errors)
+    - [Difference from listener middleware](#difference-from-listener-middleware)
+  - [Initialization options](#initialization-options)
+    - [Receiver options](#receiver-options)
+    - [App options](#app-options)
+  - [Framework error types](#framework-error-types)
+    - [Client errors](#client-errors)
 
 ---
 
-## Listener functions {#listener-functions}
+## Listener functions
 Slack apps typically receive and/or respond to one to many incoming events from Slack. This can be something like listening to an Events API event (like when a link associated with your app is shared) or a user invoking one of your app's shortcuts. For each type of incoming request from Slack, there are distinct methods that you can pass **listener functions** to handle and respond to the event.
 
-### Methods {#methods}
+### Methods
 Below is the current list of methods that accept listener functions. These methods handle specific event types coming from Slack, and typically include an identifying parameter before the listener function. The identifying parameter (included below) narrows the events to specific interactions that your listener function is intended to handle, such as a specific `callback_id`, or a certain substring within a message.
 
 | Method                          | Description |
@@ -54,7 +54,7 @@ There are a collection of constraint objects that some methods have access to. T
 | `app.view(constraints, fn)` | `type`, `callback_id` | `type` must either be `view_closed` or `view_submission`, which determines what specific event your listener function is sent. `callback_id` is the `callback_id` of the view that is sent when your app opens the modal. |
 | `app.options(constraints, fn)` | `block_id`, `action_id`, `callback_id` | Optionally listens for `block_id` and `callback_id` in addition to `action_id`. `callback_id` can only be passed when handling options elements within modals. |
 
-### Listener function arguments {#listener-function-arguments}
+### Listener function arguments
 Listener functions have access to a set of arguments that may change based on the method which the function is passed to. Below is an explanation of the different arguments. The below table details the different arguments and the methods they'll be accessible in.
 
 | Argument  | Description  |
@@ -76,13 +76,13 @@ The structure of the `payload` and `body` is detailed on the API site:
 - `view`: [`view_submission` `body` and `payload`](https://api.slack.com/reference/interaction-payloads/views#view_submission); [`view_closed` `body` and `payload`](https://api.slack.com/reference/interaction-payloads/views#view_closed)
 - `options`: [`body` and `payload`](https://api.slack.com/reference/block-kit/block-elements#external_select)
 
-### Difference from listener middleware {#difference-from-listener-middleware}
+### Difference from listener middleware
 Listener middleware is used to implement logic across many listener functions (though usually not all of them). Listener middleware has the same arguments as the above listener functions, with one distinction: they also have a `next()` function that **must** be called in order to pass the chain of execution. Learn more about listener middleware [in the documentation](/bolt-js/concepts#listener-middleware).
 
-## Initialization options  {#initialization-options}
+## Initialization options
 Bolt includes a collection of initialization options to customize apps. There are two primary kinds of options: Bolt app options and receiver options. The receiver options may change based on the receiver your app uses. The following receiver options are for the default `HTTPReceiver` (so they'll work as long as you aren't using a custom receiver).
 
-### Receiver options {#receiver-options}
+### Receiver options
 `HTTPReceiver` options can be passed into the `App` constructor, just like the Bolt app options. They'll be passed to the `HTTPReceiver` instance upon initialization.
 
 | Option  | Description  |
@@ -103,7 +103,7 @@ Bolt includes a collection of initialization options to customize apps. There ar
 | `signatureVerification` | `boolean` that determines whether Bolt should [verify Slack's signature on incoming requests](https://api.slack.com/authentication/verifying-requests-from-slack). Defaults to `true`. |
 | `customPropertiesExtractor` | Optional `function` that can extract custom properties from an incoming receiver event -- for example, extracting custom headers to propagate to other services. The function receives one argument that will have the type of the event received by your receiver (e.g. an HTTP request or websocket message) and should return an object with string keys containing your custom properties. More details available in the [Customizing a receiver documentation](/bolt-js/concepts#customizing-built-in-receivers). |
 
-### App options {#app-options}
+### App options
 App options are passed into the `App` constructor. When the `receiver` argument is `undefined` the `App` constructor also accepts the [above `Receiver` options](#receiver-options) to initialize either a `HttpReceiver` or a `SocketModeReceiver` depending on the value of the `socketMode` argument.
 
 | Option  | Description  |
@@ -128,7 +128,7 @@ App options are passed into the `App` constructor. When the `receiver` argument 
 
 > Bolt's client is an instance of `WebClient` from the [Node Slack SDK](/node-slack-sdk), so some of that documentation may be helpful as you're developing.
 
-## Framework error types {#framework-error-types}
+## Framework error types
 Bolt includes a set of error types to make errors easier to handle, with more specific contextual information. Below is a non-exhaustive list of error codes you may run into during development:
 
 | Error code                         | Details |
@@ -144,7 +144,7 @@ Bolt includes a set of error types to make errors easier to handle, with more sp
 
 > You can read the code for error definition and construction [in errors.ts](https://github.com/slackapi/bolt-js/blob/main/src/errors.ts).
 
-### Client errors {#client-errors}
+### Client errors
 Bolt imports a `WebClient` to call Slack's APIs. Below is a set of errors you may encounter when making API calls with the client, though you can read more [in the web API documentation](/node-slack-sdk/web-api#handle-errors). When handling client errors, more information can be found in the body within the `data` property.
 
 | Error code                         | Details |


### PR DESCRIPTION
###  Summary

Header tags were generated automatically and added manually, causing tags with both appended that didn't work .

Tested on local 👍 

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).