### PR TITLE
chore: update dependabot to open one PR for all @slack dependencies in /examples

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,21 +30,15 @@ updates:
           - "react"
           - "react-dom"
   - package-ecosystem: "npm"
-    directories:
-      - "/examples/custom-properties"
-      - "/examples/custom-receiver"
-      - "/examples/deploy-aws-lambda"
-      - "/examples/deploy-heroku"
-      - "/examples/getting-started-typescript"
-      - "/examples/message-metadata"
-      - "/examples/oauth-express-receiver"
-      - "/examples/oauth"
-      - "/examples/socket-mode-oauth"
-      - "/examples/socket-mode"
+    directory: "/examples"
+    schedule:
+      interval: "weekly"
     labels:
       - "area:examples"
       - "dependencies"
       - "javascript"
-    schedule:
-      interval: "weekly"
     versioning-strategy: increase
+    groups:
+      slack:
+        patterns:
+          - "@slack/*"


### PR DESCRIPTION
### Summary

This PR aims to update the dependabot configuration so that it opens one PR for all examples that bump the slack dependencies

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).