### PR TITLE
Fix Bold Text Rendering Issue

### DIFF
--- a/docs/i18n/ja-jp/docusaurus-plugin-content-docs/current/deployments/aws-lambda.md
+++ b/docs/i18n/ja-jp/docusaurus-plugin-content-docs/current/deployments/aws-lambda.md
@@ -40,7 +40,7 @@ Lambda へのデプロイでは、プログラムから AWS アカウントに�
 
 :::tip 
 
-**すでに IAM ユーザーの作成が完了している場合は、**AWS の公式ガイドに従って [IAM ユーザーのアクセスキーを作成](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-quickstart.html#cli-configure-quickstart-creds)してください。
+**すでに IAM ユーザーの作成が完了している場合は、** AWS の公式ガイドに従って [IAM ユーザーのアクセスキーを作成](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-quickstart.html#cli-configure-quickstart-creds)してください。
 
 :::
 


### PR DESCRIPTION
###  Summary

This PR aims to fix the issue with Markdown bold formatting in the documentation, specifically where bold text was not rendered correctly after punctuation marks. 

Before:
<img width="1015" alt="image" src="https://github.com/user-attachments/assets/0513209d-7d9e-43ff-a2fb-0eb083aea6a3">


### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).