### PR TITLE
ci: skip publish step if no release is needed

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,7 +58,7 @@ jobs:
   publish:
     name: Publish
     needs: changelog
-    if: needs.changelog.outputs.hasChangesets == 'false' && needs.changelog.outputs.releaseExists != 'true'
+    if: needs.changelog.outputs.hasChangesets == 'false' && needs.changelog.outputs.releaseExists == 'false'
     runs-on: ubuntu-latest
     environment: publish
     permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       hasChangesets: ${{ steps.changesets.outputs.hasChangesets }}
+      releaseExists: ${{ steps.published.outputs.exists }}
     permissions:
       contents: write
       pull-requests: write
@@ -41,10 +42,23 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Check if publish is needed
+        id: published
+        if: steps.changesets.outputs.hasChangesets == 'false'
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          if gh release view "v${VERSION}" &>/dev/null; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   publish:
     name: Publish
     needs: changelog
-    if: needs.changelog.outputs.hasChangesets == 'false'
+    if: needs.changelog.outputs.hasChangesets == 'false' && needs.changelog.outputs.releaseExists != 'true'
     runs-on: ubuntu-latest
     environment: publish
     permissions:


### PR DESCRIPTION
### Summary

This PR skips the `publish` step if no release is needed 🚀 

Fixes an issue where publishing is attempted after a recent release but no changsets exist. The "changelog" PR wasn't created so publishing was attempted! This didn't cause problems but requires unneeded approval.

### Requirements <!-- Place an `x` in each `[ ]` -->

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-js/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
