### PR TITLE
ci: add example app dependencies to weekly dependabot configurations

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,3 +24,17 @@ updates:
       docusaurus:
         patterns:
           - "@docusaurus/*"
+  - package-ecosystem: "npm"
+    directories:
+      - "/examples/custom-properties"
+      - "/examples/custom-receiver"
+      - "/examples/deploy-aws-lambda"
+      - "/examples/deploy-heroku"
+      - "/examples/getting-started-typescript"
+      - "/examples/message-metadata"
+      - "/examples/oauth-express-receiver"
+      - "/examples/oauth"
+      - "/examples/socket-mode-oauth"
+      - "/examples/socket-mode"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
### Summary

This PR adds **all** of the included example apps to the @dependabot configurations to help keep these dependencies up-to-date 👾 

### Notes

A few changes might be needed to merge future updates, but I think those are alright to save for follow-up PRs 🙏 ✨

Reference: https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#directories-or-directory--

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).