### PR TITLE
fix: correct InvalidCustomPropertyError code and MemoryStore promise handling

### DIFF
--- a/src/conversation-store.ts
+++ b/src/conversation-store.ts
@@ -36,8 +36,10 @@ export class MemoryStore<ConversationState = any> implements ConversationStore<C
           // release the memory
           this.state.delete(conversationId);
           reject(new Error('Conversation expired'));
+          return;
         }
         resolve(entry.value);
+        return;
       }
       reject(new Error('Conversation not found'));
     });

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -106,7 +106,7 @@ export class ContextMissingPropertyError extends Error implements CodedError {
 }
 
 export class InvalidCustomPropertyError extends Error implements CodedError {
-  public code = ErrorCode.AppInitializationError;
+  public code = ErrorCode.InvalidCustomPropertyError;
 }
 
 export class CustomRouteInitializationError extends Error implements CodedError {


### PR DESCRIPTION
This PR fixes two bugs:

1. **InvalidCustomPropertyError**: The error class was incorrectly using the wrong error code and now correctly uses the appropriate one.

2. **MemoryStore.get()**: Added missing `return` statements after `resolve()` and `reject()` calls to prevent promise double settlement and ensure proper async flow control.

### Changes

* Fixed error code assignment in the `InvalidCustomPropertyError` class
* Added return statements in `MemoryStore.get()` promise handlers to prevent multiple resolutions/rejections

### Requirements

* [x] I've read and understood the Contributing Guidelines and have done my best effort to follow them.
* [x] I've read and agree to the Code of Conduct.
