### PR TITLE
fix: always attach the function inputs to the context if available

### DIFF
--- a/src/App.ts
+++ b/src/App.ts
@@ -1623,6 +1623,7 @@ function extractFunctionContext(body: StringIndexed) {
   if (body.event && body.event.type === 'function_executed' && body.event.function_execution_id) {
     functionExecutionId = body.event.function_execution_id;
     functionBotAccessToken = body.event.bot_access_token;
+    functionInputs = body.event.inputs;
   }
 
   // interactivity (block_actions)

--- a/test/unit/App/middlewares/arguments.spec.ts
+++ b/test/unit/App/middlewares/arguments.spec.ts
@@ -786,6 +786,7 @@ describe('App middleware and listener arguments', () => {
       app.function(callbackId, async ({ context }) => {
         assert.strictEqual(context.functionExecutionId, functionExecutionId);
         assert.strictEqual(context.functionBotAccessToken, functionBotAccessToken);
+        assert.deepStrictEqual(context.functionInputs, inputs);
         called = true;
       });
       app.error(fakeErrorHandler);


### PR DESCRIPTION
### Summary

This PR attaches the executed step `inputs` values of a `function_executed` event to the `context` to match the behavior of `block_actions` 🙏 

Context: https://github.com/slackapi/bolt-js/pull/2513#discussion_r2072252058

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).