### PR TITLE
Added complete, fail and inputs parameters on `SlackActionMiddlewareArgs`

### DIFF
--- a/src/types/actions/index.ts
+++ b/src/types/actions/index.ts
@@ -3,6 +3,8 @@ import { InteractiveMessage } from './interactive-message';
 import { WorkflowStepEdit } from './workflow-step-edit';
 import { DialogSubmitAction, DialogValidation } from './dialog-action';
 import { SayFn, SayArguments, RespondFn, AckFn } from '../utilities';
+import { FunctionCompleteFn, FunctionFailFn } from '../../CustomFunction';
+import { FunctionInputs } from '../events';
 
 export * from './block-action';
 export * from './interactive-message';
@@ -45,6 +47,9 @@ export interface SlackActionMiddlewareArgs<Action extends SlackAction = SlackAct
   say: Action extends Exclude<SlackAction, DialogSubmitAction | WorkflowStepEdit> ? SayFn : never;
   respond: RespondFn;
   ack: ActionAckFn<Action>;
+  complete?: FunctionCompleteFn;
+  fail?: FunctionFailFn;
+  inputs?: FunctionInputs;
 }
 
 /**


### PR DESCRIPTION
So that `action` handlers have access to `complete`, `fail` and `inputs` parameters.

Tested this branch w/ `bolt-ts-starter-template` linked together, and could get the sample action in the starter template to have IDE autocomplete support for `complete`, `fail` and `inputs`.