### PR TITLE
fix(typescript): accept empty list of suggested prompts for the assistant class

### DIFF
--- a/src/Assistant.ts
+++ b/src/Assistant.ts
@@ -46,7 +46,7 @@ type SetSuggestedPromptsFn = (
 
 interface SetSuggestedPromptsArguments {
   /** @description Prompt suggestions that appear when opening assistant thread. */
-  prompts: [AssistantPrompt, ...AssistantPrompt[]];
+  prompts: AssistantPrompt[];
   /** @description Title for the prompts. */
   title?: string;
 }

--- a/test/types/assistant.test-d.ts
+++ b/test/types/assistant.test-d.ts
@@ -1,3 +1,4 @@
+import type { AssistantThreadsSetSuggestedPromptsResponse } from '@slack/web-api';
 import { expectError, expectType } from 'tsd';
 import { type AllAssistantMiddlewareArgs, Assistant } from '../../src/Assistant';
 import type { AssistantThreadContext } from '../../src/AssistantThreadContextStore';
@@ -33,8 +34,13 @@ expectType<Assistant>(
 // threadStarted tests
 new Assistant({
   userMessage: asyncNoop,
-  threadStarted: async ({ saveThreadContext }) => {
+  threadStarted: async ({ saveThreadContext, setSuggestedPrompts }) => {
     expectType<void>(await saveThreadContext());
+    expectType<AssistantThreadsSetSuggestedPromptsResponse>(
+      await setSuggestedPrompts({
+        prompts: [],
+      }),
+    );
     return Promise.resolve();
   },
 });


### PR DESCRIPTION
### Summary

This PR accepts empty arrays for the `assistant` class set suggested prompts to improve **typescript** inference with empty arrays. Fixes #2506.

### Preview

The changes of https://github.com/slack-samples/bolt-js-assistant-template/pull/48 showcase this fix:

https://github.com/slack-samples/bolt-js-assistant-template/blob/b9fb90d60797fa71d346391c25ca61a331b6350f/app.js#L61-L70

### Reviewers

Changes to a sample app can confirm this behavior! 👾 

```sh
$ npm pack       # Package Bolt JS
$ slack create asdf -t slack-samples/bolt-js-assistant-template -b zimeg-fix-suggested-prompts-types
$ cd asdf
$ npm run check  # Expect errors
$ npm install /path/to/bolt-js/slack-bolt-4.4.0.tgz  # Use the packaged version
$ npm run check  # Expect no errors!
```

### Notes

This change matches an upstream changes to `@slack/web-api` in https://github.com/slackapi/node-slack-sdk/pull/2297 🌚 ✨ 

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).