### PR TITLE
ci: send a notification of scheduled failing tests

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - main
   pull_request:
+  schedule:
+    - cron: "0 0 * * *"
+  workflow_dispatch:
 
 jobs:
   build:
@@ -37,3 +40,18 @@ jobs:
           directory: coverage
           fail_ci_if_error: true
           verbose: true
+  notifications:
+    name: Regression notifications
+    runs-on: ubuntu-latest
+    needs: build
+    if: failure() && github.ref == 'refs/heads/main' && github.event_name != 'workflow_dispatch'
+    steps:
+      - name: Send notifications of failing tests
+        uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52 # v2.1.0
+        with:
+          errors: true
+          webhook: ${{ secrets.SLACK_REGRESSION_FAILURES_WEBHOOK_URL }}
+          webhook-type: webhook-trigger
+          payload: |
+            action_url: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            repository: "${{ github.repository }}"


### PR DESCRIPTION
### Summary

This PR sends a notification of scheduled failing tests using the new "regression failures" workflow!

Follows: https://github.com/slackapi/bolt-python/pull/1323

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).