### PR TITLE
Fix spelling error in docs

### DIFF
--- a/docs/_tutorials/using-typescript.md
+++ b/docs/_tutorials/using-typescript.md
@@ -6,12 +6,14 @@ lang: en
 layout: tutorial
 permalink: /tutorial/using-typescript
 ---
+
 # Using TypeScript
+
 > ⚠️ This guide is a work-in-progress.
 
 See [the sample TypeScript project][1] to see a TypeScript equivalent of the [Getting Started app][2] (and a few other basic examples).
 
-This project is written and built using [TypeScript](https://www.typescriptlang.org/), which means many of the APIs have type information metadata 🎉. If you’re using a code editor like VSCode, Atom, or many others that know how to read that metadata, or if you’re using TypeScript in your own project, you’ll benefit from improved documentation as your write code, early detection of errors, easier refactoring, and more.
+This project is written and built using [TypeScript](https://www.typescriptlang.org/), which means many of the APIs have type information metadata 🎉. If you’re using a code editor like VSCode, Atom, or many others that know how to read that metadata, or if you’re using TypeScript in your own project, you’ll benefit from improved documentation as you write code, early detection of errors, easier refactoring, and more.
 
 This page helps describe how to use this package from a project that also uses TypeScript.
 


### PR DESCRIPTION
###  Summary

There is a minor spelling error on the page describing TypeScript use ("your" instead of "you"). This PR fixes it.
### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).