### PR TITLE
chore: group docusaurus dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,3 +16,11 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+  - package-ecosystem: "npm"
+    directory: "/docs"
+    schedule:
+      interval: "monthly"
+    groups:
+      docusaurus:
+        patterns:
+          - "@docusaurus/*"


### PR DESCRIPTION
### Summary

This PR introduces the same dependabot configuration for the `docs/` directory as [bolt-python in #1155](https://github.com/slackapi/bolt-python/pull/1155)

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).