### PR TITLE
fix(deps): update @slack/web-api to 7.10.0-aiAppsBeta.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@slack/oauth": "^3.0.4",
     "@slack/socket-mode": "^2.0.5",
     "@slack/types": "^2.16.0",
-    "@slack/web-api": "feat-ai-apps",
+    "@slack/web-api": "7.10.0-aiAppsBeta.1",
     "axios": "^1.8.3",
     "express": "^5.0.0",
     "path-to-regexp": "^8.1.0",


### PR DESCRIPTION
### Summary

This pull request fixes an issue where the incorrect version of `@slack/web-api` can be installed by updating the version of `@slack/web-api` from the label `"feat-ai-apps"` to the pinned version `"7.10.0-aiAppsBeta.1"`.

Honestly, we're unclear why it's happening. When an app uses the beta release `@slack/bolt@4.4.0-aiAppsBeta.1`, then `@slack/web-api@7.10.0` is installed as Bolt's sub-dependency. However, if the app explicitly declares the dependency `@slack/web-api@7.10.0-aiAppsBeta.1` then Bolt's sub-dependency is correctly `7.10.0-aiAppsBeta.1`.

### Reviewers

**In the bolt-js project:**

```bash
# Clone this branch
$ gh pr checkout ...

# Clear the package's cache
$ rm -rf node_modules package-lock.json

# Install the package dependencies
$ npm install

# Link this package
$ npm link
```

**In your sample app project:**

```bash
# Change into the project
$ cd my-project/

# Clear the package's cache
$ rm -rf node_modules package-lock.json

# Remove web-api from package.json
$ vim package.json
# → Remove "dependencies": { ..., ""@slack/web-api": "7.10.0-aiAppsBeta.1", ... }

# Link the local bolt-js
$ npm link @slack/bolt

# Install the dependencies
$ npm install

# Confirm bolt-js is pointing to your local project
$ npm list

# Test the project
$ npm start
```

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).