### PR TITLE
Docs - fixes README image link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Bolt ![Bolt logo](docs/assets/bolt-logo.svg) for JavaScript
+# Bolt <img src="https://raw.githubusercontent.com/slackapi/bolt-js/main/docs/static/img/bolt.svg" alt="Bolt logo" width="32"/> for JavaScript
 
 [![codecov](https://codecov.io/gh/slackapi/bolt-js/branch/main/graph/badge.svg?token=x4oCgiexvp)](https://codecov.io/gh/slackapi/bolt-js)
 [![Node.js CI](https://github.com/slackapi/bolt-js/actions/workflows/ci-build.yml/badge.svg)](https://github.com/slackapi/bolt-js/actions/workflows/ci-build.yml)


### PR DESCRIPTION
###  Summary

The Repo README uses a `/docs` image. This updates the path that changed when the site switched to using Docusaurus.

It uses the full link for display in [npm](https://www.npmjs.com/package/@slack/bolt). The GitHub README wasn't reading in the .svg size adjustment when given the full link via markdown, so used HTML and sized it manually. (Same size as in .svg file).

Tested it work by previewing the README with the changes in browser

### Requirements 

* [X] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [X] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).