### PR TITLE
docs: add xapp section

### DIFF
--- a/docs/i18n/ja-jp/docusaurus-plugin-content-docs/current/getting-started.mdx
+++ b/docs/i18n/ja-jp/docusaurus-plugin-content-docs/current/getting-started.mdx
@@ -188,6 +188,35 @@ import TabItem from '@theme/TabItem';
 
 もしボットに参加しているすべての場所で全てのメッセージイベントをリッスンさせたいなら、これら４つ全てのイベントを選んでください。選択したら、緑の **Save Changes** ボタンをクリックします。
 
+<Tabs groupId="socket-or-http">
+<TabItem value="socket-mode" label="Socket Mode">
+
+プロジェクトに戻り、先ほど保存した `xapp` トークンを環境変数に保存してください。
+
+```shell
+export SLACK_APP_TOKEN=xapp-<your-app-token>
+```
+
+Bolt の初期化部分のコードを変更し、アプリを再起動してください。
+
+```javascript
+// ソケットモードでトークンおよび signing secret で初期化します。
+const app = new App({
+  token: process.env.SLACK_BOT_TOKEN,
+  signingSecret: process.env.SLACK_SIGNING_SECRET,
+  socketMode: true, // 追加
+  appToken: process.env.SLACK_APP_TOKEN // 追加
+});
+```
+
+</TabItem>
+<TabItem value="http" label="HTTP">
+
+作業中です！
+
+</TabItem>
+</Tabs>
+
 ---
 
 ## メッセージのリスニングと応答 {#listening-and-responding-to-a-message}

--- a/docs/i18n/ja-jp/docusaurus-plugin-content-docs/current/getting-started.mdx
+++ b/docs/i18n/ja-jp/docusaurus-plugin-content-docs/current/getting-started.mdx
@@ -212,7 +212,7 @@ const app = new App({
 </TabItem>
 <TabItem value="http" label="HTTP">
 
-特に追加の設定は無いので、そのまま続けてください！
+ここでの設定は特にありません。このまま続けてください！
 
 </TabItem>
 </Tabs>

--- a/docs/i18n/ja-jp/docusaurus-plugin-content-docs/current/getting-started.mdx
+++ b/docs/i18n/ja-jp/docusaurus-plugin-content-docs/current/getting-started.mdx
@@ -212,7 +212,7 @@ const app = new App({
 </TabItem>
 <TabItem value="http" label="HTTP">
 
-作業中です！
+特に追加の設定は無いので、そのまま続けてください！
 
 </TabItem>
 </Tabs>


### PR DESCRIPTION
### Summary

I added an explanation about saving a certain environment variable to the Japanese documentation since it was mentioned in the English documentation but not in the Japanese one.

#### en

<img width="917" alt="image" src="https://github.com/user-attachments/assets/5717e765-31c8-40ed-b542-f1fa9e7fdb7e">

#### ja

<img width="825" alt="image" src="https://github.com/user-attachments/assets/4d23468b-5dda-48e5-bf4c-fae2eaf98228">

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).