### PR TITLE
ButtonAction value field not required

### DIFF
--- a/src/types/actions/block-action.ts
+++ b/src/types/actions/block-action.ts
@@ -44,7 +44,7 @@ export interface BasicElementAction<T extends string = string> {
  * An action from a button element
  */
 export interface ButtonAction extends BasicElementAction<'button'> {
-  value: string;
+  value?: string;
   text: PlainTextElement;
   url?: string;
   confirm?: Confirmation;


### PR DESCRIPTION
###  Summary
Fix https://github.com/slackapi/bolt-js/issues/2133

Corrects typing to align with [documentation](https://api.slack.com/reference/block-kit/block-elements#button) and actual API behavior.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).