### PR TITLE
build: format package repository as object metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,10 @@
     "test:types": "tsd --files test/types",
     "watch": "npx nodemon --watch 'src' --ext 'ts' --exec npm run build"
   },
-  "repository": "slackapi/bolt-js",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/slackapi/bolt-js.git"
+  },
   "homepage": "https://docs.slack.dev/tools/bolt-js",
   "bugs": {
     "url": "https://github.com/slackapi/bolt-js/issues"


### PR DESCRIPTION
## Summary
- Formats the `repository` field in `package.json` as a full object with `type` and `url` properties, replacing the shorthand string `"slackapi/bolt-js"`
- This follows the [npm `package.json` `repository` specification](https://docs.npmjs.com/cli/v11/configuring-npm/package-json#repository) and ensures compatibility with tools that expect the object format

## Test plan
- [x] Verified with `npm pkg fix` that this matches npm's normalized format
- [ ] Confirm `npm test` passes with no changes to build/test behavior

Co-Authored-By: Claude <svc-devxp-claude@slack-corp.com>
🤖 Generated with [Claude Code](https://claude.com/claude-code)