### PR TITLE
Add missing Events API payload types

### DIFF
--- a/src/types/events/base-events.ts
+++ b/src/types/events/base-events.ts
@@ -785,7 +785,10 @@ export interface SharedChannelInviteAcceptedEvent {
   accepting_user: SharedChannelUserItem;
   event_ts: string;
 }
-// for backward-compatibility
+// TODO: (breaking change) for backward-compatibility; remove non-Event-suffix type in next major version.
+/**
+ * @deprecated Will be removed in next major version. Use the `SharedChannelInviteAcceptedEvent` interface instead.
+ */
 export type SharedChannelInviteAccepted = SharedChannelInviteAcceptedEvent;
 
 export interface SharedChannelInviteApprovedEvent {
@@ -797,7 +800,10 @@ export interface SharedChannelInviteApprovedEvent {
   approving_user: SharedChannelUserItem;
   event_ts: string;
 }
-// for backward-compatibility
+// TODO: (breaking change) for backward-compatibility; remove non-Event-suffix type in next major version.
+/**
+ * @deprecated Will be removed in next major version. Use the `SharedChannelInviteApprovedEvent` interface instead.
+ */
 export type SharedChannelInviteApproved = SharedChannelInviteApprovedEvent;
 
 export interface SharedChannelInviteDeclinedEvent {
@@ -809,7 +815,10 @@ export interface SharedChannelInviteDeclinedEvent {
   declining_user: SharedChannelUserItem;
   event_ts: string;
 }
-// for backward-compatibility
+// TODO: (breaking change) for backward-compatibility; remove non-Event-suffix type in next major version.
+/**
+ * @deprecated Will be removed in next major version. Use the `SharedChannelInviteDeclinedEvent` interface instead.
+ */
 export type SharedChannelInviteDeclined = SharedChannelInviteDeclinedEvent;
 
 export interface SharedChannelInviteReceivedEvent {
@@ -818,7 +827,10 @@ export interface SharedChannelInviteReceivedEvent {
   channel: SharedChannelItem;
   event_ts: string;
 }
-// for backward-compatibility
+// TODO: (breaking change) for backward-compatibility; remove non-Event-suffix type in next major version.
+/**
+ * @deprecated Will be removed in next major version. Use the `SharedChannelInviteReceivedEvent` interface instead.
+ */
 export type SharedChannelInviteReceived = SharedChannelInviteReceivedEvent;
 
 export interface SharedChannelInviteRequestedEvent {
@@ -903,7 +915,10 @@ export interface SubteamCreatedEvent {
   subteam: Subteam;
   event_ts: string;
 }
-// for backward-compatibility
+// TODO: (breaking change) for backward-compatibility; remove non-Event-suffix type in next major version.
+/**
+ * @deprecated Will be removed in next major version. Use the `SubteamCreatedEvent` interface instead.
+ */
 export type SubteamCreated = SubteamCreatedEvent;
 
 export interface SubteamMembersChangedEvent {
@@ -918,7 +933,10 @@ export interface SubteamMembersChangedEvent {
   removed_users_count?: number;
   event_ts: string;
 }
-// for backward-compatibility
+// TODO: (breaking change) for backward-compatibility; remove non-Event-suffix type in next major version.
+/**
+ * @deprecated Will be removed in next major version. Use the `SubteamMembersChangedEvent` interface instead.
+ */
 export type SubteamMembersChanged = SubteamMembersChangedEvent;
 
 export interface SubteamSelfAddedEvent {

--- a/src/types/events/base-events.ts
+++ b/src/types/events/base-events.ts
@@ -9,6 +9,9 @@ import { MessageEvent as AllMessageEvents, MessageMetadataEvent as AllMessageMet
  */
 export type SlackEvent =
   | AppRequestedEvent
+  | AppInstalledEvent
+  | AppDeletedEvent
+  | AppUninstalledTeamEvent
   | AppHomeOpenedEvent
   | AppMentionEvent
   | AppRateLimitedEvent
@@ -59,14 +62,15 @@ export type SlackEvent =
   | PinRemovedEvent
   | ReactionAddedEvent
   | ReactionRemovedEvent
-  | SharedChannelInviteReceived
-  | SharedChannelInviteAccepted
-  | SharedChannelInviteApproved
-  | SharedChannelInviteDeclined
+  | SharedChannelInviteReceivedEvent
+  | SharedChannelInviteAcceptedEvent
+  | SharedChannelInviteApprovedEvent
+  | SharedChannelInviteDeclinedEvent
+  | SharedChannelInviteRequestedEvent
   | StarAddedEvent
   | StarRemovedEvent
-  | SubteamCreated
-  | SubteamMembersChanged
+  | SubteamCreatedEvent
+  | SubteamMembersChangedEvent
   | SubteamSelfAddedEvent
   | SubteamSelfRemovedEvent
   | SubteamUpdatedEvent
@@ -179,6 +183,38 @@ export interface AppHomeOpenedEvent {
   channel: string;
   tab?: 'home' | 'messages';
   view?: View;
+  event_ts: string;
+}
+
+export interface AppInstalledEvent {
+  type: 'app_installed';
+  app_id: string;
+  app_name: string;
+  app_owner_id: string;
+  user_id: string;
+  team_id: string;
+  team_domain: string;
+  event_ts: string;
+}
+
+export interface AppDeletedEvent {
+  type: 'app_deleted';
+  app_id: string;
+  app_name: string;
+  app_owner_id: string;
+  team_id: string;
+  team_domain: string;
+  event_ts: string;
+}
+
+export interface AppUninstalledTeamEvent {
+  type: 'app_uninstalled_team';
+  app_id: string;
+  app_name: string;
+  app_owner_id: string;
+  team_id: string;
+  team_domain: string;
+  user_id: string;
   event_ts: string;
 }
 
@@ -740,7 +776,7 @@ export interface SharedChannelItem {
   is_im: boolean;
   name: string;
 }
-export interface SharedChannelInviteAccepted {
+export interface SharedChannelInviteAcceptedEvent {
   type: 'shared_channel_invite_accepted';
   approval_required: boolean;
   invite: SharedChannelInviteItem;
@@ -749,8 +785,10 @@ export interface SharedChannelInviteAccepted {
   accepting_user: SharedChannelUserItem;
   event_ts: string;
 }
+// for backward-compatibility
+export type SharedChannelInviteAccepted = SharedChannelInviteAcceptedEvent;
 
-export interface SharedChannelInviteApproved {
+export interface SharedChannelInviteApprovedEvent {
   type: 'shared_channel_invite_approved';
   invite: SharedChannelInviteItem;
   channel: SharedChannelItem;
@@ -759,8 +797,10 @@ export interface SharedChannelInviteApproved {
   approving_user: SharedChannelUserItem;
   event_ts: string;
 }
+// for backward-compatibility
+export type SharedChannelInviteApproved = SharedChannelInviteApprovedEvent;
 
-export interface SharedChannelInviteDeclined {
+export interface SharedChannelInviteDeclinedEvent {
   type: 'shared_channel_invite_declined';
   invite: SharedChannelInviteItem;
   channel: SharedChannelItem;
@@ -769,11 +809,49 @@ export interface SharedChannelInviteDeclined {
   declining_user: SharedChannelUserItem;
   event_ts: string;
 }
+// for backward-compatibility
+export type SharedChannelInviteDeclined = SharedChannelInviteDeclinedEvent;
 
-export interface SharedChannelInviteReceived {
+export interface SharedChannelInviteReceivedEvent {
   type: 'shared_channel_invite_received';
   invite: SharedChannelInviteItem;
   channel: SharedChannelItem;
+  event_ts: string;
+}
+// for backward-compatibility
+export type SharedChannelInviteReceived = SharedChannelInviteReceivedEvent;
+
+export interface SharedChannelInviteRequestedEvent {
+  type: 'shared_channel_invite_requested';
+  actor: {
+    id: string;
+    name: string;
+    is_bot: boolean;
+    team_id: string;
+    timezone: string;
+    real_name: string;
+    display_name: string;
+  };
+  channel_id: string;
+  event_type: 'slack#/events/shared_channel_invite_requested';
+  channel_name: string;
+  channel_type: 'public' | 'private';
+  target_users: [{ email: string; invite_id: string }];
+  teams_in_channel: [
+    {
+      id: string;
+      icon: { image_34: string; image_default: boolean };
+      name: string;
+      domain: string;
+      is_verified: boolean;
+      date_created: number;
+      avatar_base_url: string;
+      requires_sponsorship: boolean;
+    },
+  ];
+  is_external_limited: boolean;
+  channel_date_created: number;
+  channel_message_latest_counted_timestamp: number;
   event_ts: string;
 }
 
@@ -820,13 +898,15 @@ interface Subteam {
   channel_count?: number;
 }
 
-export interface SubteamCreated {
+export interface SubteamCreatedEvent {
   type: 'subteam_created';
   subteam: Subteam;
   event_ts: string;
 }
+// for backward-compatibility
+export type SubteamCreated = SubteamCreatedEvent;
 
-export interface SubteamMembersChanged {
+export interface SubteamMembersChangedEvent {
   type: 'subteam_members_changed';
   subteam_id: string;
   team_id: string;
@@ -838,6 +918,8 @@ export interface SubteamMembersChanged {
   removed_users_count?: number;
   event_ts: string;
 }
+// for backward-compatibility
+export type SubteamMembersChanged = SubteamMembersChangedEvent;
 
 export interface SubteamSelfAddedEvent {
   type: 'subteam_self_added';


### PR DESCRIPTION
###  Summary

This pull request adds a few Events API payloads to the types. See also: https://github.com/slackapi/java-slack-sdk/pull/1332

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).