### PR TITLE
Fix broken link in "external select" section

### DIFF
--- a/docs/_basic/ja_listening_responding_options.md
+++ b/docs/_basic/ja_listening_responding_options.md
@@ -10,7 +10,7 @@ order: 14
 
 `external_select` メニューには `action_id` を使用することをおすすめしますが、ダイアログはまだ Block Kit をサポートしていないため、制約オブジェクトを用いて `callback_id` でフィルタリングする必要があります。
 
-オプションのリクエストへの応答には、適切なオプションを指定して `ack()` を実行する必要があります。API サイトに掲載されている[external_select の応答の例](https://api.slack.com/reference/messaging/block-elements#external_select)や[ダイアログ応答の例](https://api.slack.com/dialogs#dynamic_select_elements_external)を参考にしてください。
+オプションのリクエストへの応答には、適切なオプションを指定して `ack()` を実行する必要があります。API サイトに掲載されている[external_select の応答の例](https://api.slack.com/reference/messaging/block-elements#external_select)や[ダイアログ応答の例](https://api.slack.com/legacy/dialogs#dynamic_select_elements_external)を参考にしてください。
 </div>
 
 ```javascript

--- a/docs/_basic/ja_listening_responding_options.md
+++ b/docs/_basic/ja_listening_responding_options.md
@@ -10,7 +10,7 @@ order: 14
 
 `external_select` メニューには `action_id` を使用することをおすすめしますが、ダイアログはまだ Block Kit をサポートしていないため、制約オブジェクトを用いて `callback_id` でフィルタリングする必要があります。
 
-オプションのリクエストへの応答には、適切なオプションを指定して `ack()` を実行する必要があります。API サイトに掲載されている[external_select の応答の例](https://api.slack.com/reference/messaging/block-elements#external-select)や[ダイアログ応答の例](https://api.slack.com/dialogs#dynamic_select_elements_external)を参考にしてください。
+オプションのリクエストへの応答には、適切なオプションを指定して `ack()` を実行する必要があります。API サイトに掲載されている[external_select の応答の例](https://api.slack.com/reference/messaging/block-elements#external_select)や[ダイアログ応答の例](https://api.slack.com/dialogs#dynamic_select_elements_external)を参考にしてください。
 </div>
 
 ```javascript

--- a/docs/_basic/listening_responding_options.md
+++ b/docs/_basic/listening_responding_options.md
@@ -12,7 +12,7 @@ an `action_id` or constraints object is required.
 While it's recommended to use `action_id` for `external_select` menus, dialogs do not yet support Block Kit so you'll have to 
 use the constraints object to filter on a `callback_id`.
 
-To respond to options requests, you'll need to `ack()` with valid options. Both [external select response examples](https://api.slack.com/reference/messaging/block-elements#external_select) and [dialog response examples](https://api.slack.com/dialogs#dynamic_select_elements_external) can be found on our API site.
+To respond to options requests, you'll need to `ack()` with valid options. Both [external select response examples](https://api.slack.com/reference/messaging/block-elements#external_select) and [dialog response examples](https://api.slack.com/legacy/dialogs#dynamic_select_elements_external) can be found on our API site.
 </div>
 
 ```javascript

--- a/docs/_basic/listening_responding_options.md
+++ b/docs/_basic/listening_responding_options.md
@@ -9,7 +9,7 @@ order: 14
 The `options()` method listens for incoming option request payloads from Slack. [Similar to `action()`](#action-listening),
 an `action_id` or constraints object is required.
 
-While it's recommended to use `action_id` for `external_select` menus, dialogs do not yet support Block Kit so you'll have to 
+While it's recommended to use `action_id` for `external_select` menus, dialogs do not yet support Block Kit so you'll have to
 use the constraints object to filter on a `callback_id`.
 
 To respond to options requests, you'll need to `ack()` with valid options. Both [external select response examples](https://api.slack.com/reference/messaging/block-elements#external_select) and [dialog response examples](https://api.slack.com/legacy/dialogs#dynamic_select_elements_external) can be found on our API site.

--- a/docs/_basic/listening_responding_options.md
+++ b/docs/_basic/listening_responding_options.md
@@ -12,7 +12,7 @@ an `action_id` or constraints object is required.
 While it's recommended to use `action_id` for `external_select` menus, dialogs do not yet support Block Kit so you'll have to 
 use the constraints object to filter on a `callback_id`.
 
-To respond to options requests, you'll need to `ack()` with valid options. Both [external select response examples](https://api.slack.com/reference/messaging/block-elements#external-select) and [dialog response examples](https://api.slack.com/dialogs#dynamic_select_elements_external) can be found on our API site.
+To respond to options requests, you'll need to `ack()` with valid options. Both [external select response examples](https://api.slack.com/reference/messaging/block-elements#external_select) and [dialog response examples](https://api.slack.com/dialogs#dynamic_select_elements_external) can be found on our API site.
 </div>
 
 ```javascript


### PR DESCRIPTION
###  Summary

This PR fixes a broken link in the External Select Options page of the documentation.  
Specifically, the link heads to the [Block Kit Reference](https://api.slack.com/reference/block-kit/block-elements) page but incorrectly targets the relevant paragraph using a dash `-` in its id instead of an underscore `_`.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).