### PR TITLE
docs: detail oauth configuration options and common cases

### DIFF
--- a/docs/content/basic/authenticating-oauth.md
+++ b/docs/content/basic/authenticating-oauth.md
@@ -16,7 +16,7 @@ All of the additional underlying details around authentications can be found at
 
 To set your Slack app up for distribution, you will need to enable Bolt OAuth
 and store installation information securely. Bolt supports OAuth by using
-[`@slack/oauth`][oauth-node] to handle most of the work; this includes setting
+the [`@slack/oauth`][oauth-node] package to handle most of the work; this includes setting
 up OAuth routes, state verification, and passing your app an installation object
 which you must store.
 
@@ -403,9 +403,9 @@ const app = new App({
 });
 ```
 
-Lookups for `fetchInstallation` happen as part of the built-in
+Lookups for the `fetchInstallation` handler happen as part of the built-in
 [`authorization`][authorization] of incoming events and provides app listeners
-with the `context.botToken` for convenient use.
+with the `context.botToken` object for convenient use.
 
 <details>
   <summary>Example database object</summary>
@@ -473,12 +473,12 @@ Most OAuth processes remain the same, but the
 }
 ```
 
-Successful `fetchInstallation` lookups will also include the `context.userToken`
+Successful `fetchInstallation` lookups will also include the `context.userToken` object
 associated with the received event in the app listener arguments.
 
 :::note
 
-The `tokenType` remains `"bot"` while `scopes` are requested, even with the
+The `tokenType` value remains `"bot"` while `scopes` are requested, even with the
 included `userScopes`. This suggests `bot` details exist, and is `undefined`
 along with the `bot` if no bot `scopes` are requested.
 
