### PR TITLE
Docs: remove overzealous redirect

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -58,7 +58,7 @@ const config = {
         redirects: [
           {
             to: '/getting-started',
-            from: ['/tutorial/getting-started','/','/concepts', '/concepts/basic', '/concepts/advanced'],
+            from: ['/tutorial/getting-started','/', '/concepts/basic', '/concepts/advanced'],
           },
         ],
       },


### PR DESCRIPTION
###  Summary

This was meant to redirect a page but is redirecting all of it oof

### Requirements (place an `x` in each `[ ]`)

* [X ] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [X ] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).