### PR TITLE
ci: post regression notifications if scheduled tests do not succeed

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -44,7 +44,7 @@ jobs:
     name: Regression notifications
     runs-on: ubuntu-latest
     needs: build
-    if: failure() && github.ref == 'refs/heads/main' && github.event_name != 'workflow_dispatch'
+    if: ${{ !success() && github.ref == 'refs/heads/main' && github.event_name != 'workflow_dispatch' }}
     steps:
       - name: Send notifications of failing tests
         uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1


### PR DESCRIPTION
### Summary

This PR matches the changes of https://github.com/slackapi/bolt-python/pull/1376 to send regression notifications if scheduled tests do not succeed instead of just during failures. Fixes an issue where test timeout do not post a message.

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).