### PR TITLE
fix: always attach the function bot access token to the context if available

### DIFF
--- a/src/App.ts
+++ b/src/App.ts
@@ -969,10 +969,6 @@ export default class App<AppCustomContext extends StringIndexed = StringIndexed>
       if (functionInputs) {
         context.functionInputs = functionInputs;
       }
-    }
-
-    // Attach and make available the JIT/function-related token on context
-    if (this.attachFunctionToken) {
       if (functionBotAccessToken) {
         context.functionBotAccessToken = functionBotAccessToken;
       }


### PR DESCRIPTION
### Summary

This PR adds to the refactors of #2424 to always attach the **function** bot access token to the context if it's available.

Changes of the linked PR now use a shared `selectToken` function that no longer relies on this value in `context` to determine which `token` to use - either [workflow](https://docs.slack.dev/authentication/tokens/#wfb), bot, or user - and now use the `attachFunctionToken` argument:

https://github.com/slackapi/bolt-js/blob/d61f2cd8aeb640440a3cbf8e48d17ca05adb76eb/src/App.ts#L1580-L1591

### Preview

Before changes we had implicit use of this value to decide which token to use in the `app.function` listener:

https://github.com/slackapi/bolt-js/blob/657416fa061f9bebd1c9bdd61af2722730eb1971/src/App.ts#L973-L978

https://github.com/slackapi/bolt-js/blob/657416fa061f9bebd1c9bdd61af2722730eb1971/src/App.ts#L1102-L1105

https://github.com/slackapi/bolt-js/blob/657416fa061f9bebd1c9bdd61af2722730eb1971/src/CustomFunction.ts#L185-L188

### Notes

Including this in `context` gives a choice of using this token in certain circumstances, even if `attachFunctionToken` is **false**! 🤖 ✨ 

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).