### PR TITLE
Fix a bug where parsing assistant thread message event fails for beta feature enabled apps

### DIFF
--- a/src/Assistant.ts
+++ b/src/Assistant.ts
@@ -375,7 +375,11 @@ export function extractThreadInfo(payload: AllAssistantMiddlewareArgs['payload']
   let context: AssistantThreadContext = {};
 
   // assistant_thread_started, asssistant_thread_context_changed
-  if ('assistant_thread' in payload) {
+  if (
+    'assistant_thread' in payload &&
+    'channel_id' in payload.assistant_thread &&
+    'thread_ts' in payload.assistant_thread
+  ) {
     channelId = payload.assistant_thread.channel_id;
     threadTs = payload.assistant_thread.thread_ts;
     context = payload.assistant_thread.context;


### PR DESCRIPTION
This pull request resolves a bug where parsing assistant thread message event fails for beta feature enabled apps.
See also: https://github.com/slackapi/bolt-python/pull/1184

### Summary

Describe the goal of this PR. Mention any related Issue numbers.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).