### PR TITLE
chore(release): version @slack/bolt@4.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slack/bolt",
-  "version": "4.4.0",
+  "version": "4.5.0",
   "description": "A framework for building Slack apps, fast.",
   "author": "Slack Technologies, LLC",
   "license": "MIT",


### PR DESCRIPTION
### Summary

This PR tags the latest changes of `main` as `@slack/bolt@4.5.0` with significant changes from #2674 👾

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).