### PR TITLE
test: add start of Assistant class type tests

### DIFF
--- a/test/types/assistant.test-d.ts
+++ b/test/types/assistant.test-d.ts
@@ -1,0 +1,35 @@
+import { expectError, expectType } from 'tsd';
+import { Assistant } from '../../src/Assistant';
+
+// Constructor tests
+const asyncNoop = () => Promise.resolve();
+// missing required properties `threadStarted` and `userMessage`
+expectError(new Assistant({}));
+// missing required property `threadStarted`
+expectError(
+  new Assistant({
+    userMessage: asyncNoop,
+  }),
+);
+// missing required property `userMessage`
+expectError(
+  new Assistant({
+    threadStarted: asyncNoop,
+  }),
+);
+// happy construction
+expectType<Assistant>(
+  new Assistant({
+    threadStarted: asyncNoop,
+    userMessage: asyncNoop,
+  }),
+);
+
+// threadStarted tests
+new Assistant({
+  userMessage: asyncNoop,
+  threadStarted: async ({ saveThreadContext }) => {
+    expectType<void>(await saveThreadContext());
+    return Promise.resolve();
+  },
+});


### PR DESCRIPTION
This PR demonstrates the issue identified in https://github.com/slackapi/bolt-js/issues/2319.

I believe the issue stems from [the interface that defines the Assistant utilities](https://github.com/slackapi/bolt-js/blob/main/src/Assistant.ts#L22-L27) define [the two context get/save methods as requiring one argument](https://github.com/slackapi/bolt-js/blob/main/src/AssistantThreadContextStore.ts#L10-L12). However, it doesn't seem to me like these methods actually require arguments (see e.g. [how our example app using Assistant stuff is coded up](https://github.com/slack-samples/bolt-js-assistant-template/blob/main/app.js#L54)).