### PR TITLE
[FIX]: Include metadata with Assistant `say` util

### DIFF
--- a/src/Assistant.ts
+++ b/src/Assistant.ts
@@ -3,6 +3,7 @@ import type {
   AssistantThreadsSetSuggestedPromptsResponse,
   AssistantThreadsSetTitleResponse,
   ChatPostMessageArguments,
+  MessageMetadataEventPayloadObject,
 } from '@slack/web-api';
 import {
   type AssistantThreadContext,
@@ -132,7 +133,7 @@ export class Assistant {
 
   private async processEvent(args: AllAssistantMiddlewareArgs): Promise<void> {
     const { payload } = args;
-    const assistantArgs = enrichAssistantArgs(this.threadContextStore, args);
+    const assistantArgs = await enrichAssistantArgs(this.threadContextStore, args);
     const assistantMiddleware = this.getAssistantMiddleware(payload);
     return processAssistantMiddleware(assistantArgs, assistantMiddleware);
   }
@@ -160,10 +161,10 @@ export class Assistant {
  *  events from continuing down the global middleware chain to subsequent listeners
  *  2. Adds assistant-specific utilities (i.e., helper methods)
  * */
-export function enrichAssistantArgs(
+export async function enrichAssistantArgs(
   threadContextStore: AssistantThreadContextStore,
   args: AllAssistantMiddlewareArgs<AssistantMiddlewareArgs>, // TODO: the type here states that these args already have the assistant utilities present? the type here needs likely changing.
-): AllAssistantMiddlewareArgs {
+): Promise<AllAssistantMiddlewareArgs> {
   const { next: _next, ...assistantArgs } = args;
   const preparedArgs = { ...(assistantArgs as Exclude<AllAssistantMiddlewareArgs<AssistantMiddlewareArgs>, 'next'>) };
 
@@ -171,7 +172,7 @@ export function enrichAssistantArgs(
   preparedArgs.getThreadContext = () => threadContextStore.get(args);
   preparedArgs.saveThreadContext = () => threadContextStore.save(args);
 
-  preparedArgs.say = createSay(preparedArgs);
+  preparedArgs.say = await createSay(preparedArgs);
   preparedArgs.setStatus = createSetStatus(preparedArgs);
   preparedArgs.setSuggestedPrompts = createSetSuggestedPrompts(preparedArgs);
   preparedArgs.setTitle = createSetTitle(preparedArgs);
@@ -299,13 +300,19 @@ export async function processAssistantMiddleware(
  * was received. Alias for `postMessage()`.
  * https://api.slack.com/methods/chat.postMessage
  */
-function createSay(args: AllAssistantMiddlewareArgs): SayFn {
+async function createSay(args: AllAssistantMiddlewareArgs): Promise<SayFn> {
   const { client, payload } = args;
-  const { channelId: channel, threadTs: thread_ts } = extractThreadInfo(payload);
+  const { channelId: channel, threadTs: thread_ts, context } = extractThreadInfo(payload);
+  const threadContext = context.channel_id ? context : await args.getThreadContext(args);
 
   return (message: Parameters<SayFn>[0]) => {
     const postMessageArgument: ChatPostMessageArguments =
       typeof message === 'string' ? { text: message, channel, thread_ts } : { ...message, channel, thread_ts };
+
+    postMessageArgument.metadata = {
+      event_type: 'assistant_thread_context',
+      event_payload: threadContext as MessageMetadataEventPayloadObject,
+    };
 
     return client.chat.postMessage(postMessageArgument);
   };

--- a/test/unit/Assistant.spec.ts
+++ b/test/unit/Assistant.spec.ts
@@ -354,6 +354,9 @@ describe('Assistant class', () => {
           const { enrichAssistantArgs } = await importAssistant();
           const threadStartedArgs = enrichAssistantArgs(mockThreadContextStore, mockThreadStartedArgs);
 
+          // Verify that get is not called prior to say being used
+          sinon.assert.notCalled(mockThreadContextStore.get);
+
           await threadStartedArgs.say('Say called!');
 
           sinon.assert.calledOnce(mockThreadContextStore.get);

--- a/test/unit/Assistant.spec.ts
+++ b/test/unit/Assistant.spec.ts
@@ -194,12 +194,9 @@ describe('Assistant class', () => {
 
         const { enrichAssistantArgs } = await importAssistant();
 
-        const threadStartedArgs = await enrichAssistantArgs(mockThreadContextStore, mockThreadStartedArgs);
-        const threadContextChangedArgs = await enrichAssistantArgs(
-          mockThreadContextStore,
-          mockThreadContextChangedArgs,
-        );
-        const userMessageArgs = await enrichAssistantArgs(mockThreadContextStore, mockUserMessageArgs);
+        const threadStartedArgs = enrichAssistantArgs(mockThreadContextStore, mockThreadStartedArgs);
+        const threadContextChangedArgs = enrichAssistantArgs(mockThreadContextStore, mockThreadContextChangedArgs);
+        const userMessageArgs = enrichAssistantArgs(mockThreadContextStore, mockUserMessageArgs);
 
         assert.notExists(threadStartedArgs.next);
         assert.notExists(threadContextChangedArgs.next);
@@ -211,7 +208,7 @@ describe('Assistant class', () => {
         const mockThreadContextStore = createMockThreadContextStore();
         const { enrichAssistantArgs } = await importAssistant();
         // TODO: enrichAssistantArgs likely needs a different argument type, as AssistantMiddlewareArgs type already has the assistant utility enrichments present.
-        const assistantArgs = await enrichAssistantArgs(mockThreadContextStore, {
+        const assistantArgs = enrichAssistantArgs(mockThreadContextStore, {
           payload,
         } as AllAssistantMiddlewareArgs);
 
@@ -226,7 +223,7 @@ describe('Assistant class', () => {
         const mockThreadContextStore = createMockThreadContextStore();
         const { enrichAssistantArgs } = await importAssistant();
         // TODO: enrichAssistantArgs likely needs a different argument type, as AssistantMiddlewareArgs type already has the assistant utility enrichments present.
-        const assistantArgs = await enrichAssistantArgs(mockThreadContextStore, {
+        const assistantArgs = enrichAssistantArgs(mockThreadContextStore, {
           payload,
         } as AllAssistantMiddlewareArgs);
 
@@ -241,7 +238,7 @@ describe('Assistant class', () => {
         const mockThreadContextStore = createMockThreadContextStore();
         const { enrichAssistantArgs } = await importAssistant();
         // TODO: enrichAssistantArgs likely needs a different argument type, as AssistantMiddlewareArgs type already has the assistant utility enrichments present.
-        const assistantArgs = await enrichAssistantArgs(mockThreadContextStore, {
+        const assistantArgs = enrichAssistantArgs(mockThreadContextStore, {
           payload,
         } as AllAssistantMiddlewareArgs);
 
@@ -308,7 +305,7 @@ describe('Assistant class', () => {
           const mockThreadContextStore = createMockThreadContextStore();
 
           const { enrichAssistantArgs } = await importAssistant();
-          const threadStartedArgs = await enrichAssistantArgs(mockThreadContextStore, mockThreadStartedArgs);
+          const threadStartedArgs = enrichAssistantArgs(mockThreadContextStore, mockThreadStartedArgs);
 
           await threadStartedArgs.say('Say called!');
 
@@ -323,7 +320,7 @@ describe('Assistant class', () => {
           const mockThreadContextStore = createMockThreadContextStore();
 
           const { enrichAssistantArgs } = await importAssistant();
-          const threadStartedArgs = await enrichAssistantArgs(mockThreadContextStore, mockThreadStartedArgs);
+          const threadStartedArgs = enrichAssistantArgs(mockThreadContextStore, mockThreadStartedArgs);
 
           await threadStartedArgs.say('Say called!');
 
@@ -355,7 +352,7 @@ describe('Assistant class', () => {
           const mockThreadContextStore = { save: sinon.spy(), get: sinon.spy() };
 
           const { enrichAssistantArgs } = await importAssistant();
-          const threadStartedArgs = await enrichAssistantArgs(mockThreadContextStore, mockThreadStartedArgs);
+          const threadStartedArgs = enrichAssistantArgs(mockThreadContextStore, mockThreadStartedArgs);
 
           await threadStartedArgs.say('Say called!');
 
@@ -370,7 +367,7 @@ describe('Assistant class', () => {
           const mockThreadContextStore = createMockThreadContextStore();
 
           const { enrichAssistantArgs } = await importAssistant();
-          const threadStartedArgs = await enrichAssistantArgs(mockThreadContextStore, mockThreadStartedArgs);
+          const threadStartedArgs = enrichAssistantArgs(mockThreadContextStore, mockThreadStartedArgs);
 
           await threadStartedArgs.setStatus('Status set!');
 
@@ -385,7 +382,7 @@ describe('Assistant class', () => {
           const mockThreadContextStore = createMockThreadContextStore();
 
           const { enrichAssistantArgs } = await importAssistant();
-          const threadStartedArgs = await enrichAssistantArgs(mockThreadContextStore, mockThreadStartedArgs);
+          const threadStartedArgs = enrichAssistantArgs(mockThreadContextStore, mockThreadStartedArgs);
 
           await threadStartedArgs.setSuggestedPrompts({ prompts: [{ title: '', message: '' }] });
 
@@ -400,7 +397,7 @@ describe('Assistant class', () => {
           const mockThreadContextStore = createMockThreadContextStore();
 
           const { enrichAssistantArgs } = await importAssistant();
-          const threadStartedArgs = await enrichAssistantArgs(mockThreadContextStore, mockThreadStartedArgs);
+          const threadStartedArgs = enrichAssistantArgs(mockThreadContextStore, mockThreadStartedArgs);
 
           await threadStartedArgs.setTitle('Title set!');
 

--- a/test/unit/Assistant.spec.ts
+++ b/test/unit/Assistant.spec.ts
@@ -194,9 +194,12 @@ describe('Assistant class', () => {
 
         const { enrichAssistantArgs } = await importAssistant();
 
-        const threadStartedArgs = enrichAssistantArgs(mockThreadContextStore, mockThreadStartedArgs);
-        const threadContextChangedArgs = enrichAssistantArgs(mockThreadContextStore, mockThreadContextChangedArgs);
-        const userMessageArgs = enrichAssistantArgs(mockThreadContextStore, mockUserMessageArgs);
+        const threadStartedArgs = await enrichAssistantArgs(mockThreadContextStore, mockThreadStartedArgs);
+        const threadContextChangedArgs = await enrichAssistantArgs(
+          mockThreadContextStore,
+          mockThreadContextChangedArgs,
+        );
+        const userMessageArgs = await enrichAssistantArgs(mockThreadContextStore, mockUserMessageArgs);
 
         assert.notExists(threadStartedArgs.next);
         assert.notExists(threadContextChangedArgs.next);
@@ -208,7 +211,9 @@ describe('Assistant class', () => {
         const mockThreadContextStore = createMockThreadContextStore();
         const { enrichAssistantArgs } = await importAssistant();
         // TODO: enrichAssistantArgs likely needs a different argument type, as AssistantMiddlewareArgs type already has the assistant utility enrichments present.
-        const assistantArgs = enrichAssistantArgs(mockThreadContextStore, { payload } as AllAssistantMiddlewareArgs);
+        const assistantArgs = await enrichAssistantArgs(mockThreadContextStore, {
+          payload,
+        } as AllAssistantMiddlewareArgs);
 
         assert.exists(assistantArgs.say);
         assert.exists(assistantArgs.setStatus);
@@ -221,7 +226,9 @@ describe('Assistant class', () => {
         const mockThreadContextStore = createMockThreadContextStore();
         const { enrichAssistantArgs } = await importAssistant();
         // TODO: enrichAssistantArgs likely needs a different argument type, as AssistantMiddlewareArgs type already has the assistant utility enrichments present.
-        const assistantArgs = enrichAssistantArgs(mockThreadContextStore, { payload } as AllAssistantMiddlewareArgs);
+        const assistantArgs = await enrichAssistantArgs(mockThreadContextStore, {
+          payload,
+        } as AllAssistantMiddlewareArgs);
 
         assert.exists(assistantArgs.say);
         assert.exists(assistantArgs.setStatus);
@@ -234,7 +241,9 @@ describe('Assistant class', () => {
         const mockThreadContextStore = createMockThreadContextStore();
         const { enrichAssistantArgs } = await importAssistant();
         // TODO: enrichAssistantArgs likely needs a different argument type, as AssistantMiddlewareArgs type already has the assistant utility enrichments present.
-        const assistantArgs = enrichAssistantArgs(mockThreadContextStore, { payload } as AllAssistantMiddlewareArgs);
+        const assistantArgs = await enrichAssistantArgs(mockThreadContextStore, {
+          payload,
+        } as AllAssistantMiddlewareArgs);
 
         assert.exists(assistantArgs.say);
         assert.exists(assistantArgs.setStatus);
@@ -299,7 +308,7 @@ describe('Assistant class', () => {
           const mockThreadContextStore = createMockThreadContextStore();
 
           const { enrichAssistantArgs } = await importAssistant();
-          const threadStartedArgs = enrichAssistantArgs(mockThreadContextStore, mockThreadStartedArgs);
+          const threadStartedArgs = await enrichAssistantArgs(mockThreadContextStore, mockThreadStartedArgs);
 
           await threadStartedArgs.say('Say called!');
 
@@ -314,7 +323,7 @@ describe('Assistant class', () => {
           const mockThreadContextStore = createMockThreadContextStore();
 
           const { enrichAssistantArgs } = await importAssistant();
-          const threadStartedArgs = enrichAssistantArgs(mockThreadContextStore, mockThreadStartedArgs);
+          const threadStartedArgs = await enrichAssistantArgs(mockThreadContextStore, mockThreadStartedArgs);
 
           await threadStartedArgs.setStatus('Status set!');
 
@@ -329,7 +338,7 @@ describe('Assistant class', () => {
           const mockThreadContextStore = createMockThreadContextStore();
 
           const { enrichAssistantArgs } = await importAssistant();
-          const threadStartedArgs = enrichAssistantArgs(mockThreadContextStore, mockThreadStartedArgs);
+          const threadStartedArgs = await enrichAssistantArgs(mockThreadContextStore, mockThreadStartedArgs);
 
           await threadStartedArgs.setSuggestedPrompts({ prompts: [{ title: '', message: '' }] });
 
@@ -344,7 +353,7 @@ describe('Assistant class', () => {
           const mockThreadContextStore = createMockThreadContextStore();
 
           const { enrichAssistantArgs } = await importAssistant();
-          const threadStartedArgs = enrichAssistantArgs(mockThreadContextStore, mockThreadStartedArgs);
+          const threadStartedArgs = await enrichAssistantArgs(mockThreadContextStore, mockThreadStartedArgs);
 
           await threadStartedArgs.setTitle('Title set!');
 


### PR DESCRIPTION
### Summary

Introduces behavior seen in Python and Java implementations, where thread context is appended as `metadata` to messages posted with `say` utility provided within the `Assistant` class. [See discussion for details](https://github.com/slackapi/bolt-js/pull/2295/files#r1811588537).

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).