### PR TITLE
fix: require exact ssl_check=1 value to bypass signature verification

### DIFF
--- a/.changeset/strict-ssl-check.md
+++ b/.changeset/strict-ssl-check.md
@@ -1,0 +1,5 @@
+---
+"@slack/bolt": patch
+---
+
+Require exact `ssl_check=1` value to bypass signature verification, preventing truthy but incorrect values from skipping authentication checks.

--- a/src/receivers/HTTPModuleFunctions.ts
+++ b/src/receivers/HTTPModuleFunctions.ts
@@ -70,8 +70,10 @@ export const parseAndVerifyHTTPRequest = async (
 
   const contentType = req.headers['content-type'];
   if (contentType === 'application/x-www-form-urlencoded') {
+    // Slack sends `ssl_check=1` to verify SSL connectivity, these requests do not require x-slack-signature verification
+    // https://docs.slack.dev/interactivity/implementing-slash-commands/#responding_basic_receipt
     const parsedQs = qsParse(textBody);
-    if (parsedQs?.ssl_check) {
+    if (parsedQs?.ssl_check === '1') {
       // ssl_check requests don't require signature verification, but we must
       // strip any smuggled payload to prevent unauthenticated event injection
       const sanitized = `ssl_check=${parsedQs.ssl_check}`;

--- a/src/receivers/HTTPReceiver.ts
+++ b/src/receivers/HTTPReceiver.ts
@@ -468,9 +468,10 @@ export default class HTTPReceiver implements Receiver {
         return;
       }
 
-      // Handle SSL checks
-      if (body.ssl_check) {
-        httpFunc.buildNoBodyResponse(res, 200);
+      // Slack sends `ssl_check=1` to verify SSL connectivity
+      // https://docs.slack.dev/interactivity/implementing-slash-commands/#responding_basic_receipt
+      if (body.ssl_check === '1') {
+        httpFunc.buildSSLCheckResponse(res);
         return;
       }
 

--- a/test/unit/receivers/HTTPModuleFunctions.spec.ts
+++ b/test/unit/receivers/HTTPModuleFunctions.spec.ts
@@ -165,6 +165,88 @@ describe('HTTPModuleFunctions', async () => {
         const res: ServerResponse = sinon.createStubInstance(ServerResponse) as unknown as ServerResponse;
         const result = await func.parseAndVerifyHTTPRequest({ signingSecret }, req, res);
         assert.isDefined(result.rawBody);
+        assert.equal(result.rawBody.toString(), 'ssl_check=1');
+      });
+      it('should strip smuggled event payloads from ssl_check requests', async () => {
+        const signingSecret = 'secret';
+        const rawBody = `ssl_check=1&payload=${encodeURIComponent('{"type":"event_callback"}')}`;
+        const req = {
+          rawBody: Buffer.from(rawBody),
+          headers: {
+            'content-type': 'application/x-www-form-urlencoded',
+          },
+        } as unknown as BufferedIncomingMessage;
+        const res: ServerResponse = sinon.createStubInstance(ServerResponse) as unknown as ServerResponse;
+        const result = await func.parseAndVerifyHTTPRequest({ signingSecret }, req, res);
+        assert.equal(result.rawBody.toString(), 'ssl_check=1');
+      });
+      it('should not bypass signature verification when ssl_check=0', async () => {
+        const signingSecret = 'secret';
+        const rawBody = 'ssl_check=0&token=legacy-fixed-verification-token';
+        const req = {
+          rawBody: Buffer.from(rawBody),
+          headers: {
+            'content-type': 'application/x-www-form-urlencoded',
+          },
+        } as unknown as BufferedIncomingMessage;
+        const res: ServerResponse = sinon.createStubInstance(ServerResponse) as unknown as ServerResponse;
+        try {
+          await func.parseAndVerifyHTTPRequest({ signingSecret }, req, res);
+          assert.fail('Expected an error to be thrown');
+        } catch (e) {
+          assert.include((e as Error).message, 'Failed to verify authenticity');
+        }
+      });
+      it('should not bypass signature verification when ssl_check=true', async () => {
+        const signingSecret = 'secret';
+        const rawBody = 'ssl_check=true&token=legacy-fixed-verification-token';
+        const req = {
+          rawBody: Buffer.from(rawBody),
+          headers: {
+            'content-type': 'application/x-www-form-urlencoded',
+          },
+        } as unknown as BufferedIncomingMessage;
+        const res: ServerResponse = sinon.createStubInstance(ServerResponse) as unknown as ServerResponse;
+        try {
+          await func.parseAndVerifyHTTPRequest({ signingSecret }, req, res);
+          assert.fail('Expected an error to be thrown');
+        } catch (e) {
+          assert.include((e as Error).message, 'Failed to verify authenticity');
+        }
+      });
+      it('should not bypass signature verification for ssl_check=1 with JSON content-type', async () => {
+        const signingSecret = 'secret';
+        const rawBody = '{"ssl_check":"1"}';
+        const req = {
+          rawBody: Buffer.from(rawBody),
+          headers: {
+            'content-type': 'application/json',
+          },
+        } as unknown as BufferedIncomingMessage;
+        const res: ServerResponse = sinon.createStubInstance(ServerResponse) as unknown as ServerResponse;
+        try {
+          await func.parseAndVerifyHTTPRequest({ signingSecret }, req, res);
+          assert.fail('Expected an error to be thrown');
+        } catch (e) {
+          assert.include((e as Error).message, 'Failed to verify authenticity');
+        }
+      });
+      it('should not bypass signature verification when ssl_check is empty', async () => {
+        const signingSecret = 'secret';
+        const rawBody = 'ssl_check=&token=legacy-fixed-verification-token';
+        const req = {
+          rawBody: Buffer.from(rawBody),
+          headers: {
+            'content-type': 'application/x-www-form-urlencoded',
+          },
+        } as unknown as BufferedIncomingMessage;
+        const res: ServerResponse = sinon.createStubInstance(ServerResponse) as unknown as ServerResponse;
+        try {
+          await func.parseAndVerifyHTTPRequest({ signingSecret }, req, res);
+          assert.fail('Expected an error to be thrown');
+        } catch (e) {
+          assert.include((e as Error).message, 'Failed to verify authenticity');
+        }
       });
       it('should detect invalid signature for application/x-www-form-urlencoded body', async () => {
         const signingSecret = 'secret';

--- a/test/unit/receivers/HTTPReceiver.spec.ts
+++ b/test/unit/receivers/HTTPReceiver.spec.ts
@@ -609,5 +609,65 @@ describe('HTTPReceiver', () => {
 
       assert.throws(() => receiver.requestListener(fakeReq, fakeRes), HTTPReceiverDeferredRequestError);
     });
+
+    describe('ssl_check handling', () => {
+      let fakeHttpFunctions: Record<string, sinon.SinonSpy>;
+      let receiver: InstanceType<ReturnType<typeof importHTTPReceiver>>;
+      let fakeRes: ServerResponse;
+
+      beforeEach(() => {
+        fakeHttpFunctions = {
+          parseAndVerifyHTTPRequest: sinon.fake.resolves({
+            rawBody: Buffer.from(''),
+            headers: { 'content-type': 'application/x-www-form-urlencoded' },
+          }),
+          parseHTTPRequestBody: sinon.fake(),
+          buildSSLCheckResponse: sinon.fake(),
+          buildNoBodyResponse: sinon.fake(),
+          extractRetryNumFromHTTPRequest: sinon.fake.returns(undefined),
+          extractRetryReasonFromHTTPRequest: sinon.fake.returns(undefined),
+        };
+        const HTTPReceiver = importHTTPReceiver(
+          mergeOverrides(overrides, { './HTTPModuleFunctions': fakeHttpFunctions }),
+        );
+        receiver = new HTTPReceiver({
+          logger: noopLogger,
+          clientId: 'my-clientId',
+          clientSecret: 'my-client-secret',
+          signingSecret: 'secret',
+        });
+        fakeRes = sinon.createStubInstance(ServerResponse) as unknown as ServerResponse;
+      });
+
+      it('should respond to ssl_check=1 with 200', async () => {
+        fakeHttpFunctions.parseHTTPRequestBody = sinon.fake.returns({ ssl_check: '1' });
+        const fakeReq = sinon.createStubInstance(IncomingMessage) as IncomingMessage;
+        fakeReq.url = '/slack/events';
+        fakeReq.method = 'POST';
+        receiver.requestListener(fakeReq, fakeRes);
+        await new Promise((resolve) => setImmediate(resolve));
+        sinon.assert.calledOnce(fakeHttpFunctions.buildSSLCheckResponse);
+      });
+
+      it('should not treat ssl_check=0 as an ssl_check request', async () => {
+        fakeHttpFunctions.parseHTTPRequestBody = sinon.fake.returns({ ssl_check: '0' });
+        const fakeReq = sinon.createStubInstance(IncomingMessage) as IncomingMessage;
+        fakeReq.url = '/slack/events';
+        fakeReq.method = 'POST';
+        receiver.requestListener(fakeReq, fakeRes);
+        await new Promise((resolve) => setImmediate(resolve));
+        sinon.assert.notCalled(fakeHttpFunctions.buildSSLCheckResponse);
+      });
+
+      it('should not treat an empty ssl_check value as an ssl_check request', async () => {
+        fakeHttpFunctions.parseHTTPRequestBody = sinon.fake.returns({ ssl_check: '' });
+        const fakeReq = sinon.createStubInstance(IncomingMessage) as IncomingMessage;
+        fakeReq.url = '/slack/events';
+        fakeReq.method = 'POST';
+        receiver.requestListener(fakeReq, fakeRes);
+        await new Promise((resolve) => setImmediate(resolve));
+        sinon.assert.notCalled(fakeHttpFunctions.buildSSLCheckResponse);
+      });
+    });
   });
 });


### PR DESCRIPTION
### Summary

 - Tighten ssl_check evaluation from truthy check to strict `=== '1'` comparison, preventing crafted values like ssl_check=0 or ssl_check=true from bypassing signature verification
     - this follows the slack documentation
 - Add comprehensive tests covering smuggled payloads and invalid ssl_check values
 
This is a follow up to #2898

### Testing

1. clone this branch and build the project with `npm pack .`
2. Import this package in the following projects

```js
import { App, HTTPReceiver, LogLevel } from '@slack/bolt';
import { config } from 'dotenv';

config();

const port = Number(process.env.PORT) || 3000;

const receiver = new HTTPReceiver({
  signingSecret: process.env.SLACK_SIGNING_SECRET,
});

const app = new App({
  token: process.env.SLACK_BOT_TOKEN,
  receiver,
  logLevel: LogLevel.DEBUG,
});

app.message(/^(hi|hello|hey).*/, async ({ context, say, logger }) => {
  try {
    logger.info("I'm in the message listener!!!")
    const greeting = context.matches[0];
    await say(`${greeting}, how are you?`);
  } catch (error) {
    logger.error(error);
  }
});

(async () => {
  try {
    await app.start(port);
    app.logger.info(`⚡️ Bolt app is running on port ${port}!`);
  } catch (error) {
    app.logger.error('Failed to start the app', error);
  }
})();
```

<details>
  <summary>mainest.js</summary>

```json
{
    "_metadata": {
        "major_version": 1,
        "minor_version": 1
    },
    "display_information": {
        "name": "ssl-check-bypass"
    },
    "features": {
        "bot_user": {
            "display_name": "ssl-check-bypass",
            "always_online": false
        }
    },
    "oauth_config": {
        "scopes": {
            "bot": [
                "channels:history",
                "chat:write"
            ]
        }
    },
    "settings": {
        "event_subscriptions": {
            "bot_events": [
                "message.channels"
            ]
        },
        "org_deploy_enabled": true,
        "socket_mode_enabled": true,
        "token_rotation_enabled": false
    }
}
```

</details>

3. Use the following curl commands to see the expected behavior

```sh
url -i -X POST http://localhost:3000/slack/events \
    -H "Content-Type: application/x-www-form-urlencoded" \
    -d 'ssl_check=1&payload={"type":"event_callback","event":{"type":"message","text":"hello"}}'
```

Results in a `200` without reaching any listener code, the `"I'm in the message listener!!!"` log should not show up in your app

```sh
url -i -X POST http://localhost:3000/slack/events \
    -H "Content-Type: application/x-www-form-urlencoded" \
    -d 'ssl_check=0&payload={"type":"event_callback","event":{"type":"message","text":"hello"}}'
```

Results in a `401` since there was no verification code sent with the request

### Requirements <!-- Place an `x` in each `[ ]` -->

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-js/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
