### PR TITLE
feat: expose auto acknowledgement flag on the function handler

### DIFF
--- a/src/App.ts
+++ b/src/App.ts
@@ -7,9 +7,11 @@ import axios, { type AxiosInstance, type AxiosResponse } from 'axios';
 import type { Assistant } from './Assistant';
 import {
   CustomFunction,
-  type CustomFunctionMiddleware,
   type FunctionCompleteFn,
   type FunctionFailFn,
+  type SlackCustomFunctionMiddlewareArgs,
+  createFunctionComplete,
+  createFunctionFail,
 } from './CustomFunction';
 import type { WorkflowStep } from './WorkflowStep';
 import { type ConversationStore, MemoryStore, conversationContext } from './conversation-store';
@@ -30,6 +32,7 @@ import {
 } from './helpers';
 import {
   ignoreSelf as ignoreSelfMiddleware,
+  isSlackEventMiddlewareArgsOptions,
   matchCommandName,
   matchConstraints,
   matchEventType,
@@ -47,7 +50,6 @@ import SocketModeReceiver from './receivers/SocketModeReceiver';
 import type {
   AckFn,
   ActionConstraints,
-  AllMiddlewareArgs,
   AnyMiddlewareArgs,
   BlockAction,
   BlockElementAction,
@@ -72,6 +74,7 @@ import type {
   SlackActionMiddlewareArgs,
   SlackCommandMiddlewareArgs,
   SlackEventMiddlewareArgs,
+  SlackEventMiddlewareArgsOptions,
   SlackOptionsMiddlewareArgs,
   SlackShortcut,
   SlackShortcutMiddlewareArgs,
@@ -82,7 +85,7 @@ import type {
   ViewOutput,
   WorkflowStepEdit,
 } from './types';
-import { contextBuiltinKeys } from './types';
+import { type AllMiddlewareArgs, contextBuiltinKeys } from './types/middleware';
 import { type StringIndexed, isRejected } from './types/utilities';
 const packageJson = require('../package.json');
 
@@ -496,7 +499,7 @@ export default class App<AppCustomContext extends StringIndexed = StringIndexed>
    * @param m global middleware function
    */
   public use<MiddlewareCustomContext extends StringIndexed = StringIndexed>(
-    m: Middleware<AnyMiddlewareArgs, AppCustomContext & MiddlewareCustomContext>,
+    m: Middleware<AnyMiddlewareArgs<{ autoAcknowledge: false }>, AppCustomContext & MiddlewareCustomContext>,
   ): this {
     this.middleware.push(m as Middleware<AnyMiddlewareArgs>);
     return this;
@@ -529,10 +532,31 @@ export default class App<AppCustomContext extends StringIndexed = StringIndexed>
   /**
    * Register CustomFunction middleware
    */
-  public function(callbackId: string, ...listeners: CustomFunctionMiddleware): this {
-    const fn = new CustomFunction(callbackId, listeners, this.webClientOptions);
-    const m = fn.getMiddleware();
-    this.middleware.push(m);
+  public function<Options extends SlackEventMiddlewareArgsOptions = { autoAcknowledge: true }>(
+    callbackId: string,
+    options: Options,
+    ...listeners: Middleware<SlackCustomFunctionMiddlewareArgs<Options>>[]
+  ): this;
+  public function<Options extends SlackEventMiddlewareArgsOptions = { autoAcknowledge: true }>(
+    callbackId: string,
+    ...listeners: Middleware<SlackCustomFunctionMiddlewareArgs<Options>>[]
+  ): this;
+  public function<Options extends SlackEventMiddlewareArgsOptions = { autoAcknowledge: true }>(
+    callbackId: string,
+    ...optionOrListeners: (Options | Middleware<SlackCustomFunctionMiddlewareArgs<Options>>)[]
+  ): this {
+    // TODO: fix this casting; edge case is if dev specifically sets AutoAck generic as false, this true assignment is invalid according to TS.
+    const options = isSlackEventMiddlewareArgsOptions(optionOrListeners[0])
+      ? optionOrListeners[0]
+      : ({ autoAcknowledge: true } as Options);
+    const listeners = optionOrListeners.filter(
+      (optionOrListener): optionOrListener is Middleware<SlackCustomFunctionMiddlewareArgs<Options>> => {
+        return !isSlackEventMiddlewareArgsOptions(optionOrListener);
+      },
+    );
+
+    const fn = new CustomFunction<Options>(callbackId, listeners, options);
+    this.listeners.push(fn.getListeners());
     return this;
   }
 
@@ -979,7 +1003,7 @@ export default class App<AppCustomContext extends StringIndexed = StringIndexed>
 
     // Factory for say() utility
     const createSay = (channelId: string): SayFn => {
-      const token = selectToken(context);
+      const token = selectToken(context, this.attachFunctionToken);
       return (message) => {
         let postMessageArguments: ChatPostMessageArguments;
         if (typeof message === 'string') {
@@ -1040,27 +1064,70 @@ export default class App<AppCustomContext extends StringIndexed = StringIndexed>
       respond?: RespondFn;
       /** Ack function might be set below */
       // biome-ignore lint/suspicious/noExplicitAny: different kinds of acks accept different arguments, TODO: revisit this to see if we can type better
-      ack?: AckFn<any>;
+      ack: AckFn<any>;
       complete?: FunctionCompleteFn;
       fail?: FunctionFailFn;
       inputs?: FunctionInputs;
     } = {
       body: bodyArg,
+      ack,
       payload,
     };
+
+    // Get the client arg
+    let { client } = this;
+
+    const token = selectToken(context, this.attachFunctionToken);
+
+    if (token !== undefined) {
+      let pool: WebClientPool | undefined = undefined;
+      const clientOptionsCopy = { ...this.clientOptions };
+      if (authorizeResult.teamId !== undefined) {
+        pool = this.clients[authorizeResult.teamId];
+        if (pool === undefined) {
+          pool = this.clients[authorizeResult.teamId] = new WebClientPool();
+        }
+        // Add teamId to clientOptions so it can be automatically added to web-api calls
+        clientOptionsCopy.teamId = authorizeResult.teamId;
+      } else if (authorizeResult.enterpriseId !== undefined) {
+        pool = this.clients[authorizeResult.enterpriseId];
+        if (pool === undefined) {
+          pool = this.clients[authorizeResult.enterpriseId] = new WebClientPool();
+        }
+      }
+      if (pool !== undefined) {
+        client = pool.getOrCreate(token, clientOptionsCopy);
+      }
+    }
 
     // TODO: can we instead use type predicates in these switch cases to allow for narrowing of the body simultaneously? we have isEvent, isView, isShortcut, isAction already in types/utilities / helpers
     // Set aliases
     if (type === IncomingEventType.Event) {
-      const eventListenerArgs = listenerArgs as SlackEventMiddlewareArgs;
+      // TODO: assigning eventListenerArgs by reference to set properties of listenerArgs is error prone, there should be a better way to do this!
+      const eventListenerArgs = listenerArgs as unknown as SlackEventMiddlewareArgs;
       eventListenerArgs.event = eventListenerArgs.payload;
       if (eventListenerArgs.event.type === 'message') {
         const messageEventListenerArgs = eventListenerArgs as SlackEventMiddlewareArgs<'message'>;
         messageEventListenerArgs.message = messageEventListenerArgs.payload;
       }
+      if (eventListenerArgs.event.type === 'function_executed') {
+        listenerArgs.complete = createFunctionComplete(context, client);
+        listenerArgs.fail = createFunctionFail(context, client);
+        listenerArgs.inputs = eventListenerArgs.event.inputs;
+      } else {
+        // Events API requests are acknowledged right away, since there's no data expected
+        // Except function_executed events
+        await listenerArgs.ack();
+      }
     } else if (type === IncomingEventType.Action) {
       const actionListenerArgs = listenerArgs as SlackActionMiddlewareArgs;
       actionListenerArgs.action = actionListenerArgs.payload;
+      // Add complete() and fail() utilities for function-related interactivity
+      if (context.functionExecutionId !== undefined) {
+        listenerArgs.complete = createFunctionComplete(context, client);
+        listenerArgs.fail = createFunctionFail(context, client);
+        listenerArgs.inputs = context.functionInputs;
+      }
     } else if (type === IncomingEventType.Command) {
       const commandListenerArgs = listenerArgs as SlackCommandMiddlewareArgs;
       commandListenerArgs.command = commandListenerArgs.payload;
@@ -1086,50 +1153,6 @@ export default class App<AppCustomContext extends StringIndexed = StringIndexed>
     } else if (typeof body.response_urls !== 'undefined' && body.response_urls.length > 0) {
       // This can exist only when view_submission payloads - response_url_enabled: true
       listenerArgs.respond = buildRespondFn(this.axios, body.response_urls[0].response_url);
-    }
-
-    // Set ack() utility
-    if (type !== IncomingEventType.Event) {
-      listenerArgs.ack = ack;
-    } else {
-      // Events API requests are acknowledged right away, since there's no data expected
-      await ack();
-    }
-
-    // Get the client arg
-    let { client } = this;
-
-    // If functionBotAccessToken exists on context, the incoming event is function-related *and* the
-    // user has `attachFunctionToken` enabled. In that case, subsequent calls with the client should
-    // use the function-related/JIT token in lieu of the botToken or userToken.
-    const token = context.functionBotAccessToken ? context.functionBotAccessToken : selectToken(context);
-
-    // Add complete() and fail() utilities for function-related interactivity
-    if (type === IncomingEventType.Action && context.functionExecutionId !== undefined) {
-      listenerArgs.complete = CustomFunction.createFunctionComplete(context, client);
-      listenerArgs.fail = CustomFunction.createFunctionFail(context, client);
-      listenerArgs.inputs = context.functionInputs;
-    }
-
-    if (token !== undefined) {
-      let pool: WebClientPool | undefined = undefined;
-      const clientOptionsCopy = { ...this.clientOptions };
-      if (authorizeResult.teamId !== undefined) {
-        pool = this.clients[authorizeResult.teamId];
-        if (pool === undefined) {
-          pool = this.clients[authorizeResult.teamId] = new WebClientPool();
-        }
-        // Add teamId to clientOptions so it can be automatically added to web-api calls
-        clientOptionsCopy.teamId = authorizeResult.teamId;
-      } else if (authorizeResult.enterpriseId !== undefined) {
-        pool = this.clients[authorizeResult.enterpriseId];
-        if (pool === undefined) {
-          pool = this.clients[authorizeResult.enterpriseId] = new WebClientPool();
-        }
-      }
-      if (pool !== undefined) {
-        client = pool.getOrCreate(token, clientOptionsCopy);
-      }
     }
 
     // Dispatch event through the global middleware chain
@@ -1575,7 +1598,15 @@ function isBlockActionOrInteractiveMessageBody(
 }
 
 // Returns either a bot token or a user token for client, say()
-function selectToken(context: Context): string | undefined {
+function selectToken(context: Context, attachFunctionToken: boolean): string | undefined {
+  if (attachFunctionToken) {
+    // If functionBotAccessToken exists on context, the incoming event is function-related *and* the
+    // user has `attachFunctionToken` enabled. In that case, subsequent calls with the client should
+    // use the function-related/JIT token in lieu of the botToken or userToken.
+    if (context.functionBotAccessToken) {
+      return context.functionBotAccessToken;
+    }
+  }
   return context.botToken !== undefined ? context.botToken : context.userToken;
 }
 

--- a/src/CustomFunction.ts
+++ b/src/CustomFunction.ts
@@ -1,17 +1,18 @@
 import type { FunctionExecutedEvent } from '@slack/types';
-import {
-  type FunctionsCompleteErrorResponse,
-  type FunctionsCompleteSuccessResponse,
-  WebClient,
-  type WebClientOptions,
-} from '@slack/web-api';
+import type { FunctionsCompleteErrorResponse, FunctionsCompleteSuccessResponse, WebClient } from '@slack/web-api';
 import {
   CustomFunctionCompleteFailError,
   CustomFunctionCompleteSuccessError,
   CustomFunctionInitializationError,
 } from './errors';
-import processMiddleware from './middleware/process';
-import type { AllMiddlewareArgs, AnyMiddlewareArgs, Context, Middleware, SlackEventMiddlewareArgs } from './types';
+import { autoAcknowledge, matchEventType, onlyEvents } from './middleware/builtin';
+import type {
+  AnyMiddlewareArgs,
+  Context,
+  Middleware,
+  SlackEventMiddlewareArgs,
+  SlackEventMiddlewareArgsOptions,
+} from './types';
 
 /** Interfaces */
 
@@ -19,6 +20,8 @@ interface FunctionCompleteArguments {
   // biome-ignore lint/suspicious/noExplicitAny: TODO: could probably improve custom function parameter shapes - deno-slack-sdk has a bunch of this stuff we should move to slack/types
   outputs?: Record<string, any>;
 }
+
+/** Types */
 
 export type FunctionCompleteFn = (params?: FunctionCompleteArguments) => Promise<FunctionsCompleteSuccessResponse>;
 
@@ -28,115 +31,70 @@ interface FunctionFailArguments {
 
 export type FunctionFailFn = (params: FunctionFailArguments) => Promise<FunctionsCompleteErrorResponse>;
 
-export interface CustomFunctionExecuteMiddlewareArgs extends SlackEventMiddlewareArgs<'function_executed'> {
+export type SlackCustomFunctionMiddlewareArgs<
+  Options extends SlackEventMiddlewareArgsOptions = { autoAcknowledge: true },
+> = SlackEventMiddlewareArgs<'function_executed', Options> & {
   inputs: FunctionExecutedEvent['inputs'];
   complete: FunctionCompleteFn;
   fail: FunctionFailFn;
+};
+
+/*
+ * Middleware that filters out function scoped events that do not match the provided callback ID
+ */
+export function matchCallbackId(callbackId: string): Middleware<SlackCustomFunctionMiddlewareArgs> {
+  return async ({ payload, next }) => {
+    if (payload.function.callback_id === callbackId) {
+      await next();
+    }
+  };
 }
 
-/** Types */
-
-export type SlackCustomFunctionMiddlewareArgs = CustomFunctionExecuteMiddlewareArgs;
-
-type CustomFunctionExecuteMiddleware = Middleware<CustomFunctionExecuteMiddlewareArgs>[];
-
-export type CustomFunctionMiddleware = Middleware<CustomFunctionExecuteMiddlewareArgs>[];
-
-export type AllCustomFunctionMiddlewareArgs<
-  T extends SlackCustomFunctionMiddlewareArgs = SlackCustomFunctionMiddlewareArgs,
-> = T & AllMiddlewareArgs;
-
-/** Constants */
-
-const VALID_PAYLOAD_TYPES = new Set(['function_executed']);
-
 /** Class */
-
-export class CustomFunction {
+export class CustomFunction<Options extends SlackEventMiddlewareArgsOptions = { autoAcknowledge: true }> {
   /** Function callback_id */
   public callbackId: string;
 
-  private appWebClientOptions: WebClientOptions;
+  private listeners: Middleware<SlackCustomFunctionMiddlewareArgs<Options>>[];
 
-  private middleware: CustomFunctionMiddleware;
+  private options: Options;
 
-  public constructor(callbackId: string, middleware: CustomFunctionExecuteMiddleware, clientOptions: WebClientOptions) {
-    validate(callbackId, middleware);
+  public constructor(
+    callbackId: string,
+    listeners: Middleware<SlackCustomFunctionMiddlewareArgs<Options>>[],
+    options: Options,
+  ) {
+    validate(callbackId, listeners);
 
-    this.appWebClientOptions = clientOptions;
     this.callbackId = callbackId;
-    this.middleware = middleware;
+    this.listeners = listeners;
+    this.options = options;
   }
 
-  public getMiddleware(): Middleware<AnyMiddlewareArgs> {
-    return async (args): Promise<void> => {
-      if (isFunctionEvent(args) && this.matchesConstraints(args)) {
-        return this.processEvent(args);
-      }
-      return args.next();
-    };
-  }
-
-  private matchesConstraints(args: SlackCustomFunctionMiddlewareArgs): boolean {
-    return args.payload.function.callback_id === this.callbackId;
-  }
-
-  private async processEvent(args: AllCustomFunctionMiddlewareArgs): Promise<void> {
-    const functionArgs = enrichFunctionArgs(args, this.appWebClientOptions);
-    const functionMiddleware = this.getFunctionMiddleware();
-    return processFunctionMiddleware(functionArgs, functionMiddleware);
-  }
-
-  private getFunctionMiddleware(): CustomFunctionMiddleware {
-    return this.middleware;
-  }
-
-  /**
-   * Factory for `complete()` utility
-   */
-  public static createFunctionComplete(context: Context, client: WebClient): FunctionCompleteFn {
-    const token = selectToken(context);
-    const { functionExecutionId } = context;
-
-    if (!functionExecutionId) {
-      const errorMsg = 'No function_execution_id found';
-      throw new CustomFunctionCompleteSuccessError(errorMsg);
+  public getListeners(): Middleware<AnyMiddlewareArgs>[] {
+    if (this.options.autoAcknowledge) {
+      return [
+        onlyEvents,
+        matchEventType('function_executed'),
+        matchCallbackId(this.callbackId),
+        autoAcknowledge,
+        ...this.listeners,
+      ] as Middleware<AnyMiddlewareArgs>[];
     }
-
-    return (params: Parameters<FunctionCompleteFn>[0] = {}) =>
-      client.functions.completeSuccess({
-        token,
-        outputs: params.outputs || {},
-        function_execution_id: functionExecutionId,
-      });
-  }
-
-  /**
-   * Factory for `fail()` utility
-   */
-  public static createFunctionFail(context: Context, client: WebClient): FunctionFailFn {
-    const token = selectToken(context);
-    const { functionExecutionId } = context;
-
-    if (!functionExecutionId) {
-      const errorMsg = 'No function_execution_id found';
-      throw new CustomFunctionCompleteFailError(errorMsg);
-    }
-
-    return (params: Parameters<FunctionFailFn>[0]) => {
-      const { error } = params ?? {};
-
-      return client.functions.completeError({
-        token,
-        error,
-        function_execution_id: functionExecutionId,
-      });
-    };
+    return [
+      onlyEvents,
+      matchEventType('function_executed'),
+      matchCallbackId(this.callbackId),
+      ...this.listeners,
+    ] as Middleware<AnyMiddlewareArgs>[];
   }
 }
 
 /** Helper Functions */
-export function validate(callbackId: string, middleware: CustomFunctionExecuteMiddleware): void {
+export function validate<Options extends SlackEventMiddlewareArgsOptions = { autoAcknowledge: true }>(
+  callbackId: string,
+  middleware: Middleware<SlackCustomFunctionMiddlewareArgs<Options>>[],
+): void {
   // Ensure callbackId is valid
   if (typeof callbackId !== 'string') {
     const errorMsg = 'CustomFunction expects a callback_id as the first argument';
@@ -161,55 +119,40 @@ export function validate(callbackId: string, middleware: CustomFunctionExecuteMi
 }
 
 /**
- * `processFunctionMiddleware()` invokes each listener middleware
+ * Factory for `complete()` utility
  */
-export async function processFunctionMiddleware(
-  args: AllCustomFunctionMiddlewareArgs,
-  middleware: CustomFunctionMiddleware,
-): Promise<void> {
-  const { context, client, logger } = args;
-  const callbacks = [...middleware] as Middleware<AnyMiddlewareArgs>[];
-  const lastCallback = callbacks.pop();
+export function createFunctionComplete(context: Context, client: WebClient): FunctionCompleteFn {
+  const { functionExecutionId } = context;
 
-  if (lastCallback !== undefined) {
-    await processMiddleware(callbacks, args, context, client, logger, async () =>
-      lastCallback({ ...args, context, client, logger }),
-    );
+  if (!functionExecutionId) {
+    const errorMsg = 'No function_execution_id found';
+    throw new CustomFunctionCompleteSuccessError(errorMsg);
   }
-}
 
-export function isFunctionEvent(args: AnyMiddlewareArgs): args is AllCustomFunctionMiddlewareArgs {
-  return VALID_PAYLOAD_TYPES.has(args.payload.type);
-}
-
-function selectToken(context: Context): string | undefined {
-  // If attachFunctionToken = false, fallback to botToken or userToken
-  return context.functionBotAccessToken ? context.functionBotAccessToken : context.botToken || context.userToken;
+  return (params: Parameters<FunctionCompleteFn>[0] = {}) =>
+    client.functions.completeSuccess({
+      outputs: params.outputs || {},
+      function_execution_id: functionExecutionId,
+    });
 }
 
 /**
- * `enrichFunctionArgs()` takes in a function's args and:
- *  1. removes the next() passed in from App-level middleware processing
- *    - events will *not* continue down global middleware chain to subsequent listeners
- *  2. augments args with step lifecycle-specific properties/utilities
- * */
-export function enrichFunctionArgs(
-  args: AllCustomFunctionMiddlewareArgs,
-  webClientOptions: WebClientOptions,
-): AllCustomFunctionMiddlewareArgs {
-  const { next: _next, ...functionArgs } = args;
-  const enrichedArgs = { ...functionArgs };
-  const token = selectToken(functionArgs.context);
+ * Factory for `fail()` utility
+ */
+export function createFunctionFail(context: Context, client: WebClient): FunctionFailFn {
+  const { functionExecutionId } = context;
 
-  // Making calls with a functionBotAccessToken establishes continuity between
-  // a function_executed event and subsequent interactive events (actions)
-  const client = new WebClient(token, webClientOptions);
-  enrichedArgs.client = client;
+  if (!functionExecutionId) {
+    const errorMsg = 'No function_execution_id found';
+    throw new CustomFunctionCompleteFailError(errorMsg);
+  }
 
-  // Utility args
-  enrichedArgs.inputs = enrichedArgs.event.inputs;
-  enrichedArgs.complete = CustomFunction.createFunctionComplete(enrichedArgs.context, client);
-  enrichedArgs.fail = CustomFunction.createFunctionFail(enrichedArgs.context, client);
+  return (params: Parameters<FunctionFailFn>[0]) => {
+    const { error } = params ?? {};
 
-  return enrichedArgs as AllCustomFunctionMiddlewareArgs; // TODO: dangerous casting as it obfuscates missing `next()`
+    return client.functions.completeError({
+      error,
+      function_execution_id: functionExecutionId,
+    });
+  };
 }

--- a/src/middleware/builtin.ts
+++ b/src/middleware/builtin.ts
@@ -15,6 +15,7 @@ import type {
   SlackActionMiddlewareArgs,
   SlackCommandMiddlewareArgs,
   SlackEventMiddlewareArgs,
+  SlackEventMiddlewareArgsOptions,
   SlackOptionsMiddlewareArgs,
   SlackShortcutMiddlewareArgs,
   SlackViewAction,
@@ -55,12 +56,19 @@ function isViewBody(
   return 'view' in body && body.view !== undefined;
 }
 
-function isEventArgs(args: AnyMiddlewareArgs): args is SlackEventMiddlewareArgs {
+export function isEventArgs(args: AnyMiddlewareArgs): args is SlackEventMiddlewareArgs {
   return 'event' in args && args.event !== undefined;
 }
 
 function isMessageEventArgs(args: AnyMiddlewareArgs): args is SlackEventMiddlewareArgs<'message'> {
   return isEventArgs(args) && 'message' in args;
+}
+
+export function isSlackEventMiddlewareArgsOptions<
+  Options extends SlackEventMiddlewareArgsOptions,
+  EventMiddlewareArgs extends SlackEventMiddlewareArgs,
+>(optionOrListener: Options | Middleware<EventMiddlewareArgs>): optionOrListener is Options {
+  return typeof optionOrListener !== 'function' && 'autoAcknowledge' in optionOrListener;
 }
 
 /**
@@ -117,6 +125,16 @@ export const onlyViewActions: Middleware<AnyMiddlewareArgs> = async (args) => {
   if ('view' in args) {
     await args.next();
   }
+};
+
+/**
+ * Middleware that auto acknowledges the request received
+ */
+export const autoAcknowledge: Middleware<AnyMiddlewareArgs> = async (args) => {
+  if ('ack' in args && args.ack !== undefined) {
+    await args.ack();
+  }
+  await args.next();
 };
 
 /**

--- a/src/types/events/index.ts
+++ b/src/types/events/index.ts
@@ -1,15 +1,18 @@
 import type { SlackEvent } from '@slack/types';
-import type { SayFn, StringIndexed } from '../utilities';
+import type { AckFn, SayFn, StringIndexed } from '../utilities';
+
+export type SlackEventMiddlewareArgsOptions = { autoAcknowledge: boolean };
 
 /**
  * Arguments which listeners and middleware receive to process an event from Slack's Events API.
  */
-export type SlackEventMiddlewareArgs<EventType extends string = string> = {
+export type SlackEventMiddlewareArgs<
+  EventType extends string = string,
+  Options extends SlackEventMiddlewareArgsOptions = { autoAcknowledge: true },
+> = {
   payload: EventFromType<EventType>;
   event: EventFromType<EventType>;
   body: EnvelopedEvent<EventFromType<EventType>>;
-  // Add `ack` as undefined for global middleware in TypeScript TODO: but why? spend some time digging into this
-  ack?: undefined;
 } & (EventType extends 'message'
   ? // If this is a message event, add a `message` property
     { message: EventFromType<EventType> }
@@ -17,7 +20,8 @@ export type SlackEventMiddlewareArgs<EventType extends string = string> = {
   (EventFromType<EventType> extends { channel: string } | { item: { channel: string } }
     ? // If this event contains a channel, add a `say` utility function
       { say: SayFn }
-    : unknown);
+    : unknown) &
+  (Options['autoAcknowledge'] extends true ? unknown : { ack: AckFn<void> });
 
 export interface BaseSlackEvent<T extends string = string> {
   type: T;

--- a/src/types/middleware.ts
+++ b/src/types/middleware.ts
@@ -1,21 +1,23 @@
 import type { Logger } from '@slack/logger';
 import type { WebClient } from '@slack/web-api';
+import type { SlackCustomFunctionMiddlewareArgs } from '../CustomFunction';
 import type { SlackActionMiddlewareArgs } from './actions';
 import type { SlackCommandMiddlewareArgs } from './command';
-import type { FunctionInputs, SlackEventMiddlewareArgs } from './events';
+import type { FunctionInputs, SlackEventMiddlewareArgs, SlackEventMiddlewareArgsOptions } from './events';
 import type { SlackOptionsMiddlewareArgs } from './options';
 import type { SlackShortcutMiddlewareArgs } from './shortcuts';
 import type { StringIndexed } from './utilities';
 import type { SlackViewMiddlewareArgs } from './view';
 
 // TODO: rename this to AnyListenerArgs, and all the constituent types
-export type AnyMiddlewareArgs =
-  | SlackEventMiddlewareArgs
+export type AnyMiddlewareArgs<Options extends SlackEventMiddlewareArgsOptions = { autoAcknowledge: true }> =
+  | SlackEventMiddlewareArgs<string, Options>
   | SlackActionMiddlewareArgs
   | SlackCommandMiddlewareArgs
   | SlackOptionsMiddlewareArgs
   | SlackViewMiddlewareArgs
-  | SlackShortcutMiddlewareArgs;
+  | SlackShortcutMiddlewareArgs
+  | SlackCustomFunctionMiddlewareArgs<Options>;
 
 export interface AllMiddlewareArgs<CustomContext = StringIndexed> {
   context: Context & CustomContext;

--- a/test/types/functions.test-d.ts
+++ b/test/types/functions.test-d.ts
@@ -1,0 +1,33 @@
+import { expectError, expectNotType, expectType } from 'tsd';
+import App from '../../src/App';
+import type { FunctionCompleteFn, FunctionFailFn } from '../../src/CustomFunction';
+import type { FunctionInputs } from '../../src/types';
+import type { AckFn } from '../../src/types/utilities';
+
+const app = new App({ token: 'TOKEN', signingSecret: 'Signing Secret' });
+
+// By default `function` handlers auto-acknowledge events so `ack` should not be provided/defined
+expectError(
+  app.function('callback', async ({ ack }) => {
+    expectNotType<AckFn<void>>(ack);
+  }),
+);
+
+// For `function` handlers that are auto-acknowledged, `ack` should not be provided/defined
+expectError(
+  app.function('callback', { autoAcknowledge: true }, async ({ ack }) => {
+    expectNotType<AckFn<void>>(ack);
+  }),
+);
+
+// For `function` handlers that are not auto-acknowledged, `ack` should be provided/defined
+app.function('callback', { autoAcknowledge: false }, async ({ ack }) => {
+  expectType<AckFn<void>>(ack);
+});
+
+// By default `function` handlers provide/define the proper arguments
+app.function('callback', async ({ inputs, complete, fail }) => {
+  expectType<FunctionInputs>(inputs);
+  expectType<FunctionCompleteFn>(complete);
+  expectType<FunctionFailFn>(fail);
+});

--- a/test/unit/App/middleware.spec.ts
+++ b/test/unit/App/middleware.spec.ts
@@ -986,7 +986,7 @@ describe('App middleware processing', () => {
           authorize: sinon.fake.resolves(dummyAuthorizationResult),
         });
         app.use(async ({ ack, next }) => {
-          if (ack) {
+          if (ack !== noopVoid) {
             // this should be called even if app.view listeners do not exist
             await ack();
             return;

--- a/test/unit/App/routing-function.spec.ts
+++ b/test/unit/App/routing-function.spec.ts
@@ -1,0 +1,111 @@
+import { assert } from 'chai';
+import sinon, { type SinonSpy } from 'sinon';
+import type App from '../../../src/App';
+import {
+  FakeReceiver,
+  type Override,
+  createDummyCustomFunctionMiddlewareArgs,
+  createFakeLogger,
+  importApp,
+  mergeOverrides,
+  noopMiddleware,
+  withConversationContext,
+  withMemoryStore,
+  withNoopAppMetadata,
+  withNoopWebClient,
+} from '../helpers';
+
+function buildOverrides(secondOverrides: Override[]): Override {
+  return mergeOverrides(
+    withNoopAppMetadata(),
+    withNoopWebClient(),
+    ...secondOverrides,
+    withMemoryStore(sinon.fake()),
+    withConversationContext(sinon.fake.returns(noopMiddleware)),
+  );
+}
+
+describe('App function() routing', () => {
+  let fakeReceiver: FakeReceiver;
+  let fakeHandler: SinonSpy;
+  const fakeLogger = createFakeLogger();
+  let dummyAuthorizationResult: { botToken: string; botId: string };
+  let MockApp: Awaited<ReturnType<typeof importApp>>;
+  let app: App;
+
+  beforeEach(async () => {
+    fakeLogger.error.reset();
+    fakeReceiver = new FakeReceiver();
+    fakeHandler = sinon.fake();
+    dummyAuthorizationResult = { botToken: '', botId: '' };
+    MockApp = await importApp(buildOverrides([]));
+    app = new MockApp({
+      logger: fakeLogger,
+      receiver: fakeReceiver,
+      authorize: sinon.fake.resolves(dummyAuthorizationResult),
+    });
+  });
+  describe('for function executed events', () => {
+    it('should route a function executed event to a handler registered with `function(string)` that matches the callback ID', async () => {
+      app.function('my_id', fakeHandler);
+      const args = createDummyCustomFunctionMiddlewareArgs({
+        callbackId: 'my_id',
+        options: { autoAcknowledge: false },
+      });
+      await fakeReceiver.sendEvent({
+        ack: args.ack,
+        body: args.body,
+      });
+      sinon.assert.called(fakeHandler);
+    });
+
+    it('should route a function executed event to a handler with the proper arguments', async () => {
+      const testInputs = { test: true };
+      const testHandler = sinon.spy(async ({ inputs, complete, fail, client }) => {
+        assert.equal(inputs, testInputs);
+        assert.typeOf(complete, 'function');
+        assert.typeOf(fail, 'function');
+        assert.equal(client.token, 'xwfp-valid');
+      });
+      app.function('my_id', testHandler);
+      const args = createDummyCustomFunctionMiddlewareArgs({
+        callbackId: 'my_id',
+        inputs: testInputs,
+        options: { autoAcknowledge: false },
+      });
+      await fakeReceiver.sendEvent({
+        ack: args.ack,
+        body: args.body,
+      });
+      sinon.assert.called(testHandler);
+    });
+
+    it('should route a function executed event to a handler and auto ack by default', async () => {
+      app.function('my_id', fakeHandler);
+      const args = createDummyCustomFunctionMiddlewareArgs({ callbackId: 'my_id' });
+      let isAck = false;
+      await fakeReceiver.sendEvent({
+        ack: async () => {
+          isAck = true;
+        },
+        body: args.body,
+      });
+      sinon.assert.called(fakeHandler);
+      assert.isTrue(isAck);
+    });
+
+    it('should route a function executed event to a handler and NOT auto ack if autoAcknowledge is false', async () => {
+      app.function('my_id', { autoAcknowledge: false }, fakeHandler);
+      const args = createDummyCustomFunctionMiddlewareArgs({ callbackId: 'my_id' });
+      let isAck = false;
+      await fakeReceiver.sendEvent({
+        ack: async () => {
+          isAck = true;
+        },
+        body: args.body,
+      });
+      sinon.assert.called(fakeHandler);
+      assert.isFalse(isAck);
+    });
+  });
+});

--- a/test/unit/CustomFunction.spec.ts
+++ b/test/unit/CustomFunction.spec.ts
@@ -1,21 +1,17 @@
 import { WebClient } from '@slack/web-api';
 import { assert } from 'chai';
-import rewiremock from 'rewiremock';
 import sinon from 'sinon';
 import {
-  type AllCustomFunctionMiddlewareArgs,
   CustomFunction,
-  type CustomFunctionExecuteMiddlewareArgs,
-  type CustomFunctionMiddleware,
   type SlackCustomFunctionMiddlewareArgs,
+  createFunctionComplete,
+  createFunctionFail,
+  matchCallbackId,
+  validate,
 } from '../../src/CustomFunction';
 import { CustomFunctionInitializationError } from '../../src/errors';
-import type { AllMiddlewareArgs, Middleware } from '../../src/types';
-import { type Override, createFakeLogger } from './helpers';
-
-async function importCustomFunction(overrides: Override = {}): Promise<typeof import('../../src/CustomFunction')> {
-  return rewiremock.module(() => import('../../src/CustomFunction'), overrides);
-}
+import { autoAcknowledge, matchEventType, onlyEvents } from '../../src/middleware/builtin';
+import type { Middleware } from '../../src/types';
 
 const MOCK_FN = async () => {};
 const MOCK_FN_2 = async () => {};
@@ -23,65 +19,42 @@ const MOCK_FN_2 = async () => {};
 const MOCK_MIDDLEWARE_SINGLE = [MOCK_FN];
 const MOCK_MIDDLEWARE_MULTIPLE = [MOCK_FN, MOCK_FN_2];
 
-describe('CustomFunction class', () => {
+describe('CustomFunction', () => {
   describe('constructor', () => {
     it('should accept single function as middleware', async () => {
-      const fn = new CustomFunction('test_callback_id', MOCK_MIDDLEWARE_SINGLE, {});
+      const fn = new CustomFunction('test_callback_id', MOCK_MIDDLEWARE_SINGLE, { autoAcknowledge: true });
       assert.isNotNull(fn);
     });
 
     it('should accept multiple functions as middleware', async () => {
-      const fn = new CustomFunction('test_callback_id', MOCK_MIDDLEWARE_MULTIPLE, {});
+      const fn = new CustomFunction('test_callback_id', MOCK_MIDDLEWARE_MULTIPLE, { autoAcknowledge: true });
       assert.isNotNull(fn);
     });
   });
 
-  describe('getMiddleware', () => {
-    it('should not call next if a function_executed event', async () => {
+  describe('getListeners', () => {
+    it('should return an ordered array of listeners used to map function events to handlers', async () => {
       const cbId = 'test_executed_callback_id';
-      const fn = new CustomFunction(cbId, MOCK_MIDDLEWARE_SINGLE, {});
-      const middleware = fn.getMiddleware();
-      const fakeEditArgs = createFakeFunctionExecutedEvent(cbId);
-
-      const fakeNext = sinon.spy();
-      fakeEditArgs.next = fakeNext;
-
-      await middleware(fakeEditArgs);
-
-      assert(fakeNext.notCalled, 'next called!');
+      const fn = new CustomFunction(cbId, MOCK_MIDDLEWARE_SINGLE, { autoAcknowledge: true });
+      const listeners = fn.getListeners();
+      assert.equal(listeners.length, 5);
+      assert.equal(listeners[0], onlyEvents);
+      assert.equal(listeners[1].toString(), matchEventType('function_executed').toString());
+      assert.equal(listeners[2].toString(), matchCallbackId(cbId).toString());
+      assert.equal(listeners[3], autoAcknowledge);
+      assert.equal(listeners[4], MOCK_FN);
     });
 
-    it('should call next if valid custom function but mismatched callback_id', async () => {
-      const fn = new CustomFunction('bad_executed_callback_id', MOCK_MIDDLEWARE_SINGLE, {});
-      const middleware = fn.getMiddleware();
-      const fakeEditArgs = createFakeFunctionExecutedEvent();
-
-      const fakeNext = sinon.spy();
-      fakeEditArgs.next = fakeNext;
-
-      await middleware(fakeEditArgs);
-
-      assert(fakeNext.called);
-    });
-
-    it('should call next if not a function executed event', async () => {
-      const fn = new CustomFunction('test_view_callback_id', MOCK_MIDDLEWARE_SINGLE, {});
-      const middleware = fn.getMiddleware();
-      const fakeViewArgs = createFakeViewEvent() as unknown as SlackCustomFunctionMiddlewareArgs & AllMiddlewareArgs;
-
-      const fakeNext = sinon.spy();
-      fakeViewArgs.next = fakeNext;
-
-      await middleware(fakeViewArgs);
-
-      assert(fakeNext.called);
+    it('should return a array of listeners without the autoAcknowledge middleware when auto acknowledge is disabled', async () => {
+      const cbId = 'test_executed_callback_id';
+      const fn = new CustomFunction(cbId, MOCK_MIDDLEWARE_SINGLE, { autoAcknowledge: false });
+      const listeners = fn.getListeners();
+      assert.isFalse(listeners.includes(autoAcknowledge));
     });
   });
 
   describe('validate', () => {
     it('should throw an error if callback_id is not valid', async () => {
-      const { validate } = await importCustomFunction();
-
       // intentionally casting to string to trigger failure
       const badId = {} as string;
       const validationFn = () => validate(badId, MOCK_MIDDLEWARE_SINGLE);
@@ -91,10 +64,8 @@ describe('CustomFunction class', () => {
     });
 
     it('should throw an error if middleware is not a function or array', async () => {
-      const { validate } = await importCustomFunction();
-
-      // intentionally casting to CustomFunctionMiddleware to trigger failure
-      const badConfig = '' as unknown as CustomFunctionMiddleware;
+      // intentionally casting to Middleware<SlackCustomFunctionMiddlewareArgs>[] to trigger failure
+      const badConfig = '' as unknown as Middleware<SlackCustomFunctionMiddlewareArgs>[];
 
       const validationFn = () => validate('callback_id', badConfig);
       const expectedMsg = 'CustomFunction expects a function or array of functions as the second argument';
@@ -102,58 +73,15 @@ describe('CustomFunction class', () => {
     });
 
     it('should throw an error if middleware is not a single callback or an array of callbacks', async () => {
-      const { validate } = await importCustomFunction();
-
-      // intentionally casting to CustomFunctionMiddleware to trigger failure
-      const badMiddleware = [async () => {}, 'not-a-function'] as unknown as CustomFunctionMiddleware;
+      // intentionally casting to Middleware<SlackCustomFunctionMiddlewareArgs>[] to trigger failure
+      const badMiddleware = [
+        async () => {},
+        'not-a-function',
+      ] as unknown as Middleware<SlackCustomFunctionMiddlewareArgs>[];
 
       const validationFn = () => validate('callback_id', badMiddleware);
       const expectedMsg = 'All CustomFunction middleware must be functions';
       assert.throws(validationFn, CustomFunctionInitializationError, expectedMsg);
-    });
-  });
-
-  describe('isFunctionEvent', () => {
-    it('should return true if recognized function_executed payload type', async () => {
-      const fakeExecuteArgs = createFakeFunctionExecutedEvent();
-
-      const { isFunctionEvent } = await importCustomFunction();
-      const eventIsFunctionExcuted = isFunctionEvent(fakeExecuteArgs);
-
-      assert.isTrue(eventIsFunctionExcuted);
-    });
-
-    it('should return false if not a function_executed payload type', async () => {
-      const fakeExecutedEvent = createFakeFunctionExecutedEvent();
-      // @ts-expect-error expected invalid payload type
-      fakeExecutedEvent.payload.type = 'invalid_type';
-
-      const { isFunctionEvent } = await importCustomFunction();
-      const eventIsFunctionExecuted = isFunctionEvent(fakeExecutedEvent);
-
-      assert.isFalse(eventIsFunctionExecuted);
-    });
-  });
-
-  describe('enrichFunctionArgs', () => {
-    it('should remove next() from all original event args', async () => {
-      const fakeExecutedEvent = createFakeFunctionExecutedEvent();
-
-      const { enrichFunctionArgs } = await importCustomFunction();
-      const executeFunctionArgs = enrichFunctionArgs(fakeExecutedEvent, {});
-
-      assert.notExists(executeFunctionArgs.next);
-    });
-
-    it('should augment function_executed args with inputs, complete, and fail', async () => {
-      const fakeArgs = createFakeFunctionExecutedEvent();
-
-      const { enrichFunctionArgs } = await importCustomFunction();
-      const functionArgs = enrichFunctionArgs(fakeArgs, {});
-
-      assert.exists(functionArgs.inputs);
-      assert.exists(functionArgs.complete);
-      assert.exists(functionArgs.fail);
     });
   });
 
@@ -162,17 +90,14 @@ describe('CustomFunction class', () => {
       it('complete should call functions.completeSuccess', async () => {
         const client = new WebClient('sometoken');
         const completeMock = sinon.stub(client.functions, 'completeSuccess').resolves();
-        const complete = CustomFunction.createFunctionComplete(
-          { isEnterpriseInstall: false, functionExecutionId: 'Fx1234' },
-          client,
-        );
+        const complete = createFunctionComplete({ isEnterpriseInstall: false, functionExecutionId: 'Fx1234' }, client);
         await complete();
         assert(completeMock.called, 'client.functions.completeSuccess not called!');
       });
       it('should throw if no functionExecutionId present on context', () => {
         const client = new WebClient('sometoken');
         assert.throws(() => {
-          CustomFunction.createFunctionComplete({ isEnterpriseInstall: false }, client);
+          createFunctionComplete({ isEnterpriseInstall: false }, client);
         });
       });
     });
@@ -181,119 +106,16 @@ describe('CustomFunction class', () => {
       it('fail should call functions.completeError', async () => {
         const client = new WebClient('sometoken');
         const completeMock = sinon.stub(client.functions, 'completeError').resolves();
-        const complete = CustomFunction.createFunctionFail(
-          { isEnterpriseInstall: false, functionExecutionId: 'Fx1234' },
-          client,
-        );
+        const complete = createFunctionFail({ isEnterpriseInstall: false, functionExecutionId: 'Fx1234' }, client);
         await complete({ error: 'boom' });
         assert(completeMock.called, 'client.functions.completeError not called!');
       });
       it('should throw if no functionExecutionId present on context', () => {
         const client = new WebClient('sometoken');
         assert.throws(() => {
-          CustomFunction.createFunctionFail({ isEnterpriseInstall: false }, client);
+          createFunctionFail({ isEnterpriseInstall: false }, client);
         });
       });
     });
-
-    it('inputs should map to function payload inputs', async () => {
-      const fakeExecuteArgs = createFakeFunctionExecutedEvent();
-
-      const { enrichFunctionArgs } = await importCustomFunction();
-      const enrichedArgs = enrichFunctionArgs(fakeExecuteArgs, {});
-
-      assert.isTrue(enrichedArgs.inputs === fakeExecuteArgs.event.inputs);
-    });
-  });
-
-  describe('processFunctionMiddleware', () => {
-    it('should call each callback in user-provided middleware', async () => {
-      const { ...fakeArgs } = createFakeFunctionExecutedEvent();
-      const { processFunctionMiddleware } = await importCustomFunction();
-
-      const fn1 = sinon.spy((async ({ next: continuation }) => {
-        await continuation();
-      }) as Middleware<CustomFunctionExecuteMiddlewareArgs>);
-      const fn2 = sinon.spy(async () => {});
-      const fakeMiddleware = [fn1, fn2] as CustomFunctionMiddleware;
-
-      await processFunctionMiddleware(fakeArgs, fakeMiddleware);
-
-      assert(fn1.called, 'first user-provided middleware not called!');
-      assert(fn2.called, 'second user-provided middleware not called!');
-    });
   });
 });
-
-function createFakeFunctionExecutedEvent(callbackId?: string): AllCustomFunctionMiddlewareArgs {
-  const func = {
-    type: 'function',
-    id: 'somefunc',
-    callback_id: callbackId || 'callback_id',
-    title: 'My dope function',
-    input_parameters: [],
-    output_parameters: [],
-    app_id: 'A1234',
-    date_created: 123456,
-    date_deleted: 0,
-    date_updated: 123456,
-  };
-  const base = {
-    bot_access_token: 'xoxb-abcd-1234',
-    event_ts: '123456.789',
-    function_execution_id: 'Fx1234',
-    workflow_execution_id: 'Wf1234',
-    type: 'function_executed',
-  } as const;
-  const inputs = { message: 'test123', recipient: 'U012345' };
-  const event = {
-    function: func,
-    inputs,
-    ...base,
-  } as const;
-  return {
-    body: {
-      api_app_id: 'A1234',
-      event,
-      event_id: 'E1234',
-      event_time: 123456,
-      team_id: 'T1234',
-      token: 'xoxb-1234',
-      type: 'event_callback',
-    },
-    client: new WebClient('faketoken'),
-    complete: () => Promise.resolve({ ok: true }),
-    context: {
-      functionBotAccessToken: 'xwfp-123',
-      functionExecutionId: 'test_executed_callback_id',
-      isEnterpriseInstall: false,
-    },
-    event,
-    fail: () => Promise.resolve({ ok: true }),
-    inputs,
-    logger: createFakeLogger(),
-    next: () => Promise.resolve(),
-    payload: {
-      function: func,
-      inputs: { message: 'test123', recipient: 'U012345' },
-      ...base,
-    },
-  };
-}
-
-function createFakeViewEvent() {
-  return {
-    body: {
-      callback_id: 'test_view_callback_id',
-      trigger_id: 'test_view_trigger_id',
-      workflow_step: {
-        workflow_step_edit_id: '',
-      },
-    },
-    payload: {
-      type: 'view_submission',
-      callback_id: 'test_view_callback_id',
-    },
-    context: {},
-  };
-}

--- a/test/unit/helpers/app.ts
+++ b/test/unit/helpers/app.ts
@@ -58,7 +58,13 @@ export function withNoopWebClient(authTestResponse?: AuthTestResponse): Override
               test: sinon.fake.resolves(authTestResponse),
             };
           }
-        : class {},
+        : class {
+            public token?: string;
+
+            public constructor(token?: string, _options?: WebClientOptions) {
+              this.token = token;
+            }
+          },
     },
   };
 }

--- a/test/unit/middleware/builtin.spec.ts
+++ b/test/unit/middleware/builtin.spec.ts
@@ -2,9 +2,15 @@
 import { assert } from 'chai';
 import rewiremock from 'rewiremock';
 import sinon from 'sinon';
+import { expectType } from 'tsd';
 import { ErrorCode } from '../../../src/errors';
+import { isSlackEventMiddlewareArgsOptions } from '../../../src/middleware/builtin';
 // import { matchCommandName, matchEventType, onlyCommands, onlyEvents, subtype } from '../../../src/middleware/builtin';
-import type { Context, /* NextFn, */ SlackEventMiddlewareArgs } from '../../../src/types';
+import type {
+  Context,
+  /* NextFn, */ SlackEventMiddlewareArgs,
+  SlackEventMiddlewareArgsOptions,
+} from '../../../src/types';
 import {
   type Override,
   createDummyAppHomeOpenedEventMiddlewareArgs,
@@ -408,6 +414,27 @@ describe('Built-in global middleware', () => {
         );
         await builtins.subtype('me_message')(args);
         sinon.assert.notCalled(args.next);
+      });
+    });
+
+    describe(isSlackEventMiddlewareArgsOptions.name, () => {
+      it('should return true if object is SlackEventMiddlewareArgsOptions', async () => {
+        const actual = isSlackEventMiddlewareArgsOptions({ autoAcknowledge: true });
+        assert.isTrue(actual);
+      });
+
+      it('should narrow proper type if object is SlackEventMiddlewareArgsOptions', async () => {
+        const option = { autoAcknowledge: true };
+        if (isSlackEventMiddlewareArgsOptions({ autoAcknowledge: true })) {
+          expectType<SlackEventMiddlewareArgsOptions>(option);
+        } else {
+          assert.fail(`${option} should be of type SlackEventMiddlewareArgsOption`);
+        }
+      });
+
+      it('should return false if object is Middleware', async () => {
+        const actual = isSlackEventMiddlewareArgsOptions(async () => {});
+        assert.isFalse(actual);
       });
     });
   });


### PR DESCRIPTION
### Summary

Most changes in this PR come from approved #2283 but limit the affected behavior to `function_executed` events

#### Changes

This PR changes the way to `function_executed` events auto acknowledgement behavior operates. These changes remove auto acknowledgement for `function_executed` events and lift the logic into a middleware that is then registered to the `function` event listener

This allows the `app.function` listener to expose an `autoAcknowledge` flag that can be used to disable the auto ack middleware. This is required for the Dynamic Options, since functions used as dynamic inputs must `complete` or `fail` before acknowledging the request (this provides a crisp user experience).

#### Example
```ts
app.function('get-options', { autoAcknowledge: false }, async ({ inputs, ack, fail, complete }) => {
  try {
    const category: string[] = inputs.category as string[];
    if (category.includes('dogs')) {
      complete({
        outputs: {
          options: [
            { key: 'Poodle', value: 'value-0' },
            { key: 'Bulldog', value: 'value-1' },
            { key: 'Beagle', value: 'value-2' },
          ],
        },
      });
    } else if (category.includes('cars')) {
      complete({
        outputs: {
          options: [
            { key: 'Toyota', value: 'value-0' },
            { key: 'Ford', value: 'value-1' },
            { key: 'Jeep', value: 'value-2' },
          ],
        },
      });
    } else {
      fail({ error: `Invalid category: ${category} (valid: 'dogs', 'cars')` });
    }
  } catch (error) {
    fail({ error: `Failed to handle a function request (error: ${error})` });
  } finally {
    await ack();
  }
});
```

#### Manual tests

These changes were manually tested against
- [bolt-js-custom-step-template](https://github.com/slack-samples/bolt-js-custom-step-template) -> no breaking change observed 🟢 
- [bolt-ts-starter-template](https://github.com/slack-samples/bolt-ts-starter-template) -> no breaking change observed 🟢 

#### Testing
1. Pull this branch
2. `npm install` & `npm run build`
3. Use `npm install path/to/the/bolt-js/project` to install the built package in a project with a custom step like [bolt-js-custom-step-template](https://github.com/slack-samples/bolt-js-custom-step-template)
4. Set the options field of the function handler to  `{ autoAcknowledge: false }`
5. You should now be able to use the `ack` input parameter in your handler
6. AutoAck behavior is now disabled you must now manually call `await ack();` for this specfic handler

#### Feedback

I've messed around with the `CustomFunction exported types` I am not if these are considered "breaking changes" in this project. There may be a way to work around this.

Should there be more unit tests around these changes?

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).