### PR TITLE
fix: anticipate optional chained parameters as undefined when parsing events details

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -142,7 +142,7 @@ export function isBodyWithTypeEnterpriseInstall(body: AnyMiddlewareArgs['body'],
  * https://github.com/slackapi/bolt-js/issues/674
  */
 export function isEventTypeToSkipAuthorize(event: ReceiverEvent): boolean {
-  return eventTypesToSkipAuthorize.includes(event?.body?.event?.type);
+  return eventTypesToSkipAuthorize.includes(event.body?.event?.type);
 }
 
 /* istanbul ignore next */


### PR DESCRIPTION
### Summary

This PR aims to resolve recurring failing tests on `main`.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).