### PR TITLE
feat(SocketModeReceiver): expose Socket Mode timeout and reconnect options

### DIFF
--- a/src/receivers/SocketModeReceiver.ts
+++ b/src/receivers/SocketModeReceiver.ts
@@ -39,6 +39,10 @@ export interface SocketModeReceiverOptions {
   installerOptions?: InstallerOptions;
   appToken: string; // App Level Token
   customRoutes?: CustomRoute[];
+  clientPingTimeout?: number;
+  serverPingTimeout?: number;
+  pingPongLoggingEnabled?: boolean;
+  autoReconnectEnabled?: boolean;
   // biome-ignore lint/suspicious/noExplicitAny: user-provided custom properties can be anything
   customPropertiesExtractor?: (args: any) => StringIndexed;
   processEventErrorHandler?: (args: SocketModeReceiverProcessEventErrorHandlerArgs) => Promise<boolean>;
@@ -96,6 +100,10 @@ export default class SocketModeReceiver implements Receiver {
     appToken,
     logger = undefined,
     logLevel = LogLevel.INFO,
+    clientPingTimeout = undefined,
+    serverPingTimeout = undefined,
+    pingPongLoggingEnabled = undefined,
+    autoReconnectEnabled = undefined,
     clientId = undefined,
     clientSecret = undefined,
     stateSecret = undefined,
@@ -111,6 +119,10 @@ export default class SocketModeReceiver implements Receiver {
       appToken,
       logLevel,
       logger,
+      clientPingTimeout,
+      serverPingTimeout,
+      pingPongLoggingEnabled,
+      autoReconnectEnabled,
       clientOptions: installerOptions.clientOptions,
     });
 


### PR DESCRIPTION
## Summary

`SocketModeClient` (from `@slack/socket-mode`) accepts `clientPingTimeout`, `serverPingTimeout`, `pingPongLoggingEnabled`, and `autoReconnectEnabled` options, but `SocketModeReceiver` does not pass these through — forcing users to accept hardcoded defaults.

This is problematic because Slack's WebSocket servers frequently take >5000ms to respond to pings (see #2496), causing unnecessary disconnections with the default 5000ms `clientPingTimeout`. Users have no way to increase the timeout without bypassing `SocketModeReceiver` entirely.

### Changes

- Add `clientPingTimeout`, `serverPingTimeout`, `pingPongLoggingEnabled`, and `autoReconnectEnabled` as optional properties on `SocketModeReceiverOptions`
- Pass these options through to the `SocketModeClient` constructor
- When not provided, values default to `undefined`, preserving existing `SocketModeClient` defaults (fully backward compatible)

### Usage

```typescript
const app = new App({
  socketMode: true,
  appToken: process.env.SLACK_APP_TOKEN,
  token: process.env.SLACK_BOT_TOKEN,
  // Increase ping timeout to handle slow Slack server responses
  clientPingTimeout: 15000,
  serverPingTimeout: 60000,
  pingPongLoggingEnabled: true,
});
```

## Test plan

- [x] 4 new unit tests verifying option passthrough via constructor spy
- [x] Backward compatibility test confirming `undefined` defaults when options are omitted
- [x] All 404 existing tests continue to pass
- [x] TypeScript compilation clean (0 errors)
- [x] Biome lint clean (0 issues)

Fixes #2496

### Category

- [x] `@slack/bolt` (npm package)