### PR TITLE
chore(deps): bump @slack/web-api from 6.12.1 to 6.13.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@slack/oauth": "^2.6.3",
     "@slack/socket-mode": "^1.3.6",
     "@slack/types": "^2.13.0",
-    "@slack/web-api": "^6.12.1",
+    "@slack/web-api": "^6.13.0",
     "@types/express": "^4.16.1",
     "@types/promise.allsettled": "^1.0.3",
     "@types/tsscmp": "^1.0.0",


### PR DESCRIPTION
### Summary

This PR bumps `@slack/web-api` from `6.12.1` to `6.13.0` to include changes released with `@slack/web-api@6.13.0` in code using the latest `@slack/bolt` 🚀

Marking it as a `semver:minor` to avoid strangeness with cached dependencies and new changes, and will soon follow up with a release if that sounds right!

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).