### PR TITLE
fix: add missing fields in ChannelCreatedEvent

### DIFF
--- a/src/types/events/base-events.ts
+++ b/src/types/events/base-events.ts
@@ -297,6 +297,7 @@ export interface ChannelArchiveEvent {
 
 export interface ChannelCreatedEvent {
   type: 'channel_created';
+  event_ts: string;
   channel: {
     id: string;
     is_channel: boolean;
@@ -306,6 +307,16 @@ export interface ChannelCreatedEvent {
     creator: string; // user ID
     is_shared: boolean;
     is_org_shared: boolean;
+    context_team_id: string,
+    is_archived: boolean;
+    is_frozen: boolean,
+    is_general: boolean,
+    is_group: boolean,
+    is_private: boolean,
+    is_ext_shared: boolean,
+    is_im: boolean,
+    is_mpim: boolean,
+    is_pending_ext_shared: boolean,
   };
 }
 


### PR DESCRIPTION
###  Summary

fixes #2165

Adds missing fields in `ChannelCreatedEvent` interface.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).