### PR TITLE
ci: add typescript example integration testing

### DIFF
--- a/.github/workflows/samples.yml
+++ b/.github/workflows/samples.yml
@@ -7,6 +7,27 @@ on:
   pull_request:
 
 jobs:
+  examples:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [18.x, 20.x, 22.x]
+        example:
+          - examples/getting-started-typescript
+    steps:
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+      - uses: actions/checkout@v4
+      - name: Link bolt-js
+        run: npm link .
+      - name: Install example dependencies and link bolt-js
+        working-directory: ${{ matrix.example }}
+        run: npm i && npm link @slack/bolt
+      - name: Compile sample
+        working-directory: ${{ matrix.example }}
+        run: npm run build
   samples:
     runs-on: ubuntu-latest
     strategy:
@@ -15,7 +36,6 @@ jobs:
         sample:
           - slack-samples/bolt-ts-starter-template
           - slack-samples/bolt-ts-custom-function-template
-
     steps:
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4

--- a/.github/workflows/samples.yml
+++ b/.github/workflows/samples.yml
@@ -20,8 +20,8 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - uses: actions/checkout@v4
-      - name: Link bolt-js
-        run: npm link .
+      - name: Install dependencies and link bolt-js
+        run: npm i && npm link .
       - name: Install example dependencies and link bolt-js
         working-directory: ${{ matrix.example }}
         run: npm i && npm link @slack/bolt

--- a/examples/getting-started-typescript/src/app.ts
+++ b/examples/getting-started-typescript/src/app.ts
@@ -44,7 +44,9 @@ app.message('hello', async ({ message, say }) => {
 app.action('button_click', async ({ body, ack, say }) => {
   // Acknowledge the action
   await ack();
-  await say(`<@${body.user.id}> clicked the button`);
+  // we know that this event comes from a button click from a message in a channel, so `say` will be available.
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+  await say!(`<@${body.user.id}> clicked the button`);
 });
 
 (async () => {

--- a/examples/getting-started-typescript/src/basic.ts
+++ b/examples/getting-started-typescript/src/basic.ts
@@ -88,7 +88,7 @@ const whenSeptemberEnds = '1569887999';
 app.message('wake me up', async ({ message, client, logger }) => {
   try {
     // Call chat.scheduleMessage with the built-in client
-    const result = await client.chat.scheduleMessage({
+    await client.chat.scheduleMessage({
       channel: message.channel,
       post_at: whenSeptemberEnds,
       text: 'Summer has come and passed',
@@ -131,7 +131,11 @@ app.action<BlockAction>({ action_id: 'select_user', block_id: 'assign_ticket' },
 app.action('approve_button', async ({ ack, say }) => {
   // Acknowledge action request
   await ack();
-  await say('Request approved 👍');
+  // `say` is possibly undefined because an action could come from a surface where we cannot post message, e.g. a view.
+  // we will use a non-null assertion (!) to tell TypeScript to ignore the fact it may be undefined,
+  // but take care about the originating surface for these events when using these utilities!
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+  await say!('Request approved 👍');
 });
 
 (async () => {


### PR DESCRIPTION
start with the typescript sample to begin, fix up getting started typescript sample to get rid of TSC compilation errors.

Relates to https://github.com/slackapi/bolt-js/issues/2233