### PR TITLE
Change dependencies to peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "bugs": {
     "url": "https://github.com/slackapi/bolt-js/issues"
   },
-  "dependencies": {
+  "peerDependencies": {
     "@slack/logger": "^4.0.0",
     "@slack/oauth": "^2.6.2",
     "@slack/socket-mode": "^1.3.3",


### PR DESCRIPTION
###  Summary

Installation of the package `@slack/bolt` has next file structure:
```node_modules/@slack/bolt/node_modules```
Which brings complexity to the application. Also it makes it impossible to override package versions.

Renaming `dependencies` -> `peerDependencies` helps to get rid of this problem.

Closes https://github.com/slackapi/bolt-js/issues/2146#issue-2370583771

### Requirements (place an `x` in each `[ ]`)

* [X] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [X] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).