### PR TITLE
chore(release): publish @slack/bolt@4.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slack/bolt",
-  "version": "4.1.1",
+  "version": "4.2.0",
   "description": "A framework for building Slack apps, fast.",
   "author": "Slack Technologies, LLC",
   "license": "MIT",


### PR DESCRIPTION
### Summary

This PR tags the latest changes with a new minor version `4.2.0` - this includes changes from both [4.1.2](https://github.com/slackapi/bolt-js/milestone/53) and [4.2.0](https://github.com/slackapi/bolt-js/milestone/51) milestones.

### Notes

- [x] Prior to merging this PR, I'll merge the changes in https://github.com/slackapi/bolt-js/pull/2365 - holding off on that until we're set to release!

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).