### PR TITLE
Fix #2242 by upgrading express and its dependencies to newer major versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,8 +50,8 @@
     "@types/promise.allsettled": "^1.0.3",
     "@types/tsscmp": "^1.0.0",
     "axios": "^1.7.4",
-    "express": "^4.16.4",
-    "path-to-regexp": "^6.2.1",
+    "express": "^5.0.0",
+    "path-to-regexp": "^8.1.0",
     "promise.allsettled": "^1.0.2",
     "raw-body": "^2.3.3",
     "tsscmp": "^1.0.6"

--- a/src/receivers/ExpressReceiver.spec.ts
+++ b/src/receivers/ExpressReceiver.spec.ts
@@ -529,7 +529,7 @@ describe('ExpressReceiver', function () {
         // Act
         const req = { body: { }, url: 'http://localhost/slack/oauth_redirect', method: 'GET' } as Request;
         const resp = { send: () => { } } as Response;
-        (receiver.router as any).handle(req, resp);
+        (receiver.router as any).handle(req, resp, () => {});
 
         // Assert
         assert(handleStub.calledWith(req, resp, callbackOptions), 'installer.handleCallback not called');
@@ -552,7 +552,7 @@ describe('ExpressReceiver', function () {
         // Act
         const req = { body: { }, url: 'http://localhost/slack/oauth_redirect', method: 'GET' } as Request;
         const resp = { send: () => { } } as Response;
-        (receiver.router as any).handle(req, resp);
+        (receiver.router as any).handle(req, resp, () => {});
 
         // Assert
         assert(handleStub.calledWith(req, resp, callbackOptions, sinon.match({ scopes })), 'installer.handleCallback not called');


### PR DESCRIPTION
### Summary

This pull request could resolve #2242 but it's not an ideal solution for us. This change forces existing ExpressReceiever users to migrate to Express v5 immediately. To reviewers: read #2242 for context.

Even if we don't do this, **migrating path-to-regexp to v8 must be done as early as possible.**

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).