### PR TITLE
refactor: check payload type before extracting assistant thread info

### DIFF
--- a/src/Assistant.ts
+++ b/src/Assistant.ts
@@ -392,6 +392,7 @@ export function extractThreadInfo(payload: AllAssistantMiddlewareArgs['payload']
   let threadTs = '';
   let context: AssistantThreadContext = {};
 
+  // assistant_thread_started, asssistant_thread_context_changed
   if (
     'assistant_thread' in payload &&
     payload.assistant_thread &&

--- a/src/Assistant.ts
+++ b/src/Assistant.ts
@@ -392,15 +392,21 @@ export function extractThreadInfo(payload: AllAssistantMiddlewareArgs['payload']
   let threadTs = '';
   let context: AssistantThreadContext = {};
 
-  // assistant_thread_started, asssistant_thread_context_changed
-  if (payload.type === 'assistant_thread_started' || payload.type === 'assistant_thread_context_changed') {
-    channelId = payload.assistant_thread?.channel_id;
-    threadTs = payload.assistant_thread?.thread_ts;
-    context = payload.assistant_thread?.context;
+  if (
+    'assistant_thread' in payload &&
+    payload.assistant_thread &&
+    typeof payload.assistant_thread.channel_id === 'string' &&
+    typeof payload.assistant_thread.thread_ts === 'string'
+  ) {
+    channelId = payload.assistant_thread.channel_id;
+    threadTs = payload.assistant_thread.thread_ts;
+    if (typeof payload.assistant_thread.context === 'object' && payload.assistant_thread.context !== null) {
+      context = payload.assistant_thread.context;
+    }
   }
 
   // user message in thread
-  if (payload.type === 'message' && 'thread_ts' in payload && payload.thread_ts !== undefined) {
+  if ('channel' in payload && 'thread_ts' in payload && payload.thread_ts !== undefined) {
     channelId = payload.channel;
     threadTs = payload.thread_ts;
   }

--- a/src/Assistant.ts
+++ b/src/Assistant.ts
@@ -393,18 +393,14 @@ export function extractThreadInfo(payload: AllAssistantMiddlewareArgs['payload']
   let context: AssistantThreadContext = {};
 
   // assistant_thread_started, asssistant_thread_context_changed
-  if (
-    'assistant_thread' in payload &&
-    'channel_id' in payload.assistant_thread &&
-    'thread_ts' in payload.assistant_thread
-  ) {
-    channelId = payload.assistant_thread.channel_id;
-    threadTs = payload.assistant_thread.thread_ts;
-    context = payload.assistant_thread.context;
+  if (payload.type === 'assistant_thread_started' || payload.type === 'assistant_thread_context_changed') {
+    channelId = payload.assistant_thread?.channel_id;
+    threadTs = payload.assistant_thread?.thread_ts;
+    context = payload.assistant_thread?.context;
   }
 
   // user message in thread
-  if ('channel' in payload && 'thread_ts' in payload && payload.thread_ts !== undefined) {
+  if (payload.type === 'message' && 'thread_ts' in payload && payload.thread_ts !== undefined) {
     channelId = payload.channel;
     threadTs = payload.thread_ts;
   }


### PR DESCRIPTION
### Summary

This PR checks the payload type before extracting `assistant` thread info. Hopes to fix recent CI errors in #2601 and on [`main`](https://github.com/slackapi/bolt-js/actions/runs/16060294509/job/45774966608) 👾

```
Error: src/Assistant.ts(398,21): error TS18048: 'payload.assistant_thread' is possibly 'undefined'.
Error: src/Assistant.ts(401,5): error TS2322: Type 'unknown' is not assignable to type 'string'.
Error: src/Assistant.ts(402,5): error TS2322: Type 'unknown' is not assignable to type 'string'.
Error: src/Assistant.ts(403,5): error TS2322: Type 'unknown' is not assignable to type 'AssistantThreadContext'.
```

### Notes

- I'm not finding the same error on my machine a matching `typescript` version as #2602 👁️‍🗨️ 
- No change to functionality! Tests remain the same:

https://github.com/slackapi/bolt-js/blob/3948ded96b89c988e79c55d37df75842549084d2/test/unit/Assistant.spec.ts#L252-L298

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).