### PR TITLE
docs(fix): direct relative link to docs documentation

### DIFF
--- a/.github/maintainers_guide.md
+++ b/.github/maintainers_guide.md
@@ -21,7 +21,7 @@ A useful trick for debugging inside tests is to use the Chrome Debugging Protoco
 
 ### Managing Documentation
 
-See the [`/docs/README.md`](./docs/README.md) file for documentation instructions. 
+See the [`/docs/README.md`](../docs/README.md) file for documentation instructions.
 
 If you're not touching the `/docs` folder, you don't need to worry about the docs setup affecting your PR.
 


### PR DESCRIPTION
### Summary

This PR fixes a relative link to docs documentation in the maintainer's guide that wants to go back one more directory 🙏

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).