### PR TITLE
fix: pass a no-op `next` function to the last listener middleware

### DIFF
--- a/src/App-built-in-middleware.spec.ts
+++ b/src/App-built-in-middleware.spec.ts
@@ -366,6 +366,19 @@ describe('App built-in middleware and mechanism', () => {
       assert.throws(() => app.event('message.channels', async () => {}), 'Although the document mentions');
       assert.throws(() => app.event(/message\..+/, async () => {}), 'Although the document mentions');
     });
+
+    // https://github.com/slackapi/bolt-js/issues/1457
+    it('should not cause a runtime exception if the last listener middleware invokes next()', async () => new Promise((resolve, reject) => {
+      app.event('app_mention', async ({ next }) => {
+        try {
+          await next();
+          resolve();
+        } catch (e) {
+          reject(e);
+        }
+      });
+      fakeReceiver.sendEvent(createDummyReceiverEvent('app_mention'));
+    }));
   });
 
   describe('middleware and listener arguments', () => {

--- a/src/App.ts
+++ b/src/App.ts
@@ -1143,7 +1143,7 @@ export default class App<AppCustomContext extends StringIndexed = StringIndexed>
             // Copy the array so modifications don't affect the original
             const listenerMiddleware = [...origListenerMiddleware];
 
-            // Don't process the last item in the listenerMiddleware array - it shouldn't get a next fn
+            // Don't process the last item in the listenerMiddleware array - it will be passed a no-op next fn
             const listener = listenerMiddleware.pop();
 
             if (listener === undefined) {
@@ -1156,13 +1156,13 @@ export default class App<AppCustomContext extends StringIndexed = StringIndexed>
               client,
               this.logger,
               // When all the listener middleware are done processing,
-              // `listener` here will be called without a `next` execution
+              // `listener` here will be called with a noop `next` fn
               async () => listener({
                 ...(listenerArgs as AnyMiddlewareArgs),
                 context,
                 client,
                 logger: this.logger,
-                // `next` is already set in the outer processMiddleware
+                next: () => {},
               } as AnyMiddlewareArgs & AllMiddlewareArgs),
             );
           });


### PR DESCRIPTION
fixes #1457

Since you were originally involved in the discussion in #1457, @srajiang ,wondering if you could review this in case I missed somethign?