### PR TITLE
fix: configure dependbot to group react deps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,6 +24,10 @@ updates:
       docusaurus:
         patterns:
           - "@docusaurus/*"
+      react:
+        patterns:
+          - "react"
+          - "react-dom"
   - package-ecosystem: "npm"
     directories:
       - "/examples/custom-properties"


### PR DESCRIPTION
### Summary

#2414 and #2413 are failing tests because dependabot is opening separate PR for `react` and `react-dom` dependencies, I believe these dependencies must stay in sync in order for the tests to pass.

Once this PR is merged dependabot should open one single PR to replace #2414 and #2413

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).