### PR TITLE
fix: strip smuggled payload from ssl_check requests

### DIFF
--- a/src/receivers/HTTPModuleFunctions.ts
+++ b/src/receivers/HTTPModuleFunctions.ts
@@ -70,9 +70,12 @@ export const parseAndVerifyHTTPRequest = async (
 
   const contentType = req.headers['content-type'];
   if (contentType === 'application/x-www-form-urlencoded') {
-    // `ssl_check=1` requests do not require x-slack-signature verification
     const parsedQs = qsParse(textBody);
     if (parsedQs?.ssl_check) {
+      // ssl_check requests don't require signature verification, but we must
+      // strip any smuggled payload to prevent unauthenticated event injection
+      const sanitized = `ssl_check=${parsedQs.ssl_check}`;
+      bufferedReq.rawBody = Buffer.from(sanitized);
       return bufferedReq;
     }
   }


### PR DESCRIPTION
Fixes #2897

When `ssl_check=1` is in a form-encoded body, `parseAndVerifyHTTPRequest` skips signature verification and returns the buffered request as-is. Problem is, the raw body can also contain a `payload` field that `parseHTTPRequestBody` will extract and process as a real event — no signing secret needed.

This rewrites `rawBody` to only contain the `ssl_check` field before returning, so nothing else can be smuggled through.

Tested that:
- Smuggled `ssl_check=1&payload={...}` no longer triggers event handlers
- Legitimate `ssl_check` requests still return 200
- Requests without `ssl_check` still require valid signatures