### PR TITLE
fix: add ts to PinnedMessageItem interface

### DIFF
--- a/src/types/events/base-events.ts
+++ b/src/types/events/base-events.ts
@@ -657,6 +657,7 @@ export interface PinnedMessageItem {
   blocks?: (KnownBlock | Block)[];
   pinned_to?: string[];
   permalink: string;
+  ts: string
 }
 export interface PinnedFileItem {
   id: string;


### PR DESCRIPTION
###  Summary

fixes #2163

message ts is missing in `PinnedMessageItem` interface, however this is sent in the event from the server. This PR adds ts to the interface.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).