### PR TITLE
docs: use the app logger in examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ const app = new App({
   // Start the app
   await app.start(process.env.PORT || 3000);
 
-  console.log('⚡️ Bolt app is running!');
+  app.logger.info('⚡️ Bolt app is running!');
 })();
 ```
 

--- a/examples/custom-properties/express.js
+++ b/examples/custom-properties/express.js
@@ -22,5 +22,5 @@ app.use(async ({ logger, context, next }) => {
   // Start your app
   await app.start(process.env.PORT || 3000);
 
-  console.log('⚡️ Bolt app is running!');
+  app.logger.info('⚡️ Bolt app is running!');
 })();

--- a/examples/custom-properties/http.js
+++ b/examples/custom-properties/http.js
@@ -47,8 +47,8 @@ app.use(async ({ logger, context, next }) => {
     await app.init();
     await app.start(process.env.PORT || 3000);
   } catch (e) {
-    console.error(e);
+    app.logger.error(e);
     process.exit(255);
   }
-  console.log('⚡️ Bolt app is running!');
+  app.logger.info('⚡️ Bolt app is running!');
 })();

--- a/examples/custom-properties/socket-mode.js
+++ b/examples/custom-properties/socket-mode.js
@@ -23,5 +23,5 @@ app.use(async ({ logger, context, next }) => {
   // Start your app
   await app.start();
 
-  console.log('⚡️ Bolt app is running!');
+  app.logger.info('⚡️ Bolt app is running!');
 })();

--- a/examples/getting-started-typescript/src/app.ts
+++ b/examples/getting-started-typescript/src/app.ts
@@ -50,5 +50,5 @@ app.action<BlockButtonAction>('button_click', async ({ body, ack, say }) => {
   // Start your app
   await app.start(Number(process.env.PORT) || 3000);
 
-  console.log('⚡️ Bolt app is running!');
+  app.logger.info('⚡️ Bolt app is running!');
 })();

--- a/examples/getting-started-typescript/src/basic.ts
+++ b/examples/getting-started-typescript/src/basic.ts
@@ -140,5 +140,5 @@ app.action<BlockAction>('approve_button', async ({ ack, say }) => {
   // Start your app
   await app.start(Number(process.env.PORT) || 3000);
 
-  console.log('⚡️ Bolt app is running!');
+  app.logger.info('⚡️ Bolt app is running!');
 })();


### PR DESCRIPTION
### Summary

This PR replaces a few more instances of `console.log` with `app.logger` following https://github.com/slackapi/bolt-js/pull/2365 🪵 

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).