### PR TITLE
fix: remove please-upgrade-node

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "axios": "^1.7.4",
     "express": "^4.16.4",
     "path-to-regexp": "^6.2.1",
-    "please-upgrade-node": "^3.2.0",
     "promise.allsettled": "^1.0.2",
     "raw-body": "^2.3.3",
     "tsscmp": "^1.0.6"

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,3 @@
-import pleaseUpgradeNode from 'please-upgrade-node';
-// eslint-disable-next-line @typescript-eslint/no-require-imports
-const packageJson = require('../package.json'); // eslint-disable-line @typescript-eslint/no-var-requires, import/no-commonjs
-
-pleaseUpgradeNode(packageJson);
-
 export {
   default as App,
   AppOptions,


### PR DESCRIPTION
fixes #1274

Instead of pulling in an extra dependency to massage node version incompatibilities, I say we just rely on the node/npm tooling (in particular: the `engines` property of `package.json`) to do that work for us. Would help us in fixing issues like #1274 (people using weird bundlers and deploying to constrained runtimes).