### PR TITLE
feat(types): add block actions for context action elements

### DIFF
--- a/src/types/actions/block-action.ts
+++ b/src/types/actions/block-action.ts
@@ -10,6 +10,8 @@ import type { ViewOutput, ViewStateValue } from '../view';
  */
 export type BlockElementAction =
   | ButtonAction
+  | FeedbackButtonsAction
+  | IconButtonAction
   | UsersSelectAction
   | MultiUsersSelectAction
   | StaticSelectAction
@@ -49,6 +51,23 @@ export interface ButtonAction extends BasicElementAction<'button'> {
   text: PlainTextElement;
   url?: string;
   confirm?: Confirmation;
+}
+
+/**
+ * An action from feedback buttons
+ */
+export interface FeedbackButtonsAction extends BasicElementAction<'feedback_buttons'> {
+  value: string;
+  text: PlainTextElement;
+}
+
+/**
+ * An action from icon button
+ */
+export interface IconButtonAction extends BasicElementAction<'icon_button'> {
+  icon: string;
+  value: string;
+  text: PlainTextElement;
 }
 
 /**
@@ -329,6 +348,8 @@ export interface BlockAction<ElementAction extends BasicElementAction = BlockEle
  * Aliases - these types help make common usages shorter and less intimidating.
  */
 export type BlockButtonAction = BlockAction<ButtonAction>;
+export type BlockFeedbackButtonsAction = BlockAction<FeedbackButtonsAction>;
+export type BlockIconButtonAction = BlockAction<IconButtonAction>;
 export type BlockStaticSelectAction = BlockAction<StaticSelectAction>;
 export type BlockUsersSelectAction = BlockAction<UsersSelectAction>;
 export type BlockConversationsSelectAction = BlockAction<ConversationsSelectAction>;


### PR DESCRIPTION
### Summary

This PR adds block actions for the `context_action` elements "feedback_buttons" and "icon_button" for filtering types.

### Preview

The following listener guarantees the `value` exists for this action if the `return` is skipped:

```js
app.action({ type: "block_actions", action_id: "feedback" }, async ({ body, logger }) => {
  if (body.actions[0].type !== 'feedback_buttons') {
    return;
  }
  const value = body.actions[0].value;
  logger.info(value);
}
```

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).