### PR TITLE
Update axios dependency to version 1.12.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@slack/socket-mode": "^2.0.5",
     "@slack/types": "^2.16.0",
     "@slack/web-api": "^7.10.0",
-    "axios": "^1.8.3",
+    "axios": "^1.12.0",
     "express": "^5.0.0",
     "path-to-regexp": "^8.1.0",
     "raw-body": "^3",


### PR DESCRIPTION
Axios < 1.12.0 has a high vulnerability

**Axios is vulnerable to DoS attack through lack of data size check**

### Summary
<img width="555" height="213" alt="Screenshot 2025-09-19 at 9 34 34 AM" src="https://github.com/user-attachments/assets/08135423-b512-4ace-8f5d-bf15002cd4d6" />

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).