### PR TITLE
Fix: allows Assistant say function to properly pass metadata

### DIFF
--- a/src/Assistant.ts
+++ b/src/Assistant.ts
@@ -314,10 +314,10 @@ function createSay(args: AllAssistantMiddlewareArgs): SayFn {
     const postMessageArgument: ChatPostMessageArguments =
       typeof message === 'string' ? { text: message, channel, thread_ts } : { ...message, channel, thread_ts };
 
-    if (threadContext) {
+    if (threadContext || postMessageArgument.metadata) {
       postMessageArgument.metadata = {
-        event_type: 'assistant_thread_context',
-        event_payload: threadContext as MessageMetadataEventPayloadObject,
+        event_type: postMessageArgument.metadata?.event_type ?? 'assistant_thread_context',
+        event_payload: { ...threadContext, ...postMessageArgument.metadata?.event_payload ?? {} } as MessageMetadataEventPayloadObject,
       };
     }
 

--- a/test/unit/helpers/events.ts
+++ b/test/unit/helpers/events.ts
@@ -49,7 +49,7 @@ import type {
 
 const ts = '1234.56';
 const user = 'U1234';
-const team = 'T1234';
+export const team = 'T1234';
 const channel = 'C1234';
 const token = 'xoxb-1234';
 const app_id = 'A1234';


### PR DESCRIPTION
### Summary

Fixes issue where say function for Assistant improperly overwrites metadata context arguments passed to it

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).