### PR TITLE
docs: adds google analytics tag

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -42,6 +42,9 @@ const config = {
         theme: {
           customCss: './src/css/custom.css',
         },
+        gtag: {
+          trackingID: 'G-9H1YZW28BG',
+        },
       }),
     ],
   ],


### PR DESCRIPTION
###  Summary

We've got a working GA property now! This adds the tag to the site for those sweet sweet page views.

### Requirements (place an `x` in each `[ ]`)

* [X] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [X] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).