### PR TITLE
Remote Functions: Change how webclient options are constructed in CustomFunction

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "build:clean": "shx rm -rf ./dist ./coverage ./.nyc_output",
     "lint": "eslint --fix --ext .ts src",
     "mocha": "TS_NODE_PROJECT=tsconfig.json nyc mocha --config .mocharc.json \"src/**/*.spec.ts\"",
-    "test": "npm run lint && npm run mocha && npm run test:types",
+    "test": "npm run build && npm run lint && npm run mocha && npm run test:types",
     "test:types": "tsd",
     "watch": "npx nodemon --watch 'src' --ext 'ts' --exec npm run build"
   },

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "lint": "eslint --fix --ext .ts src",
     "mocha": "TS_NODE_PROJECT=tsconfig.json nyc mocha --config .mocharc.json \"src/**/*.spec.ts\"",
     "test": "npm run build && npm run lint && npm run mocha && npm run test:types",
+    "test:coverage": "npm run mocha && nyc report --reporter=text",
     "test:types": "tsd",
     "watch": "npx nodemon --watch 'src' --ext 'ts' --exec npm run build"
   },

--- a/src/App.ts
+++ b/src/App.ts
@@ -503,6 +503,10 @@ export default class App<AppCustomContext extends StringIndexed = StringIndexed>
     }
   }
 
