### PR TITLE
Revert "chore: update dependabot to open one PR for all @slack depend…

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,15 +30,21 @@ updates:
           - "react"
           - "react-dom"
   - package-ecosystem: "npm"
-    directory: "/examples"
-    schedule:
-      interval: "weekly"
+    directories:
+      - "/examples/custom-properties"
+      - "/examples/custom-receiver"
+      - "/examples/deploy-aws-lambda"
+      - "/examples/deploy-heroku"
+      - "/examples/getting-started-typescript"
+      - "/examples/message-metadata"
+      - "/examples/oauth-express-receiver"
+      - "/examples/oauth"
+      - "/examples/socket-mode-oauth"
+      - "/examples/socket-mode"
     labels:
       - "area:examples"
       - "dependencies"
       - "javascript"
+    schedule:
+      interval: "weekly"
     versioning-strategy: increase
-    groups:
-      slack:
-        patterns:
-          - "@slack/*"


### PR DESCRIPTION
This reverts commit a0dd3ae51d92b910a1fe48e2101089f50cbacde2.

### Summary

The changes in #2550 had not effect reverting these changes

<img width="907" alt="Screenshot 2025-05-26 at 2 51 14 PM" src="https://github.com/user-attachments/assets/f539b902-b5ce-468e-bb5b-6607e90784a8" />


### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).