### PR TITLE
feat(app): tag User-Agent with concrete receiver class name (#1150)

### DIFF
--- a/.changeset/good-ads-juggle.md
+++ b/.changeset/good-ads-juggle.md
@@ -1,0 +1,5 @@
+---
+"@slack/bolt": minor
+---
+
+feat(app): tag User-Agent with concrete receiver class name (#1150)

--- a/src/App.ts
+++ b/src/App.ts
@@ -366,6 +366,21 @@ export default class App<AppCustomContext extends StringIndexed = StringIndexed>
       // Since v3.4, WebClient starts sharing logger with App
       this.clientOptions.logger = this.logger;
     }
+
+    // Tag the User-Agent with the concrete receiver class before any
+    // WebClient is constructed. WebClient snapshots `getUserAgent()` into
+    // its axios headers at construction time, so this must run before
+    // `new WebClient(...)` below (see #1150).
+    const receiverTypeName = receiver
+      ? receiver.constructor.name
+      : this.socketMode
+        ? 'SocketModeReceiver'
+        : 'HTTPReceiver';
+    addAppMetadata({
+      name: `${packageJson.name}-${receiverTypeName}`,
+      version: packageJson.version,
+    });
+
     // The public WebClient instance (app.client)
     // Since v3.4, it can have the passed token in the case of single workspace installation.
     this.client = new WebClient(token, this.clientOptions);

--- a/test/unit/App/basic.spec.ts
+++ b/test/unit/App/basic.spec.ts
@@ -346,6 +346,23 @@ describe('App basic features', () => {
     // TODO: tests for providing endpoints option
   });
 
+  describe('receiver-type app metadata', () => {
+    it('should tag the user-agent metadata with the concrete receiver class name', () => {
+      const addAppMetadata = sinon.fake();
+      const customOverrides = mergeOverrides(
+        { '@slack/web-api': { addAppMetadata } },
+        withSuccessfulBotUserFetchingWebClient(fakeBotId, fakeBotUserId),
+      );
+      const MockApp = importApp(customOverrides);
+      new MockApp({ receiver: new FakeReceiver(), authorize: noop });
+      const names: string[] = addAppMetadata.getCalls().map((call) => call.args[0].name);
+      assert.isTrue(
+        names.some((name) => name.endsWith('-FakeReceiver')),
+        `expected an addAppMetadata call ending in "-FakeReceiver", got ${JSON.stringify(names)}`,
+      );
+    });
+  });
+
   describe('#start', () => {
     it('should pass calls through to receiver', async () => {
       // Arrange


### PR DESCRIPTION
### Summary

Closes #1150.

The Slack team wants to see which receivers bolt-js apps are actually running so they can prioritize missing features based on real usage. Today the only tag the WebClient emits for a bolt app is `@slack/bolt/<version>`, so every receiver is indistinguishable from every other.

This registers a second `addAppMetadata` entry whose name includes the concrete receiver class (for example `@slack/bolt-HTTPReceiver`, `@slack/bolt-SocketModeReceiver`, `@slack/bolt-AwsLambdaReceiver`, or the class name of a user-supplied custom receiver). It is registered from the App constructor after `this.socketMode` is resolved but before `new WebClient(...)` is constructed, because `WebClient` snapshots `getUserAgent()` into its axios headers at construction time. The existing module-load-time `addAppMetadata({ name: '@slack/bolt', version })` entry is left in place so the base package tag remains, which keeps existing telemetry consumers working.

`addAppMetadata` writes to a module-global map inside `@slack/web-api`, so a Node process that constructs multiple App instances with different receiver types will accumulate both entries in every subsequent WebClient's User-Agent. In single-App processes (the common case) the tag is exact; in multi-App processes the tag set is a superset of the receiver types that App has constructed, which over-attributes but does not under-attribute receiver usage. A tighter per-App scoping would require piping a custom User-Agent through `clientOptions` and bypassing the module-global metadata path, which is a larger design decision; happy to take that route if you prefer.

Verified with `npm run build` (clean), `npm run lint` (Biome, 136 files, no fixes applied), and `npm run test:unit` (465 tests, including a new `receiver-type app metadata` case in `test/unit/App/basic.spec.ts` that asserts `addAppMetadata` is called with a name ending in `-FakeReceiver` when an app is built with a custom receiver).

### Requirements <!-- Place an `x` in each `[ ]` -->

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-js/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
