### PR TITLE
fix: auto acknowledge assistant events

### DIFF
--- a/src/Assistant.ts
+++ b/src/Assistant.ts
@@ -13,6 +13,7 @@ import {
   type SaveThreadContextFn,
 } from './AssistantThreadContextStore';
 import { AssistantInitializationError, AssistantMissingPropertyError } from './errors';
+import { autoAcknowledge } from './middleware/builtin';
 import processMiddleware from './middleware/process';
 import type { AllMiddlewareArgs, AnyMiddlewareArgs, Middleware, SayFn, SlackEventMiddlewareArgs } from './types';
 
@@ -286,7 +287,7 @@ export async function processAssistantMiddleware(
   middleware: AssistantMiddleware,
 ): Promise<void> {
   const { context, client, logger } = args;
-  const callbacks = [...middleware] as Middleware<AnyMiddlewareArgs>[];
+  const callbacks = [autoAcknowledge, ...middleware] as Middleware<AnyMiddlewareArgs>[];
   const lastCallback = callbacks.pop();
 
   if (lastCallback !== undefined) {

--- a/src/middleware/builtin.ts
+++ b/src/middleware/builtin.ts
@@ -56,11 +56,11 @@ function isViewBody(
   return 'view' in body && body.view !== undefined;
 }
 
-function isEventArgs(args: AnyMiddlewareArgs): args is SlackEventMiddlewareArgs {
+export function isEventArgs(args: AnyMiddlewareArgs): args is SlackEventMiddlewareArgs {
   return 'event' in args && args.event !== undefined;
 }
 
-function isMessageEventArgs(args: AnyMiddlewareArgs): args is SlackEventMiddlewareArgs<'message'> {
+export function isMessageEventArgs(args: AnyMiddlewareArgs): args is SlackEventMiddlewareArgs<'message'> {
   return isEventArgs(args) && 'message' in args;
 }
 

--- a/src/middleware/builtin.ts
+++ b/src/middleware/builtin.ts
@@ -131,10 +131,14 @@ export const onlyViewActions: Middleware<AnyMiddlewareArgs> = async (args) => {
  * Middleware that auto acknowledges the request received
  */
 export const autoAcknowledge: Middleware<AnyMiddlewareArgs> = async (args) => {
+  await safelyAcknowledge(args);
+  await args.next();
+};
+
+export const safelyAcknowledge: Middleware<AnyMiddlewareArgs> = async (args) => {
   if ('ack' in args && args.ack !== undefined) {
     await args.ack();
   }
-  await args.next();
 };
 
 /**
@@ -318,6 +322,7 @@ export const ignoreSelf: Middleware<AnyMiddlewareArgs> = async (args) => {
       const { message } = args;
       // Look for an event that is identified as a bot message from the same bot ID as this app, and return to skip
       if (message.subtype === 'bot_message' && message.bot_id === botId) {
+        await safelyAcknowledge(args);
         return;
       }
     }
@@ -332,6 +337,7 @@ export const ignoreSelf: Middleware<AnyMiddlewareArgs> = async (args) => {
       args.event.user === botUserId &&
       !eventsWhichShouldBeKept.includes(args.event.type)
     ) {
+      await safelyAcknowledge(args);
       return;
     }
   }

--- a/test/unit/Assistant.spec.ts
+++ b/test/unit/Assistant.spec.ts
@@ -101,6 +101,7 @@ describe('Assistant class', () => {
       const middleware = assistant.getMiddleware();
       const fakeMessageArgs = wrapMiddleware(createDummyMessageEventMiddlewareArgs());
       await middleware(fakeMessageArgs);
+      sinon.assert.notCalled(fakeMessageArgs.ack);
       sinon.assert.called(fakeMessageArgs.next);
     });
 
@@ -109,6 +110,7 @@ describe('Assistant class', () => {
       const middleware = assistant.getMiddleware();
       const mockThreadStartedArgs = wrapMiddleware(createDummyAssistantThreadStartedEventMiddlewareArgs());
       await middleware(mockThreadStartedArgs);
+      sinon.assert.called(mockThreadStartedArgs.ack);
       sinon.assert.notCalled(mockThreadStartedArgs.next);
     });
 
@@ -424,6 +426,7 @@ describe('Assistant class', () => {
 
         await processAssistantMiddleware(mockThreadContextChangedArgs, fakeMiddleware);
 
+        sinon.assert.called(mockThreadContextChangedArgs.ack);
         assert(fn1.called);
         assert(fn2.called);
       });

--- a/test/unit/helpers/events.ts
+++ b/test/unit/helpers/events.ts
@@ -59,13 +59,14 @@ const ack: AckFn<void> = (_r?) => Promise.resolve();
 export function wrapMiddleware<Args extends AnyMiddlewareArgs>(
   args: Args,
   ctx?: Context,
-): Args & AllMiddlewareArgs & { next: SinonSpy } {
+): Args & AllMiddlewareArgs & { next: SinonSpy; ack: SinonSpy } {
   const wrapped = {
     ...args,
     context: ctx || { isEnterpriseInstall: false },
     logger: createFakeLogger(),
     client: new WebClient(),
     next: sinon.fake(),
+    ack: sinon.fake(),
   };
   return wrapped;
 }

--- a/test/unit/middleware/builtin.spec.ts
+++ b/test/unit/middleware/builtin.spec.ts
@@ -232,6 +232,7 @@ describe('Built-in global middleware', () => {
         const args = wrapMiddleware(createDummyCommandMiddlewareArgs(), ctx);
         await builtins.ignoreSelf(args);
         sinon.assert.called(args.next);
+        sinon.assert.notCalled(args.ack);
       });
 
       it('should ignore message events identified as a bot message from the same bot ID as this app', async () => {
@@ -252,6 +253,7 @@ describe('Built-in global middleware', () => {
           ctx,
         );
         await builtins.ignoreSelf(args);
+        sinon.assert.called(args.ack);
         sinon.assert.notCalled(args.next);
       });
 
@@ -259,6 +261,7 @@ describe('Built-in global middleware', () => {
         const ctx = { ...dummyContext, botUserId: fakeBotUserId };
         const args = wrapMiddleware(createDummyReactionAddedEventMiddlewareArgs({ user: fakeBotUserId }), ctx);
         await builtins.ignoreSelf(args);
+        sinon.assert.called(args.ack);
         sinon.assert.notCalled(args.next);
       });
 
@@ -266,6 +269,7 @@ describe('Built-in global middleware', () => {
         const ctx = { ...dummyContext, botUserId: fakeBotUserId, botId: fakeBotUserId };
         const args = wrapMiddleware(createDummyReactionAddedEventMiddlewareArgs({ user: fakeBotUserId }), ctx);
         await builtins.ignoreSelf(args);
+        sinon.assert.called(args.ack);
         sinon.assert.notCalled(args.next);
       });
 
@@ -279,6 +283,7 @@ describe('Built-in global middleware', () => {
 
         await Promise.all(listOfFakeArgs.map(builtins.ignoreSelf));
         for (const args of listOfFakeArgs) {
+          sinon.assert.notCalled(args.ack);
           sinon.assert.called(args.next);
         }
       });


### PR DESCRIPTION
### Summary

MEGRE #2329 FIRST!

Since #2283 event requests are no longer auto acknowledged in the processEvent function. This behavior was handed over to the autoAcknowledge middleware. This PR aims to add auto acknowledge behavior back into the assistant event handlers.

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).