@@ -547,9 +547,9 @@ or `false`:
 }
 ```
 
-Apps installed org-wide will receive `isEnterpriseInstall` as `true`, but apps
+Apps installed org-wide will receive the `isEnterpriseInstall` parameter as `true`, but apps
 could also still be installed to individual workspaces in organizations. These
-apps receive installation information for both the `team` and `enterprise`:
+apps receive installation information for both the `team` and `enterprise` parameters:
 
 ```javascript
 {

--- a/docs/content/basic/authenticating-oauth.md
+++ b/docs/content/basic/authenticating-oauth.md
@@ -9,16 +9,16 @@ in distributing your app. For each completed authentication process, you receive
 unique [access tokens and related information](#the-installation-object) that
 can be retrieved for incoming events and used to make scoped API requests.
 
-All of the additional underlying details around authentications can be found within
-[the Slack API documentation][oauth-v2]!
+All of the additional underlying details around authentications can be found
+within [the Slack API documentation][oauth-v2]!
 
 ## Configuring the application
 
 To set your Slack app up for distribution, you will need to enable Bolt OAuth
-and store installation information securely. Bolt supports OAuth by using
-the [`@slack/oauth`][oauth-node] package to handle most of the work; this includes setting
-up OAuth routes, verifying state, and passing your app an installation object
-which you must store.
+and store installation information securely. Bolt supports OAuth by using the
+[`@slack/oauth`][oauth-node] package to handle most of the work; this includes
+setting up OAuth routes, verifying state, and passing your app an installation
+object which you must store.
 
 ### App options
 
@@ -473,13 +473,13 @@ Most OAuth processes remain the same, but the
 }
 ```
 
-Successful `fetchInstallation` lookups will also include the `context.userToken` object
-associated with the received event in the app listener arguments.
+Successful `fetchInstallation` lookups will also include the `context.userToken`
+object associated with the received event in the app listener arguments.
 
 :::note
 
-The `tokenType` value remains `"bot"` while `scopes` are requested, even with the
-included `userScopes`. This suggests `bot` details exist, and is `undefined`
+The `tokenType` value remains `"bot"` while `scopes` are requested, even with
+the included `userScopes`. This suggests `bot` details exist, and is `undefined`
 along with the `bot` if no bot `scopes` are requested.
 
 :::
@@ -547,9 +547,10 @@ or `false`:
 }
 ```
 
-Apps installed org-wide will receive the `isEnterpriseInstall` parameter as `true`, but apps
-could also still be installed to individual workspaces in organizations. These
-apps receive installation information for both the `team` and `enterprise` parameters:
+Apps installed org-wide will receive the `isEnterpriseInstall` parameter as
+`true`, but apps could also still be installed to individual workspaces in
+organizations. These apps receive installation information for both the `team`
+and `enterprise` parameters:
 
 ```javascript
 {
@@ -564,8 +565,9 @@ apps receive installation information for both the `team` and `enterprise` param
 ##### The org-wide `installQuery` object
 
 This `installQuery` object provided to the `fetchInstallation` and
-`deleteInstallation` handlers is the same as ever, but now with an additional value, `enterpriseId`, defined and
-another possible `true` or `false` value for `isEnterpriseInstall`:
+`deleteInstallation` handlers is the same as ever, but now with an additional
+value, `enterpriseId`, defined and another possible `true` or `false` value for
+`isEnterpriseInstall`:
 
 ```javascript
 {
@@ -671,7 +673,8 @@ If you need additional authorizations, such as user tokens from users of a team
 where your app is already installed, or have a reason to dynamically generate an
 install URL, an additional installation is required.
 
-Generating a new installation URL requires a few steps: 
+Generating a new installation URL requires a few steps:
+
 1. Manually instantiate an `ExpressReceiver` instance.
 2. Assign the instance to a variable named `receiver`.
 3. Call the `receiver.installer.generateInstallUrl()` function.

--- a/docs/content/basic/authenticating-oauth.md
+++ b/docs/content/basic/authenticating-oauth.md
@@ -212,10 +212,9 @@ const app = new App({
 });
 ```
 
-<details>
-<summary>
-Customizing OAuth defaults
-</summary>
+---
+
+## Customizing OAuth defaults
 
 We provide several options for customizing default OAuth using the `installerOptions` object, which can be passed in during the initialization of `App`. You can override the following:
 
@@ -233,10 +232,10 @@ const app = new App({
   clientId: process.env.SLACK_CLIENT_ID,
   clientSecret: process.env.SLACK_CLIENT_SECRET,
   scopes: [
-    "channels:read",
-    "groups:read",
     "channels:manage",
+    "channels:read",
     "chat:write",
+    "groups:read",
     "incoming-webhook",
   ],
   installerOptions: {
@@ -280,6 +279,4 @@ const app = new App({
 });
 ```
 
-</details>
 [settings]: https://api.slack.com/apps
-

--- a/docs/content/basic/authenticating-oauth.md
+++ b/docs/content/basic/authenticating-oauth.md
@@ -24,19 +24,21 @@ which you must store.
 
 The following `App` options are required for OAuth installations:
 
-- `clientId`: unique identifier of the application client.
-- `clientSecret`: secret value to confirm the client ID.
-- `stateSecret`: secret value used for [state verificiation][verification] of
-  authorization requests.
-- `scopes`: permissions requested for the `bot` user during installation.
-  [Explore scopes][scopes].
-- `installationStore`: handlers that store, fetch, and delete installation
-  information.
+- `clientId`: `string`. An application credential found on the **Basic
+  Information** page of your [app settings][app-settings].
+- `clientSecret`: `string`. A secret value to confirm the client ID.
+- `stateSecret`: `string`. A secret value used to
+  [generate and verify state][verification] parameters of authorization
+  requests.
+- `scopes`: `string[]`. Permissions requested for the `bot` user during
+  installation. [Explore scopes][scopes].
+- `installationStore`: [`InstallationStore`][installation-store]. Handlers that
+  store, fetch, and delete installation information.
 
 #### Development and testing
 
 Here we've provided a default implementation of the `installationStore` with
-[`FileInstallationStore`][store-file-installation] which can be useful when
+[`FileInstallationStore`][installation-store-file] which can be useful when
 developing and testing your app:
 
 ```javascript
@@ -67,22 +69,30 @@ We provide several options for customizing default OAuth using the
 `App`. You can override these common options and
 [find others here][install-provider-options]:
 
-- `authVersion`: Settings for either new Slack Apps (`v2`) or Classic Slack Apps
-  (`v1`). Default: `v2`.
-- `directInstall`: Skip the [default installation page][installation] at
-  `installPath`. Default: `false`.
-- `installPath`: Path of the URL for starting an installation. Default:
-  `/slack/install`.
-- `metadata`: Relevant session information passed between requests. Optional.
-- `redirectUriPath`: Path of the installation callback URL. Default:
+- `authVersion`: `string`. Settings for either new Slack apps (`v2`) or
+  "classic" Slack apps (`v1`). Most apps use `v2` since `v1` was available for a
+  Slack app model that can no longer be created. Default: `v2`.
+- `directInstall`: `boolean`. Skip rendering the
+  [installation page](#add-to-slack-button) at `installPath` and redirect to the
+  authorization URL instead. Default: `false`.
+- `installPath`: `string`. Path of the URL for starting an installation.
+  Default: `/slack/install`.
+- `metadata`: `string`. Static information shared between requests as install
+  URL options. Optional.
+- `redirectUriPath`: `string`. Path of the installation callback URL. Default:
   `/slack/oauth_redirect`.
-- `stateVerification`: Option to skip state verification for requests. Default:
-  `true`.
-- `userScopes`: User scopes to request during installation. Default: `[]`.
-- `callbackOptions`: Customized [responses to send][callbacks] during OAuth.
-  Default: [`CallbackOptions`][callback-options-default].
-- `stateStore`: Replace the `stateSecret` with a [custom state store][state].
-  Default: [`ClearStateStore`][state-clear].
+- `stateVerification`: `boolean`. Option to skip state verification for
+  requests. Default: `true`.
+- `userScopes`: `string[]`. User scopes to request during installation. Default:
+  `[]`.
+- `callbackOptions`: [`CallbackOptions`][callback-options]. Customized
+  [responses to send][callbacks] during OAuth.
+  [Default callbacks][callback-options-default].
+- `stateStore`: [`StateStore`][state-store]. Customized generator and validator
+  for [OAuth state parameters][state]; the default `ClearStateStore` should work
+  well for most scenarios. However, if you need even better security, storing
+  state parameter data with a server-side database would be a good approach.
+  Default: [`ClearStateStore`][state-store-clear].
 
 ```javascript
 const app = new App({
@@ -111,10 +121,10 @@ const app = new App({
      * Example pages to navigate to on certain callbacks.
      */
     callbackOptions: {
-      success: (installation, installOptions, req, res) => {
+      success: (installation, installUrlOptions, req, res) => {
         res.send("The installation succeeded!");
       },
-      failure: (error, installOptions, req, res) => {
+      failure: (error, installUrlOptions, req, res) => {
         res.send("Something strange happened...");
       },
     },
@@ -675,6 +685,7 @@ errors, but these often have meaning! Explore [the API documentation][errors]
 for additional details for common error codes.
 
 [add-to-slack]: https://github.com/slackapi/node-slack-sdk/blob/main/packages/oauth/src/default-render-html-for-install-path.ts
+[app-settings]: https://api.slack.com/apps
 [authorization]: /concepts/authorization
 [callback-default-failure]: https://github.com/slackapi/node-slack-sdk/blob/e5a4f3fbbd4f6aad9fdd415976f80668b01fd442/packages/oauth/src/callback-options.ts#L127-L162
 [callback-default-success]: https://github.com/slackapi/node-slack-sdk/blob/e5a4f3fbbd4f6aad9fdd415976f80668b01fd442/packages/oauth/src/callback-options.ts#L81-L125
@@ -687,8 +698,9 @@ for additional details for common error codes.
 [examples]: https://github.com/slackapi/bolt-js/tree/main/examples/oauth
 [generate-install-url]: https://slack.dev/node-slack-sdk/oauth/#showing-an-installation-page
 [install-provider-options]: https://github.com/slackapi/node-slack-sdk/blob/main/packages/oauth/src/install-provider-options.ts
-[installation]: https://github.com/slackapi/node-slack-sdk/blob/main/packages/oauth/src/default-render-html-for-install-path.ts
 [installation-page]: https://slack.dev/node-slack-sdk/oauth/#showing-an-installation-page
+[installation-store]: https://slack.dev/node-slack-sdk/reference/oauth/interfaces/InstallationStore
+[installation-store-file]: https://github.com/slackapi/node-slack-sdk/blob/main/packages/oauth/src/installation-stores/file-store.ts
 [oauth-node]: https://slack.dev/node-slack-sdk/oauth
 [oauth-v2]: https://api.slack.com/authentication/oauth-v2
 [oidc]: https://slack.dev/node-slack-sdk/web-api#sign-in-with-slack-via-openid-connect
@@ -698,9 +710,9 @@ for additional details for common error codes.
 [settings]: https://api.slack.com/apps
 [siws]: https://api.slack.com/authentication/sign-in-with-slack
 [state]: https://slack.dev/node-slack-sdk/oauth#using-a-custom-state-store
-[state-clear]: https://github.com/slackapi/node-slack-sdk/blob/main/packages/oauth/src/state-stores/clear-state-store.ts
+[state-store]: https://slack.dev/node-slack-sdk/reference/oauth/interfaces/StateStore
+[state-store-clear]: https://github.com/slackapi/node-slack-sdk/blob/main/packages/oauth/src/state-stores/clear-state-store.ts
 [store]: https://slack.dev/node-slack-sdk/oauth#storing-installations-in-a-database
-[store-file-installation]: https://github.com/slackapi/node-slack-sdk/blob/main/packages/oauth/src/installation-stores/file-store.ts
 [user-tokens]: https://api.slack.com/concepts/token-types#user
 [verification]: https://slack.dev/node-slack-sdk/oauth#state-verification
 [web-api]: https://slack.dev/node-slack-sdk/web-api

--- a/docs/content/basic/authenticating-oauth.md
+++ b/docs/content/basic/authenticating-oauth.md
@@ -564,7 +564,7 @@ apps receive installation information for both the `team` and `enterprise` param
 ##### The org-wide `installQuery` object
 
 This `installQuery` object provided to the `fetchInstallation` and
-`deleteInstallation` handlers is familiar but with an `enterpriseId` defined and
+`deleteInstallation` handlers is the same as ever, but now with an additional value, `enterpriseId`, defined and
 another possible `true` or `false` value for `isEnterpriseInstall`:
 
 ```javascript
@@ -671,9 +671,10 @@ If you need additional authorizations, such as user tokens from users of a team
 where your app is already installed, or have a reason to dynamically generate an
 install URL, an additional installation is required.
 
-Generating a new installation URL requires a few steps: manually instantiate an
-`ExpressReceiver`, assign the instance to a variable named `receiver`, and then
-call `receiver.installer.generateInstallUrl()`.
+Generating a new installation URL requires a few steps: 
+1. Manually instantiate an `ExpressReceiver` instance.
+2. Assign the instance to a variable named `receiver`.
+3. Call the `receiver.installer.generateInstallUrl()` function.
 
 Read more about `generateInstallUrl()` in the
 [OAuth docs][generate-install-url].

--- a/docs/content/basic/authenticating-oauth.md
+++ b/docs/content/basic/authenticating-oauth.md
@@ -27,7 +27,7 @@ The following `App` options are required for OAuth installations:
 - `clientId`: unique identifier of the application client.
 - `clientSecret`: secret value to confirm the client ID.
 - `stateSecret`: secret value used for [state verificiation][verification] of
-  authentication requests.
+  authorization requests.
 - `scopes`: permissions requested for the `bot` user during installation.
   [Explore scopes][scopes].
 - `installationStore`: handlers that store, fetch, and delete installation

--- a/docs/content/basic/authenticating-oauth.md
+++ b/docs/content/basic/authenticating-oauth.md
@@ -308,7 +308,7 @@ const app = new App({
 
 Full reference reveals [these additional options][callback-options] but if no
 options are provided, the [`defaultCallbackSuccess`][callback-default-success]
-and [`defaultCallbackFailure`][callback-default-failure] are used.
+and [`defaultCallbackFailure`][callback-default-failure] callbacks are used.
 
 ### Workspace installations
 

--- a/docs/content/basic/authenticating-oauth.md
+++ b/docs/content/basic/authenticating-oauth.md
@@ -4,31 +4,33 @@ lang: en
 slug: /concepts/authenticating-oauth
 ---
 
-To prepare your Slack app for distribution, you will need to enable Bolt OAuth and store installation information securely. Bolt supports OAuth and will handle the rest of the work; this includes setting up OAuth routes, state verification, and passing your app an installation object which you must store. 
+To prepare your Slack app for distribution, you will need to enable Bolt OAuth and store installation information securely. Bolt supports OAuth and will handle the rest of the work; this includes setting up OAuth routes, state verification, and passing your app an installation object which you must store.
 
 To enable OAuth, you must provide:
-* `clientId`, `clientSecret`, `stateSecret` and `scopes` _(required)_
-* An `installationStore` option with handlers that store and fetch installations to your database *(optional, strongly recommended in production)*
+
+- `clientId`, `clientSecret`, `stateSecret` and `scopes` _(required)_
+- An `installationStore` option with handlers that store and fetch installations to your database _(optional, strongly recommended in production)_
 
 ---
 
 ## Development and Testing
 
-We've provided a default implementation of the `installationStore`  `FileInstallationStore` which you can use during app development and testing.
+We've provided a default implementation of the `installationStore` `FileInstallationStore` which you can use during app development and testing.
 
 ```javascript
-const { App } = require('@slack/bolt');
-const { FileInstallationStore } = require('@slack/oauth');
+const { App } = require("@slack/bolt");
+const { FileInstallationStore } = require("@slack/oauth");
 const app = new App({
   signingSecret: process.env.SLACK_SIGNING_SECRET,
   clientId: process.env.SLACK_CLIENT_ID,
   clientSecret: process.env.SLACK_CLIENT_SECRET,
-  stateSecret: 'my-state-secret',
-  scopes: ['channels:history', 'chat:write', 'commands'],
+  stateSecret: "my-state-secret",
+  scopes: ["channels:history", "chat:write", "commands"],
   installationStore: new FileInstallationStore(),
 });
 ```
-:::warning 
+
+:::warning
 
 This is **_not_** recommended for use in production - you should implement your own production store. Please see the example code to the right and [our other examples](https://github.com/slackapi/bolt-js/tree/main/examples/oauth).
 
@@ -38,7 +40,7 @@ This is **_not_** recommended for use in production - you should implement your 
 
 ## Installing your App
 
-* **Initiating an installation**: Bolt for JavaScript provides an **Install Path** `/slack/install` out-of-the-box. This endpoint returns a simple page with an `Add to Slack` button which initiates a direct install of your app (with a valid `state` parameter). An app hosted at _www.example.com_ would serve the install page at _www.example.com/slack/install_. 
+- **Initiating an installation**: Bolt for JavaScript provides an **Install Path** `/slack/install` out-of-the-box. This endpoint returns a simple page with an `Add to Slack` button which initiates a direct install of your app (with a valid `state` parameter). An app hosted at _www.example.com_ would serve the install page at _www.example.com/slack/install_.
 
 :::tip
 
@@ -46,23 +48,25 @@ You can skip rendering the provided default webpage and navigate users directly 
 
 :::
 
-* **Add to Slack**: The `Add to Slack` button initiates the OAuth process with Slack. After users have clicked Allow to grant your app permissions, Slack will call your app's **Redirect URI** (provided out-of-the-box), and prompt users to **Open Slack**. See the **Redirect URI** section below for customization options.
+- **Add to Slack**: The `Add to Slack` button initiates the OAuth process with Slack. After users have clicked Allow to grant your app permissions, Slack will call your app's **Redirect URI** (provided out-of-the-box), and prompt users to **Open Slack**. See the **Redirect URI** section below for customization options.
 
-* **Open Slack**: After users **Open Slack**, and here after as your app processes events from Slack, your provided `installationStore`'s `fetchInstallation` and `storeInstallation` handlers will execute. See the **Installation Object** section below for more detail on arguments passed to those handlers.  
+- **Open Slack**: After users **Open Slack**, and here after as your app processes events from Slack, your provided `installationStore`'s `fetchInstallation` and `storeInstallation` handlers will execute. See the **Installation Object** section below for more detail on arguments passed to those handlers.
 
-* If you need additional authorizations (user tokens) from users inside a team when your app is already installed, or have a reason to dynamically generate an install URL, manually instantiate an `ExpressReceiver`, assign the instance to a variable named `receiver`, and then call `receiver.installer.generateInstallUrl()`. Read more about `generateInstallUrl()` in the [OAuth docs](https://slack.dev/node-slack-sdk/oauth#generating-an-installation-url).
+- If you need additional authorizations (user tokens) from users inside a team when your app is already installed, or have a reason to dynamically generate an install URL, manually instantiate an `ExpressReceiver`, assign the instance to a variable named `receiver`, and then call `receiver.installer.generateInstallUrl()`. Read more about `generateInstallUrl()` in the [OAuth docs](https://slack.dev/node-slack-sdk/oauth#generating-an-installation-url).
 
-:::info 
+:::info
 
 Bolt for JavaScript does not support OAuth for [custom receivers](/concepts/receiver). If you're implementing a custom receiver, you can use our [Slack OAuth library](https://slack.dev/node-slack-sdk/oauth#slack-oauth), which is what Bolt for JavaScript uses under the hood.
 
 :::
 
 ---
-## Redirect URI
-Bolt for JavaScript provides a **Redirect URI Path** `/slack/oauth_redirect`. Slack uses the Redirect URI to redirect users after they complete an app's installation flow. 
 
-You will need to add the full **Redirect URI** including your app domain in your Slack app configuration settings under **OAuth and Permissions**, e.g. `https://example.com/slack/oauth_redirect`. 
+## Redirect URI
+
+Bolt for JavaScript provides a **Redirect URI Path** `/slack/oauth_redirect`. Slack uses the Redirect URI to redirect users after they complete an app's installation flow.
+
+You will need to add the full **Redirect URI** including your app domain in your Slack app configuration settings under **OAuth and Permissions**, e.g. `https://example.com/slack/oauth_redirect`.
 
 To supply your own custom **Redirect URI**, you can set `redirectUri` in the App options and `installerOptions.redirectUriPath`. You must supply both, and the path must be consistent with the full URI.
 
@@ -71,11 +75,11 @@ const app = new App({
   signingSecret: process.env.SLACK_SIGNING_SECRET,
   clientId: process.env.SLACK_CLIENT_ID,
   clientSecret: process.env.SLACK_CLIENT_SECRET,
-  stateSecret: 'my-state-secret',
-  scopes: ['chat:write'],
-  redirectUri: 'https://example.com/slack/redirect', // here
+  stateSecret: "my-state-secret",
+  scopes: ["chat:write"],
+  redirectUri: "https://example.com/slack/redirect", // here
   installerOptions: {
-    redirectUriPath: '/slack/redirect', // and here!
+    redirectUriPath: "/slack/redirect", // and here!
   },
 });
 ```
@@ -83,44 +87,48 @@ const app = new App({
 ---
 
 ## Installation object
+
 Bolt will pass your `installationStore`'s `storeInstallation` handler an `installation`. This can be a source of confusion for developers who aren't sure what shape of object to expect. The `installation` object should resemble:
 
 ```javascript
 {
-  team: { id: 'T012345678', name: 'example-team-name' },
+  team: { id: "T012345678", name: "example-team-name" },
   enterprise: undefined,
-  user: { token: undefined, scopes: undefined, id: 'U01234567' },
-  tokenType: 'bot',
+  user: { token: undefined, scopes: undefined, id: "U01234567" },
+  tokenType: "bot",
   isEnterpriseInstall: false,
-  appId: 'A01234567',
-  authVersion: 'v2',
+  appId: "A01234567",
+  authVersion: "v2",
   bot: {
     scopes: [
-      'chat:write',
+      "chat:write",
     ],
-    token: 'xoxb-244493-28*********-********************',
-    userId: 'U012345678',
-    id: 'B01234567'
+    token: "xoxb-244493-28*********-********************",
+    userId: "U012345678",
+    id: "B01234567"
   }
 }
 ```
+
 Bolt will pass your `fetchInstallation` and `deleteInstallation` handlers an `installQuery` object:
 
 ```javascript
 {
-  userId: 'U012345678',
+  userId: "U012345678",
   isEnterpriseInstall: false,
-  teamId: 'T012345678',
+  teamId: "T012345678",
   enterpriseId: undefined,
-  conversationId: 'D02345678'
+  conversationId: "D02345678"
 }
 ```
 
 ---
+
 ## Org-wide installation
+
 To add support for [org-wide installations](https://api.slack.com/enterprise/apps), you will need Bolt for JavaScript version `3.0.0` or later. Make sure you have enabled org-wide installation in your app configuration settings under **Org Level Apps**.
 
-Installing an [org-wide](https://api.slack.com/enterprise/apps) app from admin pages requires additional configuration to work with Bolt. In that scenario, the recommended `state` parameter is not supplied. Bolt will try to verify `state` and stop the installation from progressing. 
+Installing an [org-wide](https://api.slack.com/enterprise/apps) app from admin pages requires additional configuration to work with Bolt. In that scenario, the recommended `state` parameter is not supplied. Bolt will try to verify `state` and stop the installation from progressing.
 
 You may disable state verification in Bolt by setting the `stateVerification` option to false. See the example setup below:
 
@@ -129,7 +137,7 @@ const app = new App({
   signingSecret: process.env.SLACK_SIGNING_SECRET,
   clientId: process.env.SLACK_CLIENT_ID,
   clientSecret: process.env.SLACK_CLIENT_SECRET,
-  scopes: ['chat:write'],
+  scopes: ["chat:write"],
   installerOptions: {
     stateVerification: false,
   },
@@ -142,20 +150,23 @@ To learn more about the OAuth installation flow with Slack, [read the API docume
 const database = {
   async get(key) {},
   async delete(key) {},
-  async set(key, value) {}
+  async set(key, value) {},
 };
 
 const app = new App({
   signingSecret: process.env.SLACK_SIGNING_SECRET,
   clientId: process.env.SLACK_CLIENT_ID,
   clientSecret: process.env.SLACK_CLIENT_SECRET,
-  stateSecret: 'my-secret',
-  scopes: ['chat:write', 'commands'],
+  stateSecret: "my-secret",
+  scopes: ["chat:write", "commands"],
   installationStore: {
     storeInstallation: async (installation) => {
       // Bolt will pass your handler an installation object
       // Change the lines below so they save to your database
-      if (installation.isEnterpriseInstall && installation.enterprise !== undefined) {
+      if (
+        installation.isEnterpriseInstall &&
+        installation.enterprise !== undefined
+      ) {
         // handle storing org-wide app installation
         return await database.set(installation.enterprise.id, installation);
       }
@@ -163,12 +174,15 @@ const app = new App({
         // single team app installation
         return await database.set(installation.team.id, installation);
       }
-      throw new Error('Failed saving installation data to installationStore');
+      throw new Error("Failed saving installation data to installationStore");
     },
     fetchInstallation: async (installQuery) => {
       // Bolt will pass your handler an installQuery object
       // Change the lines below so they fetch from your database
-      if (installQuery.isEnterpriseInstall && installQuery.enterpriseId !== undefined) {
+      if (
+        installQuery.isEnterpriseInstall &&
+        installQuery.enterpriseId !== undefined
+      ) {
         // handle org wide app installation lookup
         return await database.get(installQuery.enterpriseId);
       }
@@ -176,12 +190,15 @@ const app = new App({
         // single team app installation lookup
         return await database.get(installQuery.teamId);
       }
-      throw new Error('Failed fetching installation');
+      throw new Error("Failed fetching installation");
     },
     deleteInstallation: async (installQuery) => {
       // Bolt will pass your handler  an installQuery object
       // Change the lines below so they delete from your database
-      if (installQuery.isEnterpriseInstall && installQuery.enterpriseId !== undefined) {
+      if (
+        installQuery.isEnterpriseInstall &&
+        installQuery.enterpriseId !== undefined
+      ) {
         // org wide app installation deletion
         return await database.delete(installQuery.enterpriseId);
       }
@@ -189,7 +206,7 @@ const app = new App({
         // single team app installation deletion
         return await database.delete(installQuery.teamId);
       }
-      throw new Error('Failed to delete installation');
+      throw new Error("Failed to delete installation");
     },
   },
 });
@@ -205,7 +222,7 @@ We provide several options for customizing default OAuth using the `installerOpt
 - `authVersion`: Used to toggle between new Slack Apps and Classic Slack Apps
 - `metadata`: Used to pass around session related information
 - `installPath`: Override default path for "Add to Slack" button
-- `redirectUriPath`: This relative path must match the `redirectUri` provided in the App options 
+- `redirectUriPath`: This relative path must match the `redirectUri` provided in the App options
 - `callbackOptions`: Provide custom success and failure pages at the end of the OAuth flow
 - `stateStore`: Provide a custom state store instead of using the built in `ClearStateStore`
 - `userScopes`: Array of user scopes needed when the user installs the app, similar to `scopes` attribute at the parent level.
@@ -215,45 +232,53 @@ const app = new App({
   signingSecret: process.env.SLACK_SIGNING_SECRET,
   clientId: process.env.SLACK_CLIENT_ID,
   clientSecret: process.env.SLACK_CLIENT_SECRET,
-  scopes: ['channels:read', 'groups:read', 'channels:manage', 'chat:write', 'incoming-webhook'],
+  scopes: [
+    "channels:read",
+    "groups:read",
+    "channels:manage",
+    "chat:write",
+    "incoming-webhook",
+  ],
   installerOptions: {
-      authVersion: 'v1', // default  is 'v2', 'v1' is used for classic slack apps
-      metadata: 'some session data',
-      installPath: '/slack/installApp',
-      redirectUriPath: '/slack/redirect',
-      userScopes: ['chat:write'],
-      callbackOptions: {
-        success: (installation, installOptions, req, res) => {
-          // Do custom success logic here
-          res.send('successful!');
-        }, 
-        failure: (error, installOptions , req, res) => {
-          // Do custom failure logic here
-          res.send('failure');
-        }
+    authVersion: "v1", // default  is 'v2', 'v1' is used for classic slack apps
+    metadata: "some session data",
+    installPath: "/slack/installApp",
+    redirectUriPath: "/slack/redirect",
+    userScopes: ["chat:write"],
+    callbackOptions: {
+      success: (installation, installOptions, req, res) => {
+        // Do custom success logic here
+        res.send("successful!");
       },
-      stateStore: {
-        // Do not need to provide a `stateSecret` when passing in a stateStore
-        // generateStateParam's first argument is the entire InstallUrlOptions object which was passed into generateInstallUrl method
-        // the second argument is a date object
-        // the method is expected to return a string representing the state
-        generateStateParam: async (installUrlOptions, date) => {
-          // generate a random string to use as state in the URL
-          const randomState = randomStringGenerator();
-          // save installOptions to cache/db
-          await myDB.set(randomState, installUrlOptions);
-          // return a state string that references saved options in DB
-          return randomState;
-        },
-        // verifyStateParam's first argument is a date object and the second argument is a string representing the state
-        // verifyStateParam is expected to return an object representing installUrlOptions
-        verifyStateParam:  async (date, state) => {
-          // fetch saved installOptions from DB using state reference
-          const installUrlOptions = await myDB.get(randomState);
-          return installUrlOptions;
-        }
+      failure: (error, installOptions, req, res) => {
+        // Do custom failure logic here
+        res.send("failure");
       },
-  }
+    },
+    stateStore: {
+      // Do not need to provide a `stateSecret` when passing in a stateStore
+      // generateStateParam's first argument is the entire InstallUrlOptions object which was passed into generateInstallUrl method
+      // the second argument is a date object
+      // the method is expected to return a string representing the state
+      generateStateParam: async (installUrlOptions, date) => {
+        // generate a random string to use as state in the URL
+        const randomState = randomStringGenerator();
+        // save installOptions to cache/db
+        await myDB.set(randomState, installUrlOptions);
+        // return a state string that references saved options in DB
+        return randomState;
+      },
+      // verifyStateParam's first argument is a date object and the second argument is a string representing the state
+      // verifyStateParam is expected to return an object representing installUrlOptions
+      verifyStateParam: async (date, state) => {
+        // fetch saved installOptions from DB using state reference
+        const installUrlOptions = await myDB.get(randomState);
+        return installUrlOptions;
+      },
+    },
+  },
 });
 ```
+
 </details>
+

--- a/docs/content/basic/authenticating-oauth.md
+++ b/docs/content/basic/authenticating-oauth.md
@@ -23,7 +23,8 @@ The following `App` options are required for OAuth installations:
 
 - `clientId`: `string`. An application credential found on the **Basic
   Information** page of your [app settings][app-settings].
-- `clientSecret`: `string`. A secret value to confirm the client ID.
+- `clientSecret`: `string`. A secret value also found on the **Basic
+  Information** page of your [app settings][app-settings].
 - `stateSecret`: `string`. A secret value used to
   [generate and verify state][verification] parameters of authorization
   requests.
@@ -78,8 +79,10 @@ We provide several options for customizing default OAuth using the
   URL options. Optional.
 - `redirectUriPath`: `string`. Path of the installation callback URL. Default:
   `/slack/oauth_redirect`.
-- `stateVerification`: `boolean`. Option to skip state verification for
-  requests. Default: `true`.
+- `stateVerification`: `boolean`. Option to customize the state verification
+  logic. When set to `false`, the app does not verify the state parameter. While
+  not recommended for general OAuth security, some apps might want to skip this
+  for internal installations within an enterprise grid org. Default: `true`.
 - `userScopes`: `string[]`. User scopes to request during installation. Default:
   `[]`.
 - `callbackOptions`: [`CallbackOptions`][callback-options]. Customized

--- a/docs/content/basic/authenticating-oauth.md
+++ b/docs/content/basic/authenticating-oauth.md
@@ -9,15 +9,15 @@ in distributing your app. For each completed authentication process, you receive
 unique [access tokens and related information](#the-installation-object) that
 can be retrieved for incoming events and used to make scoped API requests.
 
-All of the additional underlying details around authentications can be found at
-[api.slack.com/authentication/oauth-v2][oauth-v2]!
+All of the additional underlying details around authentications can be found within
+[the Slack API documentation][oauth-v2]!
 
 ## Configuring the application
 
 To set your Slack app up for distribution, you will need to enable Bolt OAuth
 and store installation information securely. Bolt supports OAuth by using
 the [`@slack/oauth`][oauth-node] package to handle most of the work; this includes setting
-up OAuth routes, state verification, and passing your app an installation object
+up OAuth routes, verifying state, and passing your app an installation object
 which you must store.
 
 ### App options
@@ -247,7 +247,7 @@ links to the authorization page!
 
 :::note
 
-Authorization requests with changed or additional scops require
+Authorization requests with changed or additional scopes require
 [generating a unique authorization URL](#extra-authorizations).
 
 :::

--- a/docs/content/basic/authenticating-oauth.md
+++ b/docs/content/basic/authenticating-oauth.md
@@ -412,11 +412,11 @@ For quick testing purposes, the following might be interesting:
 ```javascript
 const database = {
   store: {},
-  async get(key) {
-    return this.store[key];
-  },
   async delete(key) {
     delete this.store[key];
+  },
+  async get(key) {
+    return this.store[key];
   },
   async set(key, value) {
     this.store[key] = value;

--- a/docs/content/basic/authenticating-oauth.md
+++ b/docs/content/basic/authenticating-oauth.md
@@ -328,7 +328,7 @@ workspace team, the `installation` object resembles the following:
 {
   team: { id: "T012345678", name: "example-team-name" },
   enterprise: undefined,
-  user: { token: undefined, scopes: undefined, id: "U01234567" },
+  user: { token: undefined, scopes: undefined, id: "U012345678" },
   tokenType: "bot",
   isEnterpriseInstall: false,
   appId: "A01234567",
@@ -338,7 +338,7 @@ workspace team, the `installation` object resembles the following:
       "chat:write",
     ],
     token: "xoxb-244493-28*********-********************",
-    userId: "U012345678",
+    userId: "U001111000",
     id: "B01234567"
   }
 }
@@ -462,7 +462,7 @@ Most OAuth processes remain the same, but the
   user: {
     token: "xoxp-314159-26*********-********************",
     scopes: ["chat:write"],
-    id: "U01234567"
+    id: "U012345678"
   },
   tokenType: "bot",
   appId: "A01234567",

--- a/docs/content/basic/authenticating-oauth.md
+++ b/docs/content/basic/authenticating-oauth.md
@@ -4,18 +4,40 @@ lang: en
 slug: /concepts/authenticating-oauth
 ---
 
-To prepare your Slack app for distribution, you will need to enable Bolt OAuth and store installation information securely. Bolt supports OAuth and will handle the rest of the work; this includes setting up OAuth routes, state verification, and passing your app an installation object which you must store.
+OAuth allows installation of your app to any workspace and is an important step
+in distributing your app. For each completed authentication process, you receive
+unique [access tokens and related information](#the-installation-object) that
+can be retrieved for incoming events and used to make scoped API requests.
 
-To enable OAuth, you must provide:
+All of the additional underlying details around authentications can be found at
+[api.slack.com/authentication/oauth-v2][oauth-v2]!
 
-- `clientId`, `clientSecret`, `stateSecret` and `scopes` _(required)_
-- An `installationStore` option with handlers that store and fetch installations to your database _(optional, strongly recommended in production)_
+## Configuring the application
 
----
+To set your Slack app up for distribution, you will need to enable Bolt OAuth
+and store installation information securely. Bolt supports OAuth by using
+[`@slack/oauth`][oauth-node] to handle most of the work; this includes setting
+up OAuth routes, state verification, and passing your app an installation object
+which you must store.
 
-## Development and Testing
+### App options
 
-We've provided a default implementation of the `installationStore` `FileInstallationStore` which you can use during app development and testing.
+The following `App` options are required for OAuth installations:
+
+- `clientId`: unique identifier of the application client.
+- `clientSecret`: secret value to confirm the client ID.
+- `stateSecret`: secret value used for [state verificiation][verification] of
+  authentication requests.
+- `scopes`: permissions requested for the `bot` user during installation.
+  [Explore scopes][scopes].
+- `installationStore`: handlers that store, fetch, and delete installation
+  information.
+
+#### Development and testing
+
+Here we've provided a default implementation of the `installationStore` with
+[`FileInstallationStore`][store-file-installation] which can be useful when
+developing and testing your app:
 
 ```javascript
 const { App } = require("@slack/bolt");
@@ -32,43 +54,207 @@ const app = new App({
 
 :::warning
 
-This is **_not_** recommended for use in production - you should implement your own production store. Please see the example code to the right and [our other examples](https://github.com/slackapi/bolt-js/tree/main/examples/oauth).
+This is **not** recommended for use in production - you should
+[implement your own installation store](#installation-store). Please continue
+reading or inspect [our example apps][examples].
 
 :::
+
+### Installer options
+
+We provide several options for customizing default OAuth using the
+`installerOptions` object, which can be passed in during the initialization of
+`App`. You can override these common options and
+[find others here][install-provider-options]:
+
+- `authVersion`: Settings for either new Slack Apps (`v2`) or Classic Slack Apps
+  (`v1`). Default: `v2`.
+- `directInstall`: Skip the [default installation page][installation] at
+  `installPath`. Default: `false`.
+- `installPath`: Path of the URL for starting an installation. Default:
+  `/slack/install`.
+- `metadata`: Relevant session information passed between requests. Optional.
+- `redirectUriPath`: Path of the installation callback URL. Default:
+  `/slack/oauth_redirect`.
+- `stateVerification`: Option to skip state verification for requests. Default:
+  `true`.
+- `userScopes`: User scopes to request during installation. Default: `[]`.
+- `callbackOptions`: Customized [responses to send][callbacks] during OAuth.
+  Default: [`CallbackOptions`][callback-options-default].
+- `stateStore`: Replace the `stateSecret` with a [custom state store][state].
+  Default: [`ClearStateStore`][state-clear].
+
+```javascript
+const app = new App({
+  signingSecret: process.env.SLACK_SIGNING_SECRET,
+  clientId: process.env.SLACK_CLIENT_ID,
+  clientSecret: process.env.SLACK_CLIENT_SECRET,
+  scopes: [
+    "channels:manage",
+    "channels:read",
+    "chat:write",
+    "groups:read",
+    "incoming-webhook",
+  ],
+  installerOptions: {
+    authVersion: "v2",
+    directInstall: false,
+    installPath: "/slack/install",
+    metadata: "",
+    redirectUriPath: "/slack/oauth_redirect",
+    stateVerification: "true",
+    /**
+     * Example user scopes to request during installation.
+     */
+    userScopes: ["chat:write"],
+    /**
+     * Example pages to navigate to on certain callbacks.
+     */
+    callbackOptions: {
+      success: (installation, installOptions, req, res) => {
+        res.send("The installation succeeded!");
+      },
+      failure: (error, installOptions, req, res) => {
+        res.send("Something strange happened...");
+      },
+    },
+    /**
+     * Example validation of installation options using a random state and an
+     * expiration time between requests.
+     */
+    stateStore: {
+      generateStateParam: async (installUrlOptions, now) => {
+        const state = randomStringGenerator();
+        const value = { options: installUrlOptions, now: now.toJSON() };
+        await database.set(state, value);
+        return state;
+      },
+      verifyStateParam: async (now, state) => {
+        const value = await database.get(state);
+        const generated = new Date(value.now);
+        const seconds = Math.floor(
+          (now.getTime() - generated.getTime()) / 1000,
+        );
+        if (seconds > 600) {
+          throw new Error("The state expired after 10 minutes!");
+        }
+        return value.options;
+      },
+    },
+  },
+});
+```
+
+<details>
+  <summary>Example database object</summary>
+
+For quick testing purposes, the following might be interesting:
+
+```javascript
+const database = {
+  store: {},
+  async get(key) {
+    return this.store[key];
+  },
+  async set(key, value) {
+    this.store[key] = value;
+  },
+};
+```
+
+</details>
 
 ---
 
-## Installing your App
+## Completing authentication
 
-- **Initiating an installation**: Bolt for JavaScript provides an **Install Path** `/slack/install` out-of-the-box. This endpoint returns a simple page with an `Add to Slack` button which initiates a direct install of your app (with a valid `state` parameter). An app hosted at _www.example.com_ would serve the install page at _www.example.com/slack/install_.
-
-:::tip
-
-You can skip rendering the provided default webpage and navigate users directly to Slack authorize URL by setting`installerOptions.directInstall: true` in the `App` constructor ([example](https://github.com/slackapi/bolt-js/blob/5b4d9ceb65e6bf5cf29dfa58268ea248e5466bfb/examples/oauth/app.js#L58-L64)).
-
-:::
-
-- **Add to Slack**: The `Add to Slack` button initiates the OAuth process with Slack. After users have clicked Allow to grant your app permissions, Slack will call your app's **Redirect URL** (provided out-of-the-box), and prompt users to **Open Slack**. Read the [**Redirect URL**](#redirect-url) section for customization options.
-
-- **Open Slack**: After users **Open Slack**, and here after as your app processes events from Slack, your provided `installationStore`'s `fetchInstallation` and `storeInstallation` handlers will execute. See the **Installation Object** section below for more detail on arguments passed to those handlers.
-
-- If you need additional authorizations (user tokens) from users inside a team when your app is already installed, or have a reason to dynamically generate an install URL, manually instantiate an `ExpressReceiver`, assign the instance to a variable named `receiver`, and then call `receiver.installer.generateInstallUrl()`. Read more about `generateInstallUrl()` in the [OAuth docs](https://slack.dev/node-slack-sdk/oauth#generating-an-installation-url).
+The complete authentication handshake involves requesting scopes using a
+generated installation URL and processing approved installations. Bolt handles
+this with a default installation and callback route, but some configurations to
+the app settings are needed and changes to these routes might be desired.
 
 :::info
 
-Bolt for JavaScript does not support OAuth for [custom receivers](/concepts/receiver). If you're implementing a custom receiver, you can use our [Slack OAuth library](https://slack.dev/node-slack-sdk/oauth#slack-oauth), which is what Bolt for JavaScript uses under the hood.
+Bolt for JavaScript does not support OAuth for
+[custom receivers](/concepts/receiver). If you're implementing a custom
+receiver, you can use our
+[Slack OAuth library](https://slack.dev/node-slack-sdk/oauth#slack-oauth), which
+is what Bolt for JavaScript uses under the hood.
 
 :::
 
----
+### Installing your App
 
-## Redirect URL
+Bolt for JavaScript provides an **Install Path** `/slack/install`
+out-of-the-box. This endpoint returns a simple static page that includes an
+`Add to Slack` button that links to a generated authorization URL for your app.
+This has the right scopes, a valid `state`, the works.
 
-Bolt for JavaScript provides a **Redirect URL Path** `/slack/oauth_redirect`. Slack uses the Redirect URL to redirect users after they complete an app's installation flow.
+An app hosted at _www.example.com_ will serve the install page at
+_www.example.com/slack/install_ but this path can be changed with
+`installerOptions.installPath`. Rendering a webpage before the authorization URL
+is also optional and can be skipped using `installerOptions.directInstall`.
 
-You will need to add the full **Redirect URL** including your app domain in your Slack [app settings][settings] under **OAuth and Permissions**, e.g. `https://example.com/slack/oauth_redirect`.
+Inspect this [example app][direct-install] and snippet below:
 
-To supply your own custom **Redirect URL**, you can set `redirectUri` in the App options and `installerOptions.redirectUriPath`. You must supply both, and the path must be consistent with the full URL.
+```javascript
+const app = new App({
+  signingSecret: process.env.SLACK_SIGNING_SECRET,
+  // ...
+  installerOptions: {
+    // highlight-start
+    directInstall: true,
+    installPath: "/slack/installations", // www.example.com/slack/installations
+    // highlight-end
+  },
+});
+```
+
+#### Add to Slack button
+
+The [default][add-to-slack] `Add to Slack` button initiates the OAuth process
+with Slack using a generated installation URL. If customizations are wanted to
+this page, changes can be made using
+[`installerOptions.renderHtmlForInstallPath`][installation-page] and the
+generated installation URL:
+
+```javascript
+const app = new App({
+  signingSecret: process.env.SLACK_SIGNING_SECRET,
+  // ...
+  installerOptions: {
+    // highlight-start
+    renderHtmlForInstallPath: (addToSlackUrl) => {
+      return `<a href="${addToSlackUrl}">Add to Slack</a>`;
+    },
+    // highlight-end
+  },
+});
+```
+
+We do recommend using the provided [button generator][oauth-v2] when formatting
+links to the authorization page!
+
+:::note
+
+Authorization requests with changed or additional scops require
+[generating a unique authorization URL](#extra-authorizations).
+
+:::
+
+### Redirect URL
+
+Bolt for JavaScript provides the **Redirect URL** path `/slack/oauth_redirect`
+out-of-the-box for Slack to use when redirecting users that complete the OAuth
+installation flow.
+
+You will need to add the full **Redirect URL** including your app domain in
+[app settings][settings] under **OAuth and Permissions**, e.g.
+`https://example.com/slack/oauth_redirect`.
+
+To supply a custom Redirect URL, you can set `redirectUri` in the App options
+and `installerOptions.redirectUriPath`. Both must be supplied and be consistent
+with the full URL if a custom Redirect URL is provided:
 
 ```javascript
 const app = new App({
@@ -77,18 +263,59 @@ const app = new App({
   clientSecret: process.env.SLACK_CLIENT_SECRET,
   stateSecret: "my-state-secret",
   scopes: ["chat:write"],
-  redirectUri: "https://example.com/slack/redirect", // here
+  // highlight-next-line
+  redirectUri: "https://example.com/slack/redirect",
   installerOptions: {
-    redirectUriPath: "/slack/redirect", // and here!
+    // highlight-next-line
+    redirectUriPath: "/slack/redirect",
   },
 });
 ```
 
----
+#### Custom callbacks
 
-## Installation object
+The page shown after OAuth is complete can be changed with
+`installerOptions.callbackOptions` to display different details:
 
-Bolt will pass your `installationStore`'s `storeInstallation` handler an `installation`. This can be a source of confusion for developers who aren't sure what shape of object to expect. The `installation` object should resemble:
+```javascript
+const app = new App({
+  signingSecret: process.env.SLACK_SIGNING_SECRET,
+  // ...
+  installerOptions: {
+    // highlight-start
+    callbackOptions: {
+      success: (installation, installOptions, req, res) => {
+        res.send("The installation succeeded!");
+      },
+      failure: (error, installOptions, req, res) => {
+        res.send("Something strange happened...");
+      },
+    },
+    // highlight-end
+  },
+});
+```
+
+Full reference reveals [these additional options][callback-options] but if no
+options are provided, the [`defaultCallbackSuccess`][callback-default-success]
+and [`defaultCallbackFailure`][callback-default-failure] are used.
+
+### Workspace installations
+
+Incoming installations are received after a successful OAuth process and must be
+stored for later lookup. This happens in the terms of installation objects and
+an installation store.
+
+The following outlines installations to individual workspaces with more
+[information on org-wide installations](#org-wide-installation) below.
+
+#### Installation objects
+
+##### The `installation` object
+
+Bolt passes an `installation` object to the `storeInstallation` method of your
+`installationStore` after each installation. When installing the app to a single
+workspace team, the `installation` object resembles the following:
 
 ```javascript
 {
@@ -110,7 +337,10 @@ Bolt will pass your `installationStore`'s `storeInstallation` handler an `instal
 }
 ```
 
-Bolt will pass your `fetchInstallation` and `deleteInstallation` handlers an `installQuery` object:
+##### The `installQuery` object
+
+Bolt also passes an `installQuery` object to your `fetchInstallation` and
+`deleteInstallation` handlers:
 
 ```javascript
 {
@@ -122,88 +352,39 @@ Bolt will pass your `fetchInstallation` and `deleteInstallation` handlers an `in
 }
 ```
 
----
+#### Installation store
 
-## Org-wide installation
+The `installation` object received above must be stored after installations for
+retrieval during lookup or removal during deletion using values from the
+`installQuery` object.
 
-To add support for [org-wide installations](https://api.slack.com/enterprise/apps), you will need Bolt for JavaScript version `3.0.0` or later. Make sure you have enabled org-wide installation in your app configuration settings under **Org Level Apps**.
-
-Installing an [org-wide](https://api.slack.com/enterprise/apps) app from admin pages requires additional configuration to work with Bolt. In that scenario, the recommended `state` parameter is not supplied. Bolt will try to verify `state` and stop the installation from progressing.
-
-You may disable state verification in Bolt by setting the `stateVerification` option to false. See the example setup below:
+An [installation store][store] implements the handlers `storeInstallation`,
+`fetchInstallation`, and `deleteInstallation` for each part of this process. The
+following implements a simple installation store in memory, but persistent
+storage is strongly recommended for production:
 
 ```javascript
 const app = new App({
   signingSecret: process.env.SLACK_SIGNING_SECRET,
   clientId: process.env.SLACK_CLIENT_ID,
   clientSecret: process.env.SLACK_CLIENT_SECRET,
-  scopes: ["chat:write"],
-  installerOptions: {
-    stateVerification: false,
-  },
-});
-```
-
-To learn more about the OAuth installation flow with Slack, [read the API documentation](https://api.slack.com/authentication/oauth-v2).
-
-```javascript
-const database = {
-  async get(key) {},
-  async delete(key) {},
-  async set(key, value) {},
-};
-
-const app = new App({
-  signingSecret: process.env.SLACK_SIGNING_SECRET,
-  clientId: process.env.SLACK_CLIENT_ID,
-  clientSecret: process.env.SLACK_CLIENT_SECRET,
-  stateSecret: "my-secret",
+  stateSecret: "my-state-secret",
   scopes: ["chat:write", "commands"],
   installationStore: {
     storeInstallation: async (installation) => {
-      // Bolt will pass your handler an installation object
-      // Change the lines below so they save to your database
-      if (
-        installation.isEnterpriseInstall &&
-        installation.enterprise !== undefined
-      ) {
-        // handle storing org-wide app installation
-        return await database.set(installation.enterprise.id, installation);
-      }
       if (installation.team !== undefined) {
-        // single team app installation
         return await database.set(installation.team.id, installation);
       }
-      throw new Error("Failed saving installation data to installationStore");
+      throw new Error("Failed to save installation data to installationStore");
     },
     fetchInstallation: async (installQuery) => {
-      // Bolt will pass your handler an installQuery object
-      // Change the lines below so they fetch from your database
-      if (
-        installQuery.isEnterpriseInstall &&
-        installQuery.enterpriseId !== undefined
-      ) {
-        // handle org wide app installation lookup
-        return await database.get(installQuery.enterpriseId);
-      }
       if (installQuery.teamId !== undefined) {
-        // single team app installation lookup
         return await database.get(installQuery.teamId);
       }
-      throw new Error("Failed fetching installation");
+      throw new Error("Failed to fetch installation");
     },
     deleteInstallation: async (installQuery) => {
-      // Bolt will pass your handler  an installQuery object
-      // Change the lines below so they delete from your database
-      if (
-        installQuery.isEnterpriseInstall &&
-        installQuery.enterpriseId !== undefined
-      ) {
-        // org wide app installation deletion
-        return await database.delete(installQuery.enterpriseId);
-      }
       if (installQuery.teamId !== undefined) {
-        // single team app installation deletion
         return await database.delete(installQuery.teamId);
       }
       throw new Error("Failed to delete installation");
@@ -212,71 +393,314 @@ const app = new App({
 });
 ```
 
+Lookups for `fetchInstallation` happen as part of the built-in
+[`authorization`][authorization] of incoming events and provides app listeners
+with the `context.botToken` for convenient use.
+
+<details>
+  <summary>Example database object</summary>
+
+For quick testing purposes, the following might be interesting:
+
+```javascript
+const database = {
+  store: {},
+  async get(key) {
+    return this.store[key];
+  },
+  async delete(key) {
+    delete this.store[key];
+  },
+  async set(key, value) {
+    this.store[key] = value;
+  },
+};
+```
+
+</details>
+
 ---
 
-## Customizing OAuth defaults
+## Additional cases
 
-We provide several options for customizing default OAuth using the `installerOptions` object, which can be passed in during the initialization of `App`. You can override the following:
+The above sections set your app up for collecting a bot token on workspace
+installations with handfuls of configuration, but other cases might still be
+explored.
 
-- `authVersion`: Used to toggle between new Slack Apps and Classic Slack Apps
-- `metadata`: Used to pass around session related information
-- `installPath`: Override default path for "Add to Slack" button
-- `redirectUriPath`: This relative path must match the `redirectUri` provided in the App options
-- `callbackOptions`: Provide custom success and failure pages at the end of the OAuth flow
-- `stateStore`: Provide a custom state store instead of using the built in `ClearStateStore`
-- `userScopes`: Array of user scopes needed when the user installs the app, similar to `scopes` attribute at the parent level.
+### User tokens
+
+User tokens represent workspace members and can be used to
+[take action on behalf of users][user-tokens]. Requesting user scopes during
+installation is required for these tokens to be issued:
 
 ```javascript
 const app = new App({
   signingSecret: process.env.SLACK_SIGNING_SECRET,
   clientId: process.env.SLACK_CLIENT_ID,
   clientSecret: process.env.SLACK_CLIENT_SECRET,
-  scopes: [
-    "channels:manage",
-    "channels:read",
-    "chat:write",
-    "groups:read",
-    "incoming-webhook",
-  ],
+  scopes: ["chat:write", "channels:history"],
   installerOptions: {
-    authVersion: "v1", // default  is 'v2', 'v1' is used for classic slack apps
-    metadata: "some session data",
-    installPath: "/slack/installApp",
-    redirectUriPath: "/slack/redirect",
     userScopes: ["chat:write"],
-    callbackOptions: {
-      success: (installation, installOptions, req, res) => {
-        // Do custom success logic here
-        res.send("successful!");
-      },
-      failure: (error, installOptions, req, res) => {
-        // Do custom failure logic here
-        res.send("failure");
-      },
-    },
-    stateStore: {
-      // Do not need to provide a `stateSecret` when passing in a stateStore
-      // generateStateParam's first argument is the entire InstallUrlOptions object which was passed into generateInstallUrl method
-      // the second argument is a date object
-      // the method is expected to return a string representing the state
-      generateStateParam: async (installUrlOptions, date) => {
-        // generate a random string to use as state in the URL
-        const randomState = randomStringGenerator();
-        // save installOptions to cache/db
-        await myDB.set(randomState, installUrlOptions);
-        // return a state string that references saved options in DB
-        return randomState;
-      },
-      // verifyStateParam's first argument is a date object and the second argument is a string representing the state
-      // verifyStateParam is expected to return an object representing installUrlOptions
-      verifyStateParam: async (date, state) => {
-        // fetch saved installOptions from DB using state reference
-        const installUrlOptions = await myDB.get(randomState);
-        return installUrlOptions;
-      },
-    },
   },
 });
 ```
 
+Most OAuth processes remain the same, but the
+[`installation`](#the-installation-object) object received in
+`storeInstallation` has a `user` attribute that should be stored too:
+
+```javascript
+{
+  team: { id: "T012345678", name: "example-team-name" },
+  user: {
+    token: "xoxp-314159-26*********-********************",
+    scopes: ["chat:write"],
+    id: "U01234567"
+  },
+  tokenType: "bot",
+  appId: "A01234567",
+  // ...
+}
+```
+
+Successful `fetchInstallation` lookups will also include the `context.userToken`
+associated with the received event in the app listener arguments.
+
+:::note
+
+The `tokenType` remains `"bot"` while `scopes` are requested, even with the
+included `userScopes`. This suggests `bot` details exist, and is `undefined`
+along with the `bot` if no bot `scopes` are requested.
+
+:::
+
+### Org-wide installations
+
+To add support for [org-wide installations][org-ready], you will need Bolt for
+JavaScript version `3.0.0` or later. Make sure you have enabled org-wide
+installation in your app configuration settings under **Org Level Apps**.
+
+#### Admin installation state verficiation
+
+Installing an [org-wide](https://api.slack.com/enterprise/apps) app from admin
+pages requires additional configuration to work with Bolt. In that scenario, the
+recommended `state` parameter is not supplied. Bolt will try to verify `state`
+and stop the installation from progressing.
+
+You may disable state verification in Bolt by setting the `stateVerification`
+option to false. See the example setup below:
+
+```javascript
+const app = new App({
+  signingSecret: process.env.SLACK_SIGNING_SECRET,
+  clientId: process.env.SLACK_CLIENT_ID,
+  clientSecret: process.env.SLACK_CLIENT_SECRET,
+  scopes: ["chat:write"],
+  installerOptions: {
+    // highlight-next-line
+    stateVerification: false,
+  },
+});
+```
+
+To learn more about the OAuth installation flow with org-wide apps,
+[read the API documentation][org-ready-oauth].
+
+#### Org-wide installation objects
+
+Being installed to an organization can grant your app access to multiple
+workspaces and the associated events.
+
+##### The org-wide `installation` object
+
+The `installation` object from installations to a team in an organization have
+an additional `enterprise` object and `isEnterpriseInstall` set to either `true`
+or `false`:
+
+```javascript
+{
+  team: undefined,
+  enterprise: { id: "E0000000001", name: "laboratories" },
+  user: { token: undefined, scopes: undefined, id: "U0000000001" },
+  tokenType: "bot",
+  isEnterpriseInstall: true,
+  appId: "A0000000001",
+  authVersion: "v2",
+  bot: {
+    scopes: [
+      "chat:write",
+    ],
+    token: "xoxb-000001-00*********-********************",
+    userId: "U0000000002",
+    id: "B0000000001"
+  }
+}
+```
+
+Apps installed org-wide will receive `isEnterpriseInstall` as `true`, but apps
+could also still be installed to individual workspaces in organizations. These
+apps receive installation information for both the `team` and `enterprise`:
+
+```javascript
+{
+  team: { id: "T0000000001", name: "experimental-sandbox" },
+  enterprise: { id: "E0000000001", name: "laboratories" },
+  // ...
+  isEnterpriseInstall: false,
+  // ...
+}
+```
+
+##### The org-wide `installQuery` object
+
+This `installQuery` object provided to the `fetchInstallation` and
+`deleteInstallation` handlers is familiar but with an `enterpriseId` defined and
+another possible `true` or `false` value for `isEnterpriseInstall`:
+
+```javascript
+{
+  userId: "U0000000001",
+  isEnterpriseInstall: true,
+  teamId: "T0000000001",
+  enterpriseId: "E0000000001",
+  conversationId: "D0000000001"
+}
+```
+
+#### Org-wide installation store
+
+Storing and retrieving installations from an installation store requires similar
+handling as before, but with additional checks for org-wide installations of
+org-ready apps:
+
+```javascript
+const app = new App({
+  signingSecret: process.env.SLACK_SIGNING_SECRET,
+  clientId: process.env.SLACK_CLIENT_ID,
+  clientSecret: process.env.SLACK_CLIENT_SECRET,
+  stateSecret: "my-state-secret",
+  scopes: ["chat:write", "commands"],
+  // highlight-start
+  installationStore: {
+    storeInstallation: async (installation) => {
+      if (
+        installation.isEnterpriseInstall &&
+        installation.enterprise !== undefined
+      ) {
+        return await database.set(installation.enterprise.id, installation);
+      }
+      if (installation.team !== undefined) {
+        return await database.set(installation.team.id, installation);
+      }
+      throw new Error("Failed to save installation data to installationStore");
+    },
+    fetchInstallation: async (installQuery) => {
+      if (
+        installQuery.isEnterpriseInstall &&
+        installQuery.enterpriseId !== undefined
+      ) {
+        return await database.get(installQuery.enterpriseId);
+      }
+      if (installQuery.teamId !== undefined) {
+        return await database.get(installQuery.teamId);
+      }
+      throw new Error("Failed to fetch installation");
+    },
+    deleteInstallation: async (installQuery) => {
+      if (
+        installQuery.isEnterpriseInstall &&
+        installQuery.enterpriseId !== undefined
+      ) {
+        return await database.delete(installQuery.enterpriseId);
+      }
+      if (installQuery.teamId !== undefined) {
+        return await database.delete(installQuery.teamId);
+      }
+      throw new Error("Failed to delete installation");
+    },
+  },
+  // highlight-end
+});
+```
+
+<details>
+  <summary>Example database object</summary>
+
+For quick testing purposes, the following might be interesting:
+
+```javascript
+const database = {
+  store: {},
+  async get(key) {
+    return this.store[key];
+  },
+  async delete(key) {
+    delete this.store[key];
+  },
+  async set(key, value) {
+    this.store[key] = value;
+  },
+};
+```
+
+</details>
+
+### Sign in with Slack
+
+Right now Bolt does not support [Sign in with Slack][siws] out-of-the-box. This
+still continues to remain an option using APIs from the
+[`@slack/web-api`][web-api] package, which aim to make implementing OpenID
+Connect (OIDC) connections simple. Alternative [routes][custom-routes] might be
+required.
+
+Explore [this relevant package documentation][oidc] for reference and example.
+
+### Extra authorizations
+
+If you need additional authorizations, such as user tokens from users of a team
+where your app is already installed, or have a reason to dynamically generate an
+install URL, an additional installation is required.
+
+Generating a new installation URL requires a few steps: manually instantiate an
+`ExpressReceiver`, assign the instance to a variable named `receiver`, and then
+call `receiver.installer.generateInstallUrl()`.
+
+Read more about `generateInstallUrl()` in the
+[OAuth docs][generate-install-url].
+
+### Common errors
+
+Occasional mishaps in various places throughout the OAuth process can cause
+errors, but these often have meaning! Explore [the API documentation][errors]
+for additional details for common error codes.
+
+[add-to-slack]: https://github.com/slackapi/node-slack-sdk/blob/main/packages/oauth/src/default-render-html-for-install-path.ts
+[authorization]: /concepts/authorization
+[callback-default-failure]: https://github.com/slackapi/node-slack-sdk/blob/e5a4f3fbbd4f6aad9fdd415976f80668b01fd442/packages/oauth/src/callback-options.ts#L127-L162
+[callback-default-success]: https://github.com/slackapi/node-slack-sdk/blob/e5a4f3fbbd4f6aad9fdd415976f80668b01fd442/packages/oauth/src/callback-options.ts#L81-L125
+[callback-options]: https://slack.dev/node-slack-sdk/reference/oauth/interfaces/CallbackOptions
+[callback-options-default]: https://github.com/slackapi/node-slack-sdk/blob/e5a4f3fbbd4f6aad9fdd415976f80668b01fd442/packages/oauth/src/callback-options.ts#L81-L162
+[callbacks]: https://slack.dev/node-slack-sdk/reference/oauth/interfaces/CallbackOptions
+[custom-routes]: /concepts/custom-routes
+[direct-install]: https://github.com/slackapi/bolt-js/blob/5b4d9ceb65e6bf5cf29dfa58268ea248e5466bfb/examples/oauth/app.js#L58-L64
+[errors]: https://api.slack.com/authentication/oauth-v2#errors
+[examples]: https://github.com/slackapi/bolt-js/tree/main/examples/oauth
+[generate-install-url]: https://slack.dev/node-slack-sdk/oauth/#showing-an-installation-page
+[install-provider-options]: https://github.com/slackapi/node-slack-sdk/blob/main/packages/oauth/src/install-provider-options.ts
+[installation]: https://github.com/slackapi/node-slack-sdk/blob/main/packages/oauth/src/default-render-html-for-install-path.ts
+[installation-page]: https://slack.dev/node-slack-sdk/oauth/#showing-an-installation-page
+[oauth-node]: https://slack.dev/node-slack-sdk/oauth
+[oauth-v2]: https://api.slack.com/authentication/oauth-v2
+[oidc]: https://slack.dev/node-slack-sdk/web-api#sign-in-with-slack-via-openid-connect
+[org-ready]: https://api.slack.com/enterprise/org-ready-apps
+[org-ready-oauth]: https://api.slack.com/enterprise/org-ready-apps#oauth
+[scopes]: https://api.slack.com/scopes
 [settings]: https://api.slack.com/apps
+[siws]: https://api.slack.com/authentication/sign-in-with-slack
+[state]: https://slack.dev/node-slack-sdk/oauth#using-a-custom-state-store
+[state-clear]: https://github.com/slackapi/node-slack-sdk/blob/main/packages/oauth/src/state-stores/clear-state-store.ts
+[store]: https://slack.dev/node-slack-sdk/oauth#storing-installations-in-a-database
+[store-file-installation]: https://github.com/slackapi/node-slack-sdk/blob/main/packages/oauth/src/installation-stores/file-store.ts
+[user-tokens]: https://api.slack.com/concepts/token-types#user
+[verification]: https://slack.dev/node-slack-sdk/oauth#state-verification
+[web-api]: https://slack.dev/node-slack-sdk/web-api

--- a/docs/content/basic/authenticating-oauth.md
+++ b/docs/content/basic/authenticating-oauth.md
@@ -4,10 +4,7 @@ lang: en
 slug: /concepts/authenticating-oauth
 ---
 
-OAuth allows installation of your app to any workspace and is an important step
-in distributing your app. For each completed authentication process, you receive
-unique [access tokens and related information](#the-installation-object) that
-can be retrieved for incoming events and used to make scoped API requests.
+OAuth allows installation of your app to any workspace and is an important step in distributing your app. For each completed authentication process, you receive unique [access tokens and related information](#the-installation-object) that can be retrieved for incoming events and used to make scoped API requests.
 
 All of the additional underlying details around authentications can be found
 within [the Slack API documentation][oauth-v2]!

--- a/docs/content/basic/authenticating-oauth.md
+++ b/docs/content/basic/authenticating-oauth.md
@@ -48,7 +48,7 @@ You can skip rendering the provided default webpage and navigate users directly 
 
 :::
 
-- **Add to Slack**: The `Add to Slack` button initiates the OAuth process with Slack. After users have clicked Allow to grant your app permissions, Slack will call your app's **Redirect URI** (provided out-of-the-box), and prompt users to **Open Slack**. See the **Redirect URI** section below for customization options.
+- **Add to Slack**: The `Add to Slack` button initiates the OAuth process with Slack. After users have clicked Allow to grant your app permissions, Slack will call your app's **Redirect URL** (provided out-of-the-box), and prompt users to **Open Slack**. Read the [**Redirect URL**](#redirect-url) section for customization options.
 
 - **Open Slack**: After users **Open Slack**, and here after as your app processes events from Slack, your provided `installationStore`'s `fetchInstallation` and `storeInstallation` handlers will execute. See the **Installation Object** section below for more detail on arguments passed to those handlers.
 
@@ -62,13 +62,13 @@ Bolt for JavaScript does not support OAuth for [custom receivers](/concepts/rece
 
 ---
 
-## Redirect URI
+## Redirect URL
 
-Bolt for JavaScript provides a **Redirect URI Path** `/slack/oauth_redirect`. Slack uses the Redirect URI to redirect users after they complete an app's installation flow.
+Bolt for JavaScript provides a **Redirect URL Path** `/slack/oauth_redirect`. Slack uses the Redirect URL to redirect users after they complete an app's installation flow.
 
-You will need to add the full **Redirect URI** including your app domain in your Slack app configuration settings under **OAuth and Permissions**, e.g. `https://example.com/slack/oauth_redirect`.
+You will need to add the full **Redirect URL** including your app domain in your Slack [app settings][settings] under **OAuth and Permissions**, e.g. `https://example.com/slack/oauth_redirect`.
 
-To supply your own custom **Redirect URI**, you can set `redirectUri` in the App options and `installerOptions.redirectUriPath`. You must supply both, and the path must be consistent with the full URI.
+To supply your own custom **Redirect URL**, you can set `redirectUri` in the App options and `installerOptions.redirectUriPath`. You must supply both, and the path must be consistent with the full URL.
 
 ```javascript
 const app = new App({
@@ -281,4 +281,5 @@ const app = new App({
 ```
 
 </details>
+[settings]: https://api.slack.com/apps
 

--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -25,6 +25,7 @@
   --slack-dark-blue: #1264a3;
 
   --grey: #868686;
+  --dim: #eef2f6;
   --white: #ffffff;
 }
 
@@ -44,6 +45,7 @@ p a {
 
 /* adjusting for light and dark modes */
 [data-theme="light"] {
+  --docusaurus-highlighted-code-line-bg: var(--dim);
   --ifm-color-primary: var(--aubergine-active);
   --ifm-footer-background-color: var(--horchata);
   --slack-link: var(--slack-dark-blue);

--- a/examples/oauth/app.js
+++ b/examples/oauth/app.js
@@ -3,10 +3,13 @@ const { App, LogLevel } = require('@slack/bolt');
 const databaseData = {};
 const database = {
   set: async (key, data) => {
-    databaseData[key] = data
+    databaseData[key] = data;
   },
   get: async (key) => {
     return databaseData[key];
+  },
+  delete: async (key) => {
+    delete databaseData[key];
   },
 };
 


### PR DESCRIPTION
### Summary

This PR updates the OAuth installation docs to include a bit more detail on configuration options and common cases. Kinda hoping this can be a solid reference page for Bolt developers with enough linking to additional resources to be dangerous 😈 ⚡

Fixes: #2215. But some other notable changes might include:

- Quick reference of available app and installer options
- Reference for various `installation` objects
- Hints at finding and adjusting default installation pages and routes
- Details around requesting and processing user tokens
- Limitations around Sign in with Slack and a suggested workaround
- Common API errors found throughout authentications

### Reviewers

Checkout this branch and read the changes!

```sh
$ cd docs
$ npm install
$ npm start
$ open http://localhost:3000/bolt-js/concepts/authenticating-oauth
```

### Notes

- The included snippets were tested throughout various cases, but I couldn't get the final "extra authorizations" concept to work well with the state store...
- Markdown formatting from `deno fmt` was applied to this file for easier future edits - open to reverting this!

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).