### PR TITLE
ci: publish releases using the @slackapi github app token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,10 +51,21 @@ jobs:
       contents: write
       id-token: write # OIDC: https://docs.npmjs.com/trusted-publishers
     steps:
+      - name: Gather credentials
+        id: credentials
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        with:
+          client-id: ${{ secrets.GH_APP_CLIENT_ID }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+          permission-contents: write
+
       - name: Checkout repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: true
+          token: ${{ steps.credentials.outputs.token }}
 
       - name: Setup Node
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
@@ -72,7 +83,7 @@ jobs:
           createGithubReleases: true
           publish: npm run changeset -- publish
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.credentials.outputs.token }}
 
       - name: Get publication details
         if: steps.changesets.outputs.published == 'true'
@@ -81,7 +92,7 @@ jobs:
           echo "url=$(gh release view --json url -q .url)" >> "$GITHUB_OUTPUT"
           echo "message=$(echo "$PUBLISHED_PACKAGES" | jq -r '.[] | "\(.name)@\(.version)"' | paste -sd ', ' -)" >> "$GITHUB_OUTPUT"
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.credentials.outputs.token }}
           PUBLISHED_PACKAGES: ${{ steps.changesets.outputs.publishedPackages }}
 
       - name: Notify Slack


### PR DESCRIPTION
### Summary

This PR updates the release workflow to publish releases using the @slackapi GitHub app token.

### Preview

🔭 https://github.com/slackapi/slack-github-action/releases/tag/v3.0.2

### Notes

This mirrors the release process found in the Slack GitHub Action: https://github.com/slackapi/slack-github-action/pull/592

- We have a few secrets to add alongside these changes before the next release too 🔏 
- The "immutable" release is a separate setting that might not be useful since we publish to `npm` with this package. FWIW this doesn't require much additional change!

### Requirements <!-- Place an `x` in each `[ ]` -->

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-js/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
