### PR TITLE
ci: increase updated versions to depend on the latest releases

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,7 @@ updates:
       - dependency-name: "@types/node"
       # allow updates for slack official libraries
       - dependency-name: "@slack/*"
+    versioning-strategy: increase
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
@@ -42,3 +43,4 @@ updates:
       - "/examples/socket-mode"
     schedule:
       interval: "weekly"
+    versioning-strategy: increase


### PR DESCRIPTION
### Summary

This PR uses the "increase" [`versioning-strategy`](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#versioning-strategy--) @dependabot has to match the latest upstream `@slack` dependencies 📦 ✨

### Notes

This change is suggested after finding "[dependabot only updates lock file](https://stackoverflow.com/questions/60201543/dependabot-only-updates-lock-file)" when started from the **Insights** tab AFAICT. If applied, I'm hoping we'll find these updates afterwards 👾

https://github.com/slackapi/bolt-js/actions/runs/14114557499/job/39541462306#step:3:1295:

```
updater | 2025/03/27 18:57:35 INFO <job_988067578> Started process PID: 1732 with command: {} npm install @slack/web-api@7.9.1 --package-lock-only --dry-run\=true --ignore-scripts {}
```

I'm curious if keeping up-to-date with the latest `@slack` packages makes sense for `@slack/bolt` overall? I believe sometimes options are added upstream that we use here, so this might guarantee the latest `@slack/bolt` will be working with these. I'm not sure if other `@slack` dependencies are sometimes pinned to different versions in application code though.

IMO recommending the latest versions are used altogether does seem nice for avoiding strange edge cases overall...

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).