### PR TITLE
fix: allow all web api client option types in app initialization

### DIFF
--- a/src/App.ts
+++ b/src/App.ts
@@ -127,7 +127,12 @@ export interface AppOptions {
   logger?: Logger;
   logLevel?: LogLevel;
   ignoreSelf?: boolean;
-  clientOptions?: Pick<WebClientOptions, 'slackApiUrl'>;
+  /**
+   * Configurations for the web client used to send Slack API method requests.
+   *
+   * See {@link https://tools.slack.dev/node-slack-sdk/reference/web-api/interfaces/WebClientOptions} for more information.
+   */
+  clientOptions?: WebClientOptions;
   socketMode?: boolean;
   developerMode?: boolean;
   tokenVerificationEnabled?: boolean;

--- a/test/types/App.test-d.ts
+++ b/test/types/App.test-d.ts
@@ -1,0 +1,64 @@
+import { Agent } from 'node:http';
+import { ConsoleLogger, LogLevel } from '@slack/logger';
+import type { Installation, InstallationQuery } from '@slack/oauth';
+import { expectAssignable, expectError, expectType } from 'tsd';
+import App from '../../src/App';
+
+expectAssignable<App>(
+  new App({
+    token: 'xoxb-example',
+    signingSecret: 'secretpassword',
+  }),
+);
+
+expectAssignable<App>(
+  new App({
+    token: 'xoxb-example',
+    socketMode: true,
+    appToken: 'xapp-example',
+  }),
+);
+
+expectAssignable<App>(
+  new App({
+    logLevel: LogLevel.DEBUG,
+    signingSecret: 'secretpassword',
+    clientId: '0123456789',
+    clientSecret: 'randomvalues',
+    stateSecret: 'hidden',
+    scopes: ['chat:write'],
+    installationStore: {
+      storeInstallation: async <AuthVersion extends 'v1' | 'v2'>(installation: Installation<AuthVersion, boolean>) => {
+        expectType<Installation<AuthVersion, boolean>>(installation);
+      },
+      fetchInstallation: async (query) => {
+        expectType<InstallationQuery<boolean>>(query);
+        return {
+          user: { token: undefined, scopes: [], id: 'U0123456789' },
+          bot: { token: 'xoxb-example', scopes: ['chat:write'], id: 'B0123456789', userId: 'U0101010101' },
+          team: { id: 'T0123456789' },
+          enterprise: undefined,
+        };
+      },
+      deleteInstallation: async (query) => {
+        expectType<InstallationQuery<boolean>>(query);
+      },
+    },
+  }),
+);
+
+expectAssignable<App>(
+  new App({
+    clientOptions: {
+      agent: new Agent(),
+      allowAbsoluteUrls: false,
+      logger: new ConsoleLogger(),
+      retryConfig: {
+        forever: true,
+      },
+      slackApiUrl: 'http://localhost:8080/api/',
+    },
+  }),
+);
+
+expectError(new App({ password: 'randomish!' }));


### PR DESCRIPTION
### Summary

This PR exposes **all** options of [`WebClient`](https://tools.slack.dev/node-slack-sdk/reference/web-api/interfaces/WebClientOptions) to the `App` constructor since these values can be customized for behaviors that might be specific to calls of the Slack Web API methods. Perhaps for a custom `logger` or other added options.

Fixes #2484.

### Preview

With `typescript` setups the following will now check without errors:

```ts
const app = new App({
  token: process.env.SLACK_BOT_TOKEN,
  socketMode: true,
  appToken: process.env.SLACK_APP_TOKEN,
  logLevel: LogLevel.DEBUG,
  clientOptions: {
    allowAbsoluteUrls: false,
    slackApiUrl: "http://localhost:8080/api",
  },
});
```

### Notes

All provided options are shared when the `WebClient` is constructed:

https://github.com/slackapi/bolt-js/blob/20a5997f550b8d8bb2f995e36cad28af9d1cac1c/src/App.ts#L336-L353

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).