### PR TITLE
chore: release @slack/bolt@4.4.0-aiAppsBeta.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slack/bolt",
-  "version": "4.4.0-aiAppsBeta.1",
+  "version": "4.4.0-aiAppsBeta.2",
   "description": "A framework for building Slack apps, fast.",
   "author": "Slack Technologies, LLC",
   "license": "MIT",
@@ -45,8 +45,8 @@
     "@slack/logger": "^4.0.0",
     "@slack/oauth": "^3.0.4",
     "@slack/socket-mode": "^2.0.5",
-    "@slack/types": "^2.16.0",
-    "@slack/web-api": "7.10.0-aiAppsBeta.1",
+    "@slack/types": "2.16.0-aiAppsBeta.1",
+    "@slack/web-api": "7.10.0-aiAppsBeta.2",
     "axios": "^1.8.3",
     "express": "^5.0.0",
     "path-to-regexp": "^8.1.0",


### PR DESCRIPTION
### Summary

This PR bumps the `@slack/web-api` and `@slack/types` dependencies to the latest AI Apps Beta release and bumps the version of the `@slack/bolt` package to `@slack/bolt@4.4.0-aiAppsBeta.2`.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).