### PR TITLE
fix: auto acknowledge self events before ignoring

### DIFF
--- a/src/middleware/builtin.ts
+++ b/src/middleware/builtin.ts
@@ -131,10 +131,14 @@ export const onlyViewActions: Middleware<AnyMiddlewareArgs> = async (args) => {
  * Middleware that auto acknowledges the request received
  */
 export const autoAcknowledge: Middleware<AnyMiddlewareArgs> = async (args) => {
+  await safelyAcknowledge(args);
+  await args.next();
+};
+
+export const safelyAcknowledge: Middleware<AnyMiddlewareArgs> = async (args) => {
   if ('ack' in args && args.ack !== undefined) {
     await args.ack();
   }
-  await args.next();
 };
 
 /**
@@ -318,6 +322,7 @@ export const ignoreSelf: Middleware<AnyMiddlewareArgs> = async (args) => {
       const { message } = args;
       // Look for an event that is identified as a bot message from the same bot ID as this app, and return to skip
       if (message.subtype === 'bot_message' && message.bot_id === botId) {
+        await safelyAcknowledge(args);
         return;
       }
     }
@@ -332,6 +337,7 @@ export const ignoreSelf: Middleware<AnyMiddlewareArgs> = async (args) => {
       args.event.user === botUserId &&
       !eventsWhichShouldBeKept.includes(args.event.type)
     ) {
+      await safelyAcknowledge(args);
       return;
     }
   }

--- a/test/unit/helpers/events.ts
+++ b/test/unit/helpers/events.ts
@@ -59,13 +59,14 @@ const ack: AckFn<void> = (_r?) => Promise.resolve();
 export function wrapMiddleware<Args extends AnyMiddlewareArgs>(
   args: Args,
   ctx?: Context,
-): Args & AllMiddlewareArgs & { next: SinonSpy } {
+): Args & AllMiddlewareArgs & { next: SinonSpy; ack: SinonSpy } {
   const wrapped = {
     ...args,
     context: ctx || { isEnterpriseInstall: false },
     logger: createFakeLogger(),
     client: new WebClient(),
     next: sinon.fake(),
+    ack: sinon.fake(),
   };
   return wrapped;
 }

--- a/test/unit/middleware/builtin.spec.ts
+++ b/test/unit/middleware/builtin.spec.ts
@@ -232,6 +232,7 @@ describe('Built-in global middleware', () => {
         const args = wrapMiddleware(createDummyCommandMiddlewareArgs(), ctx);
         await builtins.ignoreSelf(args);
         sinon.assert.called(args.next);
+        sinon.assert.notCalled(args.ack);
       });
 
       it('should ignore message events identified as a bot message from the same bot ID as this app', async () => {
@@ -252,6 +253,7 @@ describe('Built-in global middleware', () => {
           ctx,
         );
         await builtins.ignoreSelf(args);
+        sinon.assert.called(args.ack);
         sinon.assert.notCalled(args.next);
       });
 
@@ -259,6 +261,7 @@ describe('Built-in global middleware', () => {
         const ctx = { ...dummyContext, botUserId: fakeBotUserId };
         const args = wrapMiddleware(createDummyReactionAddedEventMiddlewareArgs({ user: fakeBotUserId }), ctx);
         await builtins.ignoreSelf(args);
+        sinon.assert.called(args.ack);
         sinon.assert.notCalled(args.next);
       });
 
@@ -266,6 +269,7 @@ describe('Built-in global middleware', () => {
         const ctx = { ...dummyContext, botUserId: fakeBotUserId, botId: fakeBotUserId };
         const args = wrapMiddleware(createDummyReactionAddedEventMiddlewareArgs({ user: fakeBotUserId }), ctx);
         await builtins.ignoreSelf(args);
+        sinon.assert.called(args.ack);
         sinon.assert.notCalled(args.next);
       });
 
@@ -279,6 +283,7 @@ describe('Built-in global middleware', () => {
 
         await Promise.all(listOfFakeArgs.map(builtins.ignoreSelf));
         for (const args of listOfFakeArgs) {
+          sinon.assert.notCalled(args.ack);
           sinon.assert.called(args.next);
         }
       });


### PR DESCRIPTION
### Summary

Since #2283 event requests are no longer auto acknowledged in the `processEvent` function. This behavior was handed over to the `autoAcknowledge` middleware. This created a gap in the `ignoreSelf` middleware since the events reaching it were assumed to already be acknowledged. This PR aims to add auto acknowledge behavior into the `ignoreSelf` global middleware. 

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).