### PR TITLE
docs(fix): redirect links for project package migration guides to the tools site

### DIFF
--- a/docs/content/migration/migration-v4.md
+++ b/docs/content/migration/migration-v4.md
@@ -56,11 +56,11 @@ With the above, now when a message payload is wrapped in middleware arguments, i
 
 All bolt handlers are [provided a convenience `client` argument](../concepts/web-api) that developers can use to make API requests to [Slack's public HTTP APIs][methods]. This `client` is powered by [the `@slack/web-api` package][web-api]. In bolt v4, `web-api` has been upgraded from v6 to v7.
 
-More APIs! Better argument type safety! And a whole slew of other changes, too. Many of these changes won't affect JavaScript application builders, but if you are building a bolt app using TypeScript, you may see some compilation issues. Head over to [the `@slack/web-api` v6 -> v7 migration guide](https://github.com/slackapi/node-slack-sdk/wiki/Migration-Guide-for-web%E2%80%90api-v7) to get the details on what changed and how to migrate to v7.
+More APIs! Better argument type safety! And a whole slew of other changes, too. Many of these changes won't affect JavaScript application builders, but if you are building a bolt app using TypeScript, you may see some compilation issues. Head over to [the `@slack/web-api` v6 -> v7 migration guide](https://tools.slack.dev/node-slack-sdk/migration/migrating-web-api-package-to-v7) to get the details on what changed and how to migrate to v7.
 
 ## 🔌 `@slack/socket-mode` v2 upgrade {#socket-mode-v2}
 
-While the breaking changes from this upgrade should be shielded from most bolt-js users, if you are using [the `SocketModeReceiver` or setting `socketMode: true`](../concepts/socket-mode) _and_ attach custom code to how the `SocketModeReceiver` operates, we suggest you read through [the `@slack/socket-mode` v1 -> v2 migration guide](https://github.com/slackapi/node-slack-sdk/wiki/Migration-Guide-for-socket%E2%80%90mode-2.0), just in case.
+While the breaking changes from this upgrade should be shielded from most bolt-js users, if you are using [the `SocketModeReceiver` or setting `socketMode: true`](../concepts/socket-mode) _and_ attach custom code to how the `SocketModeReceiver` operates, we suggest you read through [the `@slack/socket-mode` v1 -> v2 migration guide](https://tools.slack.dev/node-slack-sdk/migration/migrating-socket-mode-package-to-v2/), just in case.
 
 ## 🚅 `express` v5 upgrade {#express-v5}
 


### PR DESCRIPTION
### Summary

This PR redirects links for project package migrations guide when upgrade to `@v4` to the [tools.slack.dev](https://tools.slack.dev) equivalents 📚 ✨ 

Fixes https://github.com/slackapi/node-slack-sdk/issues/2251!

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).