### PR TITLE
docs: precede code snippet with standard sentence formatting

### DIFF
--- a/docs/english/concepts/message-sending.md
+++ b/docs/english/concepts/message-sending.md
@@ -22,22 +22,24 @@ To explore adding rich message layouts to your app, read through [the guide on o
 app.event('reaction_added', async ({ event, say }) => {
   if (event.reaction === 'calendar') {
     await say({
-      blocks: [{
-        "type": "section",
-        "text": {
-          "type": "mrkdwn",
-          "text": "Pick a date for me to remind you"
+      blocks: [
+        {
+          type: 'section',
+          text: {
+            type: 'mrkdwn',
+            text: 'Pick a date for me to remind you',
+          },
+          accessory: {
+            type: 'datepicker',
+            action_id: 'datepicker_remind',
+            initial_date: '2019-04-28',
+            placeholder: {
+              type: 'plain_text',
+              text: 'Select a date',
+            },
+          },
         },
-        "accessory": {
-          "type": "datepicker",
-          "action_id": "datepicker_remind",
-          "initial_date": "2019-04-28",
-          "placeholder": {
-            "type": "plain_text",
-            "text": "Select a date"
-          }
-        }
-      }]
+      ],
     });
   }
 });
@@ -47,11 +49,11 @@ app.event('reaction_added', async ({ event, say }) => {
 
 You can have your app's messages stream in to replicate conventional AI chatbot behavior. This is done through three Web API methods:
 
-* [`chat.startStream`](/reference/methods/chat.startstream)
-* [`chat.appendStream`](/reference/methods/chat.appendstream)
-* [`chat.stopStream`](/reference/methods/chat.stopstream)
+- [`chat.startStream`](/reference/methods/chat.startstream)
+- [`chat.appendStream`](/reference/methods/chat.appendstream)
+- [`chat.stopStream`](/reference/methods/chat.stopstream)
 
-The Node Slack SDK provides a [`chatStream()`](/tools/node-slack-sdk/reference/web-api/classes/WebClient#chatstream) helper utility to streamline calling these methods. Here's an excerpt from our [Assistant template app](https://github.com/slack-samples/bolt-js-assistant-template)
+The Node Slack SDK provides a [`chatStream()`](/tools/node-slack-sdk/reference/web-api/classes/WebClient#chatstream) helper utility to streamline calling these methods. Here's an excerpt from our [Assistant template app](https://github.com/slack-samples/bolt-js-assistant-template):
 
 ```js
 // Provide a response to the user


### PR DESCRIPTION
### Summary

This PR improves the formatting of a code snippet following a link. 

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).