+  public get webClientOptions(): WebClientOptions {
+    return this.clientOptions;
+  }
+
   /**
    * Register a new middleware, processed in the order registered.
    *
@@ -530,7 +534,7 @@ export default class App<AppCustomContext extends StringIndexed = StringIndexed>
  * Register CustomFunction middleware
  */
   public function(callbackId: string, ...listeners: CustomFunctionMiddleware): this {
-    const fn = new CustomFunction(callbackId, listeners);
+    const fn = new CustomFunction(callbackId, listeners, this.webClientOptions);
     const m = fn.getMiddleware();
     this.middleware.push(m);
     return this;

--- a/src/CustomFunction.spec.ts
+++ b/src/CustomFunction.spec.ts
@@ -163,9 +163,37 @@ describe('CustomFunction class', () => {
   });
 
   describe('custom function utility functions', () => {
-    it('complete should call functions.completeSuccess');
+    describe('`complete` factory function', () => {
+      it('complete should call functions.completeSuccess', async () => {
+        const client = new WebClient('sometoken');
+        const completeMock = sinon.stub(client.functions, 'completeSuccess').resolves();
+        const complete = CustomFunction.createFunctionComplete({ isEnterpriseInstall: false, functionExecutionId: 'Fx1234' }, client);
+        await complete();
+        assert(completeMock.called, 'client.functions.completeSuccess not called!');
+      });
+      it('should throw if no functionExecutionId present on context', () => {
+        const client = new WebClient('sometoken');
+        assert.throws(() => {
+          CustomFunction.createFunctionComplete({ isEnterpriseInstall: false }, client);
+        });
+      });
+    });
 
-    it('fail should call functions.completeError');
+    describe('`fail` factory function', () => {
+      it('fail should call functions.completeError', async () => {
+        const client = new WebClient('sometoken');
+        const completeMock = sinon.stub(client.functions, 'completeError').resolves();
+        const complete = CustomFunction.createFunctionFail({ isEnterpriseInstall: false, functionExecutionId: 'Fx1234' }, client);
+        await complete({ error: 'boom' });
+        assert(completeMock.called, 'client.functions.completeError not called!');
+      });
+      it('should throw if no functionExecutionId present on context', () => {
+        const client = new WebClient('sometoken');
+        assert.throws(() => {
+          CustomFunction.createFunctionFail({ isEnterpriseInstall: false }, client);
+        });
+      });
+    });
 
     it('inputs should map to function payload inputs', async () => {
       const fakeExecuteArgs = createFakeFunctionExecutedEvent();

--- a/src/CustomFunction.spec.ts
+++ b/src/CustomFunction.spec.ts
@@ -244,12 +244,14 @@ function createFakeFunctionExecutedEvent(callbackId?: string): AllCustomFunction
     fail: () => Promise.resolve({ ok: true }),
     inputs,
     logger: createFakeLogger(),
+    message: undefined,
     next: () => Promise.resolve(),
     payload: {
       function: func,
       inputs: { message: 'test123', recipient: 'U012345' },
       ...base,
     },
+    say: undefined,
   };
 }
 

--- a/src/CustomFunction.spec.ts
+++ b/src/CustomFunction.spec.ts
@@ -2,6 +2,7 @@ import 'mocha';
 import { assert } from 'chai';
 import sinon from 'sinon';
 import rewiremock from 'rewiremock';
+import { WebClient } from '@slack/web-api';
 import {
   CustomFunction,
   SlackCustomFunctionMiddlewareArgs,
@@ -9,8 +10,8 @@ import {
   CustomFunctionMiddleware,
   CustomFunctionExecuteMiddlewareArgs,
 } from './CustomFunction';
-import { Override } from './test-helpers';
-import { AllMiddlewareArgs, AnyMiddlewareArgs, Middleware } from './types';
+import { createFakeLogger, Override } from './test-helpers';
+import { AllMiddlewareArgs, Middleware } from './types';
 import { CustomFunctionInitializationError } from './errors';
 
 async function importCustomFunction(overrides: Override = {}): Promise<typeof import('./CustomFunction')> {
@@ -26,36 +27,35 @@ const MOCK_MIDDLEWARE_MULTIPLE = [MOCK_FN, MOCK_FN_2];
 describe('CustomFunction class', () => {
   describe('constructor', () => {
     it('should accept single function as middleware', async () => {
-      const fn = new CustomFunction('test_callback_id', MOCK_MIDDLEWARE_SINGLE);
+      const fn = new CustomFunction('test_callback_id', MOCK_MIDDLEWARE_SINGLE, {});
       assert.isNotNull(fn);
     });
 
     it('should accept multiple functions as middleware', async () => {
-      const fn = new CustomFunction('test_callback_id', MOCK_MIDDLEWARE_MULTIPLE);
+      const fn = new CustomFunction('test_callback_id', MOCK_MIDDLEWARE_MULTIPLE, {});
       assert.isNotNull(fn);
     });
   });
 
   describe('getMiddleware', () => {
     it('should not call next if a function_executed event', async () => {
-      const fn = new CustomFunction('test_executed_callback_id', MOCK_MIDDLEWARE_SINGLE);
+      const cbId = 'test_executed_callback_id';
+      const fn = new CustomFunction(cbId, MOCK_MIDDLEWARE_SINGLE, {});
       const middleware = fn.getMiddleware();
-      const fakeEditArgs = createFakeFunctionExecutedEvent() as unknown as
-        SlackCustomFunctionMiddlewareArgs & AllMiddlewareArgs;
+      const fakeEditArgs = createFakeFunctionExecutedEvent(cbId);
 
       const fakeNext = sinon.spy();
       fakeEditArgs.next = fakeNext;
 
       await middleware(fakeEditArgs);
 
-      assert(fakeNext.notCalled);
+      assert(fakeNext.notCalled, 'next called!');
     });
 
     it('should call next if valid custom function but mismatched callback_id', async () => {
-      const fn = new CustomFunction('bad_executed_callback_id', MOCK_MIDDLEWARE_SINGLE);
+      const fn = new CustomFunction('bad_executed_callback_id', MOCK_MIDDLEWARE_SINGLE, {});
       const middleware = fn.getMiddleware();
-      const fakeEditArgs = createFakeFunctionExecutedEvent() as unknown as
-        SlackCustomFunctionMiddlewareArgs & AllMiddlewareArgs;
+      const fakeEditArgs = createFakeFunctionExecutedEvent();
 
       const fakeNext = sinon.spy();
       fakeEditArgs.next = fakeNext;
@@ -66,7 +66,7 @@ describe('CustomFunction class', () => {
     });
 
     it('should call next if not a function executed event', async () => {
-      const fn = new CustomFunction('test_view_callback_id', MOCK_MIDDLEWARE_SINGLE);
+      const fn = new CustomFunction('test_view_callback_id', MOCK_MIDDLEWARE_SINGLE, {});
       const middleware = fn.getMiddleware();
       const fakeViewArgs = createFakeViewEvent() as unknown as
         SlackCustomFunctionMiddlewareArgs & AllMiddlewareArgs;
@@ -120,8 +120,7 @@ describe('CustomFunction class', () => {
 
   describe('isFunctionEvent', () => {
     it('should return true if recognized function_executed payload type', async () => {
-      const fakeExecuteArgs = createFakeFunctionExecutedEvent() as unknown as SlackCustomFunctionMiddlewareArgs
-      & AllMiddlewareArgs;
+      const fakeExecuteArgs = createFakeFunctionExecutedEvent();
 
       const { isFunctionEvent } = await importCustomFunction();
       const eventIsFunctionExcuted = isFunctionEvent(fakeExecuteArgs);
@@ -130,7 +129,8 @@ describe('CustomFunction class', () => {
     });
 
     it('should return false if not a function_executed payload type', async () => {
-      const fakeExecutedEvent = createFakeFunctionExecutedEvent() as unknown as AnyMiddlewareArgs;
+      const fakeExecutedEvent = createFakeFunctionExecutedEvent();
+      // @ts-expect-error expected invalid payload type
       fakeExecutedEvent.payload.type = 'invalid_type';
 
       const { isFunctionEvent } = await importCustomFunction();
@@ -142,10 +142,10 @@ describe('CustomFunction class', () => {
 
   describe('enrichFunctionArgs', () => {
     it('should remove next() from all original event args', async () => {
-      const fakeExecutedEvent = createFakeFunctionExecutedEvent() as unknown as AnyMiddlewareArgs;
+      const fakeExecutedEvent = createFakeFunctionExecutedEvent();
 
       const { enrichFunctionArgs } = await importCustomFunction();
-      const executeFunctionArgs = enrichFunctionArgs(fakeExecutedEvent);
+      const executeFunctionArgs = enrichFunctionArgs(fakeExecutedEvent, {});
 
       assert.notExists(executeFunctionArgs.next);
     });
@@ -154,7 +154,7 @@ describe('CustomFunction class', () => {
       const fakeArgs = createFakeFunctionExecutedEvent();
 
       const { enrichFunctionArgs } = await importCustomFunction();
-      const functionArgs = enrichFunctionArgs(fakeArgs);
+      const functionArgs = enrichFunctionArgs(fakeArgs, {});
 
       assert.exists(functionArgs.inputs);
       assert.exists(functionArgs.complete);
@@ -163,19 +163,15 @@ describe('CustomFunction class', () => {
   });
 
   describe('custom function utility functions', () => {
-    it('complete should call functions.completeSuccess', async () => {
-      // TODO
-    });
+    it('complete should call functions.completeSuccess');
 
-    it('fail should call functions.completeError', async () => {
-      // TODO
-    });
+    it('fail should call functions.completeError');
 
     it('inputs should map to function payload inputs', async () => {
-      const fakeExecuteArgs = createFakeFunctionExecutedEvent() as unknown as AllCustomFunctionMiddlewareArgs;
+      const fakeExecuteArgs = createFakeFunctionExecutedEvent();
 
       const { enrichFunctionArgs } = await importCustomFunction();
-      const enrichedArgs = enrichFunctionArgs(fakeExecuteArgs);
+      const enrichedArgs = enrichFunctionArgs(fakeExecuteArgs, {});
 
       assert.isTrue(enrichedArgs.inputs === fakeExecuteArgs.event.inputs);
     });
@@ -183,39 +179,76 @@ describe('CustomFunction class', () => {
 
   describe('processFunctionMiddleware', () => {
     it('should call each callback in user-provided middleware', async () => {
-      const { ...fakeArgs } = createFakeFunctionExecutedEvent() as unknown as AllCustomFunctionMiddlewareArgs;
+      const { ...fakeArgs } = createFakeFunctionExecutedEvent();
       const { processFunctionMiddleware } = await importCustomFunction();
 
       const fn1 = sinon.spy((async ({ next: continuation }) => {
         await continuation();
       }) as Middleware<CustomFunctionExecuteMiddlewareArgs>);
-      const fn2 = sinon.spy(async () => {});
+      const fn2 = sinon.spy(async () => {
+      });
       const fakeMiddleware = [fn1, fn2] as CustomFunctionMiddleware;
 
       await processFunctionMiddleware(fakeArgs, fakeMiddleware);
 
-      assert(fn1.called);
-      assert(fn2.called);
+      assert(fn1.called, 'first user-provided middleware not called!');
+      assert(fn2.called, 'second user-provided middleware not called!');
     });
   });
 });
 
-function createFakeFunctionExecutedEvent() {
+function createFakeFunctionExecutedEvent(callbackId?: string): AllCustomFunctionMiddlewareArgs {
+  const func = {
+    type: 'function',
+    id: 'somefunc',
+    callback_id: callbackId || 'callback_id',
+    title: 'My dope function',
+    input_parameters: [],
+    output_parameters: [],
+    app_id: 'A1234',
+    date_created: 123456,
+    date_deleted: 0,
+    date_updated: 123456,
+  };
+  const base = {
+    bot_access_token: 'xoxb-abcd-1234',
+    event_ts: '123456.789',
+    function_execution_id: 'Fx1234',
+    workflow_execution_id: 'Wf1234',
+    type: 'function_executed',
+  } as const;
+  const inputs = { message: 'test123', recipient: 'U012345' };
+  const event = {
+    function: func,
+    inputs,
+    ...base,
+  } as const;
   return {
-    event: {
-      inputs: { message: 'test123', recipient: 'U012345' },
+    body: {
+      api_app_id: 'A1234',
+      event,
+      event_id: 'E1234',
+      event_time: 123456,
+      team_id: 'T1234',
+      token: 'xoxb-1234',
+      type: 'event_callback',
     },
-    payload: {
-      type: 'function_executed',
-      function: {
-        callback_id: 'test_executed_callback_id',
-      },
-      inputs: { message: 'test123', recipient: 'U012345' },
-      bot_access_token: 'xwfp-123',
-    },
+    client: new WebClient('faketoken'),
+    complete: () => Promise.resolve({ ok: true }),
     context: {
       functionBotAccessToken: 'xwfp-123',
       functionExecutionId: 'test_executed_callback_id',
+      isEnterpriseInstall: false,
+    },
+    event,
+    fail: () => Promise.resolve({ ok: true }),
+    inputs,
+    logger: createFakeLogger(),
+    next: () => Promise.resolve(),
+    payload: {
+      function: func,
+      inputs: { message: 'test123', recipient: 'U012345' },
+      ...base,
     },
   };
 }

--- a/src/CustomFunction.ts
+++ b/src/CustomFunction.ts
@@ -126,15 +126,15 @@ export class CustomFunction {
  */
   public static createFunctionFail(context: Context, client: WebClient): FunctionFailFn {
     const token = selectToken(context);
+    const { functionExecutionId } = context;
+
+    if (!functionExecutionId) {
+      const errorMsg = 'No function_execution_id found';
+      throw new CustomFunctionCompleteFailError(errorMsg);
+    }
 
     return (params: Parameters<FunctionFailFn>[0]) => {
       const { error } = params ?? {};
-      const { functionExecutionId } = context;
-
-      if (!functionExecutionId) {
-        const errorMsg = 'No function_execution_id found';
-        throw new CustomFunctionCompleteFailError(errorMsg);
-      }
 
       return client.functions.completeError({
         token,

--- a/src/middleware/process.ts
+++ b/src/middleware/process.ts
@@ -21,8 +21,8 @@ export default async function processMiddleware(
     if (toCallMiddlewareIndex < middleware.length) {
       lastCalledMiddlewareIndex = toCallMiddlewareIndex;
       return middleware[toCallMiddlewareIndex]({
-        next: () => invokeMiddleware(toCallMiddlewareIndex + 1),
         ...initialArgs,
+        next: () => invokeMiddleware(toCallMiddlewareIndex + 1),
         context,
         client,
         logger,

--- a/src/types/actions/index.ts
+++ b/src/types/actions/index.ts
@@ -44,7 +44,7 @@ export interface SlackActionMiddlewareArgs<Action extends SlackAction = SlackAct
   action: this['payload'];
   body: Action;
   // all action types except dialog submission have a channel context
-  say: Action extends Exclude<SlackAction, DialogSubmitAction | WorkflowStepEdit> ? SayFn : never;
+  say: Action extends Exclude<SlackAction, DialogSubmitAction | WorkflowStepEdit> ? SayFn : undefined;
   respond: RespondFn;
   ack: ActionAckFn<Action>;
   complete?: FunctionCompleteFn;

--- a/src/types/events/index.ts
+++ b/src/types/events/index.ts
@@ -29,11 +29,11 @@ export {
 export interface SlackEventMiddlewareArgs<EventType extends string = string> {
   payload: EventFromType<EventType>;
   event: this['payload'];
-  message: EventType extends 'message' ? this['payload'] : never;
+  message?: EventType extends 'message' ? this['payload'] : undefined;
   body: EnvelopedEvent<this['payload']>;
-  say: WhenEventHasChannelContext<this['payload'], SayFn>;
+  say?: WhenEventHasChannelContext<this['payload'], SayFn>;
   // Add `ack` as undefined for global middleware in TypeScript
-  ack: undefined;
+  ack?: undefined;
 }
 
 /**
@@ -78,8 +78,8 @@ export type KnownEventFromType<T extends string> = Extract<SlackEvent, { type: T
 
 /**
  * Type function which tests whether or not the given `Event` contains a channel ID context for where the event
- * occurred, and returns `Type` when the test passes. Otherwise this returns `never`.
+ * occurred, and returns `Type` when the test passes. Otherwise this returns `undefined`.
  */
 type WhenEventHasChannelContext<Event, Type> = Event extends { channel: string } | { item: { channel: string } }
   ? Type
-  : never;
+  : undefined;

--- a/src/types/events/index.ts
+++ b/src/types/events/index.ts
@@ -29,9 +29,9 @@ export {
 export interface SlackEventMiddlewareArgs<EventType extends string = string> {
   payload: EventFromType<EventType>;
   event: this['payload'];
-  message?: EventType extends 'message' ? this['payload'] : undefined;
+  message: EventType extends 'message' ? this['payload'] : undefined;
   body: EnvelopedEvent<this['payload']>;
-  say?: WhenEventHasChannelContext<this['payload'], SayFn>;
+  say: WhenEventHasChannelContext<this['payload'], SayFn>;
   // Add `ack` as undefined for global middleware in TypeScript
   ack?: undefined;
 }

--- a/src/types/helpers.ts
+++ b/src/types/helpers.ts
@@ -1,9 +1,11 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
+// TODO: breaking change: remove, unnecessary abstraction, just use Record directly
 /**
  * Extend this interface to build a type that is treated as an open set of properties, where each key is a string.
  */
 export type StringIndexed = Record<string, any>;
 
+// TODO: breaking change: no longer used! remove
 /**
  * @deprecated No longer works in TypeScript 4.3
  */

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -14,6 +14,7 @@
     ".eslintrc.js",
     "docs/**/*",
     "examples/**/*",
+    "types-tests/**/*"
   ],
   "exclude": [
     // Overwrite exclude from the base config to clear the value
@@ -21,6 +22,5 @@
     // Contains external module type definitions, which are not subject to this project's style rules
     "types/**/*",
     // Contain intentional type checking issues for the purpose of testing the typechecker's output
-    "types-tests/**/*"
   ]
 }

--- a/types-tests/event.test-d.ts
+++ b/types-tests/event.test-d.ts
@@ -8,7 +8,7 @@ expectType<void>(
     expectType<AppMentionEvent>(event);
     expectNotType<SlackEvent>(event);
     await Promise.resolve(event);
-  })
+  }),
 );
 
 expectType<void>(
@@ -16,7 +16,7 @@ expectType<void>(
     expectType<ReactionAddedEvent>(event);
     expectNotType<SlackEvent>(event);
     await Promise.resolve(event);
-  })
+  }),
 );
 
 expectType<void>(
@@ -24,7 +24,7 @@ expectType<void>(
     expectType<ReactionRemovedEvent>(event);
     expectNotType<SlackEvent>(event);
     await Promise.resolve(event);
-  })
+  }),
 );
 
 expectType<void>(
@@ -32,7 +32,7 @@ expectType<void>(
     expectType<UserHuddleChangedEvent>(event);
     expectNotType<SlackEvent>(event);
     await Promise.resolve(event);
-  })
+  }),
 );
 
 expectType<void>(
@@ -40,7 +40,7 @@ expectType<void>(
     expectType<UserProfileChangedEvent>(event);
     expectNotType<SlackEvent>(event);
     await Promise.resolve(event);
-  })
+  }),
 );
 
 expectType<void>(
@@ -48,15 +48,15 @@ expectType<void>(
     expectType<UserStatusChangedEvent>(event);
     expectNotType<SlackEvent>(event);
     await Promise.resolve(event);
-  })
+  }),
 );
 
 expectType<void>(
   app.event('pin_added', async ({ say, event }) => {
-    expectType<SayFn>(say);
+    expectType<SayFn>(say!);
     expectType<PinAddedEvent>(event);
     await Promise.resolve(event);
-  })
+  }),
 );
 
 expectType<void>(
@@ -64,19 +64,19 @@ expectType<void>(
     expectType<SayFn>(say);
     expectType<PinRemovedEvent>(event);
     await Promise.resolve(event);
-  })
+  }),
 );
 
 expectType<void>(
   app.event('reaction_added', async ({ say, event }) => {
     expectType<SayFn>(say);
     await Promise.resolve(event);
-  })
+  }),
 );
 
 expectType<void>(
   app.event('reaction_removed', async ({ say, event }) => {
     expectType<SayFn>(say);
     await Promise.resolve(event);
-  })
+  }),
 );

--- a/types-tests/event.test-d.ts
+++ b/types-tests/event.test-d.ts
@@ -53,7 +53,7 @@ expectType<void>(
 
 expectType<void>(
   app.event('pin_added', async ({ say, event }) => {
-    expectType<SayFn>(say!);
+    expectType<SayFn>(say);
     expectType<PinAddedEvent>(event);
     await Promise.resolve(event);
   }),


### PR DESCRIPTION
Instead of spreading the existing app-level webclient properties as options when constructing the web client, expose a getter on `App` to retrieve the user-provided original assembled web client options and construct a `CustomFunction` instance that way.

This ensures no funny business using the spread operator (like spreading readonly properties) and ensures the original user-provided web client options are honoured.

Also adds a couple of tests for `CustomFunction` complete/fail factory methods to increase test coverage a tad.

Should address the two remaining "in progress" List items assigned to me for Remote Functions GA.