### PR TITLE
fix(types): return void promises from the express receiver middleware parser

### DIFF
--- a/src/receivers/ExpressReceiver.ts
+++ b/src/receivers/ExpressReceiver.ts
@@ -443,7 +443,7 @@ function buildVerificationBodyParserMiddleware(
   logger: Logger,
   signingSecret: string | (() => PromiseLike<string>),
 ): RequestHandler {
-  return async (req, res, next) => {
+  return async (req, res, next): Promise<void> => {
     let stringBody: string;
     // On some environments like GCP (Google Cloud Platform),
     // req.body can be pre-parsed and be passed as req.rawBody here
@@ -470,15 +470,17 @@ function buildVerificationBodyParserMiddleware(
       if (error) {
         if (error instanceof ReceiverAuthenticityError) {
           logError(logger, 'Request verification failed', error);
-          return res.status(401).send();
+          res.status(401).send();
+          return;
         }
 
         logError(logger, 'Parsing request body failed', error);
-        return res.status(400).send();
+        res.status(400).send();
+        return;
       }
     }
 
-    return next();
+    next();
   };
 }
 
@@ -545,7 +547,7 @@ export function verifySignatureAndParseBody(
 }
 
 export function buildBodyParserMiddleware(logger: Logger): RequestHandler {
-  return async (req, res, next) => {
+  return async (req, res, next): Promise<void> => {
     let stringBody: string;
     // On some environments like GCP (Google Cloud Platform),
     // req.body can be pre-parsed and be passed as req.rawBody here
@@ -561,10 +563,11 @@ export function buildBodyParserMiddleware(logger: Logger): RequestHandler {
     } catch (error) {
       if (error) {
         logError(logger, 'Parsing request body failed', error);
-        return res.status(400).send();
+        res.status(400).send();
+        return;
       }
     }
-    return next();
+    next();
   };
 }
 

--- a/src/receivers/ExpressReceiver.ts
+++ b/src/receivers/ExpressReceiver.ts
@@ -221,9 +221,9 @@ export default class ExpressReceiver implements Receiver {
     if (
       clientId !== undefined &&
       clientSecret !== undefined &&
-       (installerOptions.stateVerification === false || // state store not needed
-         stateSecret !== undefined ||
-          installerOptions.stateStore !== undefined) // user provided state store
+      (installerOptions.stateVerification === false || // state store not needed
+        stateSecret !== undefined ||
+        installerOptions.stateStore !== undefined) // user provided state store
     ) {
       this.installer = new InstallProvider({
         clientId,
@@ -355,8 +355,8 @@ export default class ExpressReceiver implements Receiver {
     serverOptions: ServerOptions | HTTPSServerOptions = {},
   ): Promise<Server | HTTPSServer> {
     let createServerFn:
-    typeof createServer<typeof IncomingMessage, typeof ServerResponse> |
-    typeof createHttpsServer<typeof IncomingMessage, typeof ServerResponse> = createServer;
+      typeof createServer<typeof IncomingMessage, typeof ServerResponse> |
+      typeof createHttpsServer<typeof IncomingMessage, typeof ServerResponse> = createServer;
 
     // Look for HTTPS-specific serverOptions to determine which factory function to use
     if (Object.keys(serverOptions).filter((k) => httpsOptionKeys.includes(k)).length > 0) {


### PR DESCRIPTION
###  Summary

This PR fixes type errors found in #2140 caused by the latest floating version of @types/express:

```
Error: src/receivers/ExpressReceiver.ts(446,3): error TS2322: Type '(req: Request<ParamsDictionary, any, any, ParsedQs, Record<string, any>>, res: Response<any, Record<string, any>, number>, next: NextFunction) => Promise<...>' is not assignable to type 'RequestHandler<ParamsDictionary, any, any, ParsedQs, Record<string, any>>'.
  Type 'Promise<void | Response<any, Record<string, any>, number>>' is not assignable to type 'void | Promise<void>'.
    Type 'Promise<void | Response<any, Record<string, any>, number>>' is not assignable to type 'Promise<void>'.
      Type 'void | Response<any, Record<string, any>, number>' is not assignable to type 'void'.
        Type 'Response<any, Record<string, any>, number>' is not assignable to type 'void'.
Error: src/receivers/ExpressReceiver.ts(548,3): error TS2322: Type '(req: Request<ParamsDictionary, any, any, ParsedQs, Record<string, any>>, res: Response<any, Record<string, any>, number>, next: NextFunction) => Promise<...>' is not assignable to type 'RequestHandler<ParamsDictionary, any, any, ParsedQs, Record<string, any>>'.
  Type 'Promise<void | Response<any, Record<string, any>, number>>' is not assignable to type 'void | Promise<void>'.
```

### Notes

I'm pretty sure sending `res.send()` then returning after is equivalent to what existed before. Just without the typing strangeness.

The final `next()` without a return seems alright too IMO since this function returns as a `Promise<void>`.

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).