### PR TITLE
build: find the biome config schema from the installed path

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/1.8.3/schema.json",
+  "$schema": "./node_modules/@biomejs/biome/configuration_schema.json",
   "files": {
     "ignore": [
       "docs/_site",


### PR DESCRIPTION
### Summary

This PR updates the `$schema` of `biome.json` to use the relative path to the installed JSON schema file, as recommended in https://biomejs.dev/reference/configuration/#schema

Fixes an issue where an updated version of `biome` might add or remove configurations not existing for version 1.8.3, which would invalidate this JSON schema! 😳 

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).