### PR TITLE
ci: label updates to example app dependencies with an 'area:examples' label

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -41,6 +41,10 @@ updates:
       - "/examples/oauth"
       - "/examples/socket-mode-oauth"
       - "/examples/socket-mode"
+    labels:
+      - "area:examples"
+      - "dependencies"
+      - "javascript"
     schedule:
       interval: "weekly"
     versioning-strategy: increase


### PR DESCRIPTION
### Summary

This PR adds the `area:examples` [label](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#labels--) to automatic updates of example app dependencies thanks to the kind @dependabot 🤖 ✨ 

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).