### PR TITLE
Enable esModuleInterop in tsconfig

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
   "compilerOptions": {
     "declaration": true,
     "declarationMap": true,
+    "esModuleInterop": true,
     "module": "CommonJS",
     "moduleResolution": "node",
     "noErrorTruncation": true,


### PR DESCRIPTION
### Summary

In a recent update, TypeScript [errors related to years-old code began surfacing](https://github.com/slackapi/bolt-js/actions/runs/19349879592), all related to default module imports. To address this without having to update any of the existing imports, `esModuleInterop` ([see docs](https://www.typescriptlang.org/tsconfig/#esModuleInterop)) has been set to `true` in this PR. 

This `Emit[s] additional JavaScript to ease support for importing CommonJS modules`, and, given that our `module` is still set to `CommonJS`, seems like the appropriate fit.

The alternative to this flag is to update the now-offending imports:

```
// Using require syntax
import MyModule = require('my-module');

// Using a namespace import
import * as MyModule from 'my-module';
```

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).