### PR TITLE
chore(deps): bump axios to 1.8.3 to address CVE-2025-27152

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@slack/socket-mode": "^2.0.3",
     "@slack/types": "^2.13.0",
     "@slack/web-api": "^7.8.0",
-    "axios": "^1.8.2",
+    "axios": "^1.8.3",
     "express": "^5.0.0",
     "path-to-regexp": "^8.1.0",
     "raw-body": "^3",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@slack/socket-mode": "^2.0.3",
     "@slack/types": "^2.13.0",
     "@slack/web-api": "^7.8.0",
-    "axios": "^1.7.8",
+    "axios": "^1.8.2",
     "express": "^5.0.0",
     "path-to-regexp": "^8.1.0",
     "raw-body": "^3",


### PR DESCRIPTION
### Summary

This PR updates `axios` to `1.8.3` to address CVE-2025-27152 - as noted in slackapi/node-slack-sdk#2169 🔐

### Notes

A `semver:minor` release for `axios` happened with this change, but AFAICT no other changes are needed. It might be nice to share [these changes](https://github.com/axios/axios/releases/tag/v1.8.0) in a following patch 👀

Also, `axios` is also a dependency of `@slack/web-api` which has a similar PR in https://github.com/slackapi/node-slack-sdk/pull/2172 that might be worth including in the related `@slack/bolt` release?

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).