### PR TITLE
chore: make @types/express optional peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,5 +74,10 @@
   },
   "peerDependencies": {
     "@types/express": "^5.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@types/express": {
+      "optional": true
+    }
   }
 }


### PR DESCRIPTION
### Summary
using the peerDependenciesMeta to decalre the peer dependency as optional

In https://github.com/slackapi/bolt-js/pull/2421 a change was made (in release `v4.2.1`) to make `@types/express` an optional peer dependency. This change actually made the package a required peer dependency, and we must declare `peerDependenciesMeta` to make this optional.

NPM docs here: https://docs.npmjs.com/cli/v10/configuring-npm/package-json#peerdependenciesmeta

Thanks!

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).