### PR TITLE
ci: pin node 22.17.1 in tests

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -19,7 +19,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [18.x, 20.x, 22.x]
+        node-version:
+          - 18.x
+          - 20.x
+          - 22.17.1
+          - 22.18.0
     permissions:
       contents: read
     steps:

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -22,8 +22,7 @@ jobs:
         node-version:
           - 18.x
           - 20.x
-          - 22.17.1
-          - 22.18.0
+          - 22.17.1 # https://github.com/slackapi/bolt-js/pull/2628
     permissions:
       contents: read
     steps:


### PR DESCRIPTION
### Summary

This PR pins `node` **22** tests to **22.17.1** to workaround [regressions](https://github.com/slackapi/bolt-js/actions/runs/16923967849/job/47955945653#step:5:35) found in **22.18.0**:

```
 Exception during run: Error: Rewiremock: there is no "parent module". Is there two HotModuleReplacementPlugins?
    at Object.<anonymous> (/home/runner/work/bolt-js/bolt-js/node_modules/rewiremock/lib/index.js:42:9)
    at Module._compile (node:internal/modules/cjs/loader:1688:14)
    at node:internal/modules/cjs/loader:1820:10
    at Object.require.extensions.<computed> [as .js] (/home/runner/work/bolt-js/bolt-js/node_modules/ts-node/src/index.ts:1608:43)
    at Module.load (node:internal/modules/cjs/loader:1423:32)
    at Function._load (node:internal/modules/cjs/loader:1246:12)
    at TracingChannel.traceSync (node:diagnostics_channel:322:14)
    at wrapModuleLoad (node:internal/modules/cjs/loader:235:24)
    at Module.require (node:internal/modules/cjs/loader:1445:12)
    at require (node:internal/modules/helpers:135:16)
    at Object.<anonymous> (/home/runner/work/bolt-js/bolt-js/test/unit/Assistant.spec.ts:4:1)
    at Module._compile (node:internal/modules/cjs/loader:1688:14)
    at Module.m._compile (/home/runner/work/bolt-js/bolt-js/node_modules/ts-node/src/index.ts:1618:23)
    at node:internal/modules/cjs/loader:1820:10
    at Object.require.extensions.<computed> [as .ts] (/home/runner/work/bolt-js/bolt-js/node_modules/ts-node/src/index.ts:1621:12)
    at Module.load (node:internal/modules/cjs/loader:1423:32)
    at Function._load (node:internal/modules/cjs/loader:1246:12)
    at TracingChannel.traceSync (node:diagnostics_channel:322:14)
    at wrapModuleLoad (node:internal/modules/cjs/loader:235:24)
    at Module.require (node:internal/modules/cjs/loader:1445:12)
    at require (node:internal/modules/helpers:135:16)
    at Object.exports.requireOrImport (/home/runner/work/bolt-js/bolt-js/node_modules/mocha/lib/nodejs/esm-utils.js:53:16)
    at async Object.exports.loadFilesAsync (/home/runner/work/bolt-js/bolt-js/node_modules/mocha/lib/nodejs/esm-utils.js:100:20)
    at async singleRun (/home/runner/work/bolt-js/bolt-js/node_modules/mocha/lib/cli/run-helpers.js:162:3)
    at async Object.exports.handler (/home/runner/work/bolt-js/bolt-js/node_modules/mocha/lib/cli/run.js:375:5)
```

### Notes

- This change is limited to tests to reduce regression failures. A better change I'm hoping is possible, but we might limit the `engines` if a change is released without testing the current latest `node` version:

https://github.com/slackapi/bolt-js/blob/94bbc94a67b1764280bddb2391398e4693c9ba80/package.json#L23-L26

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).