### PR TITLE
build: update the redirected repo homepage url to postfix js

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "test:types": "tsd --files test/types",
     "watch": "npx nodemon --watch 'src' --ext 'ts' --exec npm run build"
   },
-  "repository": "slackapi/bolt",
+  "repository": "slackapi/bolt-js",
   "homepage": "https://tools.slack.dev/bolt-js",
   "bugs": {
     "url": "https://github.com/slackapi/bolt-js/issues"


### PR DESCRIPTION
### Summary

This PR updates the `repository` field of this package to use the most recent `slackapi/bolt-js` path of this repo! 👾 

### Preview

NPM: https://www.npmjs.com/package/@slack/bolt

### Notes

Docs: https://docs.npmjs.com/cli/v10/configuring-npm/package-json?v=true#repository

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).