### PR TITLE
chore(deps): set a minimum @slack/web-api@^6.12.1 to address CVE-2024-39338

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,10 +42,10 @@
   },
   "dependencies": {
     "@slack/logger": "^4.0.0",
-    "@slack/oauth": "^2.6.2",
-    "@slack/socket-mode": "^1.3.3",
+    "@slack/oauth": "^2.6.3",
+    "@slack/socket-mode": "^1.3.6",
     "@slack/types": "^2.11.0",
-    "@slack/web-api": "^6.12.0",
+    "@slack/web-api": "^6.12.1",
     "@types/express": "^4.16.1",
     "@types/promise.allsettled": "^1.0.3",
     "@types/tsscmp": "^1.0.0",


### PR DESCRIPTION
### Summary

This PR sets a minimum `@slack/web-api` version to include changes from a [`@slack/web-api@6.12.1` release](https://github.com/slackapi/node-slack-sdk/releases/tag/%40slack%2Fweb-api%406.12.1) that address CVE-2024-39338.

### Notes

Other updated packages include:

- [`@slack/oauth@2.6.3`](https://github.com/slackapi/node-slack-sdk/releases/tag/%40slack%2Foauth%402.6.3)
- [`@slack/socket-mode@1.3.6`](https://github.com/slackapi/node-slack-sdk/releases/tag/%40slack%2Fsocket-mode%401.3.6)

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).