### PR TITLE
Link to JS release notes

### DIFF
--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -95,7 +95,7 @@ const sidebars = {
     {
       type: 'link',
       label: 'Release notes',
-      href: 'https://github.com/slackapi/bolt-python/releases',
+      href: 'https://github.com/slackapi/bolt-js/releases',
     },
     {
       type: 'link',


### PR DESCRIPTION
### Summary

Fixes release notes link in documentation.  JavaScript documentation should link to bolt-js release notes, not bolt-python release notes.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).