### PR TITLE
API Docs: Replace OpenAI references with Hugging Face

### DIFF
--- a/docs/content/concepts/ai-apps.md
+++ b/docs/content/concepts/ai-apps.md
@@ -113,7 +113,7 @@ There are three [utilities](/reference#the-assistantconfig-configuration-object)
 * `setTitle`
 * `setStatus`
 
-The following example uses the [OpenAI API client](https://platform.openai.com/docs/api-reference/introduction), but you can substitute it with the AI client of your choice.
+The following example uses a [Hugging Face inference provider](https://huggingface.co/docs/inference-providers/en/index), but you can substitute it with the AI client of your choice.
 
  ```js
  ...
@@ -145,10 +145,10 @@ The following example uses the [OpenAI API client](https://platform.openai.com/d
       ];
 
       // Send message history and newest question to LLM
-      const llmResponse = await openai.chat.completions.create({
-        model: 'gpt-4o-mini',
-        n: 1,
+      const llmResponse = await hfClient.chatCompletion({
+        model: 'Qwen/QwQ-32B',
         messages,
+        max_tokens: 2000,
       });
 
       // Provide a response to the user


### PR DESCRIPTION
### Summary

For internal reasons, we're updating our sample code to use Hugging Face instead of OpenAI. This will get merged alongside [this PR](https://github.com/slack-samples/bolt-js-assistant-template/pull/29) that updates the sample app these docs reference.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).