### PR TITLE
bug: make `@types/express` an optional peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,6 @@
     "@biomejs/biome": "^1.9.0",
     "@tsconfig/node18": "^18.2.4",
     "@types/chai": "^4.1.7",
-    "@types/express": "^5.0.0",
     "@types/mocha": "^10.0.1",
     "@types/node": "22.13.1",
     "@types/sinon": "^7.0.11",
@@ -72,5 +71,13 @@
     "ts-node": "^10.9.2",
     "tsd": "^0.31.2",
     "typescript": "5.3.3"
+  },
+  "peerDependencies": {
+    "@types/express": "^5.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@types/express": {
+      "optional": true
+    }
   }
 }


### PR DESCRIPTION
### Summary

This aims to resolve #2409

In #2355 we moved `@types/express` from `dependencies` to `devDependencies`. This PR aims to make `@types/express` an `optional` `peerDependency` allowing the package to be used without being automatically installed 


### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).