### PR TITLE
chore: drop support for node 18

### DIFF
--- a/.changeset/drop-node-18.md
+++ b/.changeset/drop-node-18.md
@@ -1,0 +1,5 @@
+---
+"@slack/bolt": major
+---
+
+Drop Node.js 18 support. The minimum required runtime is now Node.js 20 (npm >=9.6.4).

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -20,7 +20,6 @@ jobs:
       fail-fast: false
       matrix:
         node-version:
-          - 18.x
           - 20.x
           - 22.x
           - 24.x

--- a/.github/workflows/samples.yml
+++ b/.github/workflows/samples.yml
@@ -17,7 +17,6 @@ jobs:
       fail-fast: false
       matrix:
         node-version:
-          - 18.x
           - 20.x
           - 22.x
           - 24.x
@@ -48,7 +47,6 @@ jobs:
       fail-fast: false
       matrix:
         node-version:
-          - 18.x
           - 20.x
           - 22.x
           - 24.x

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,7 +113,7 @@ Listeners receive a single object with these properties (availability depends on
 
 ## Code Conventions
 
-- **TypeScript** throughout. Compiler options in `tsconfig.json` (extends `@tsconfig/node18`, CommonJS output).
+- **TypeScript** throughout. Compiler options in `tsconfig.json` (extends `@tsconfig/node20`, CommonJS output).
 - **Biome** for formatting and linting. Configuration in `biome.json`.
 - **Testing:** See the Testing section below for test frameworks and conventions.
 

--- a/examples/custom-receiver/package-lock.json
+++ b/examples/custom-receiver/package-lock.json
@@ -18,7 +18,7 @@
         "koa": "^3"
       },
       "devDependencies": {
-        "@tsconfig/node18": "^18.2.6",
+        "@tsconfig/node20": "^20.1.5",
         "@types/koa": "^3.0.2",
         "@types/node": "^24",
         "ts-node": "^10",
@@ -341,10 +341,10 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@tsconfig/node18": {
-      "version": "18.2.6",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node18/-/node18-18.2.6.tgz",
-      "integrity": "sha512-eAWQzAjPj18tKnDzmWstz4OyWewLUNBm9tdoN9LayzoboRktYx3Enk1ZXPmThj55L7c4VWYq/Bzq0A51znZfhw==",
+    "node_modules/@tsconfig/node20": {
+      "version": "20.1.9",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node20/-/node20-20.1.9.tgz",
+      "integrity": "sha512-IjlTv1RsvnPtUcjTqtVsZExKVq+KQx4g5pCP5tI7rAs6Xesl2qFwSz/tPDBC4JajkL/MlezBu3gPUwqRHl+RIg==",
       "dev": true,
       "license": "MIT"
     },

--- a/examples/custom-receiver/package.json
+++ b/examples/custom-receiver/package.json
@@ -20,7 +20,7 @@
     "koa": "^3"
   },
   "devDependencies": {
-    "@tsconfig/node18": "^18.2.6",
+    "@tsconfig/node20": "^20.1.5",
     "@types/koa": "^3.0.2",
     "@types/node": "^24",
     "ts-node": "^10",

--- a/examples/custom-receiver/tsconfig.json
+++ b/examples/custom-receiver/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node18/tsconfig.json",
+  "extends": "@tsconfig/node20/tsconfig.json",
   "compilerOptions": {
     "resolveJsonModule": true,
     "allowSyntheticDefaultImports": true,

--- a/examples/getting-started-typescript/package.json
+++ b/examples/getting-started-typescript/package.json
@@ -14,7 +14,7 @@
     "dotenv": "^17"
   },
   "devDependencies": {
-    "@tsconfig/node18": "^18.2.6",
+    "@tsconfig/node20": "^20.1.5",
     "@types/node": "^24",
     "ts-node": "^10",
     "typescript": "6.0.3"

--- a/examples/getting-started-typescript/tsconfig.json
+++ b/examples/getting-started-typescript/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node18/tsconfig.json",
+  "extends": "@tsconfig/node20/tsconfig.json",
   "compilerOptions": {
     "resolveJsonModule": true,
     "allowSyntheticDefaultImports": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,10 +23,10 @@
       "devDependencies": {
         "@biomejs/biome": "^1.9.0",
         "@changesets/cli": "^2.29.8",
-        "@tsconfig/node18": "^18.2.4",
+        "@tsconfig/node20": "^20.1.5",
         "@types/chai": "^4.1.7",
         "@types/mocha": "^10.0.1",
-        "@types/node": "18.19.130",
+        "@types/node": "20.19.0",
         "@types/proxyquire": "^1.3.31",
         "@types/sinon": "^17.0.4",
         "@types/tsscmp": "^1.0.0",
@@ -42,8 +42,8 @@
         "typescript": "5.3.3"
       },
       "engines": {
-        "node": ">=18",
-        "npm": ">=8.6.0"
+        "node": ">=20",
+        "npm": ">=9.6.4"
       },
       "peerDependencies": {
         "@types/express": "^5.0.0"
@@ -1013,8 +1013,10 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@tsconfig/node18": {
-      "version": "18.2.6",
+    "node_modules/@tsconfig/node20": {
+      "version": "20.1.9",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node20/-/node20-20.1.9.tgz",
+      "integrity": "sha512-IjlTv1RsvnPtUcjTqtVsZExKVq+KQx4g5pCP5tI7rAs6Xesl2qFwSz/tPDBC4JajkL/MlezBu3gPUwqRHl+RIg==",
       "dev": true,
       "license": "MIT"
     },
@@ -1121,11 +1123,19 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "18.19.130",
+      "version": "20.19.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.0.tgz",
+      "integrity": "sha512-hfrc+1tud1xcdVTABC2JiomZJEklMcXYNTVtZLAeqTVWD+qL5jkHKT+1lOtqDdGxt+mB53DTtiz673vfjU8D1Q==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~5.26.4"
+        "undici-types": "~6.21.0"
       }
+    },
+    "node_modules/@types/node/node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "license": "MIT"
     },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.4",
@@ -4562,10 +4572,6 @@
       "engines": {
         "node": ">=14.17"
       }
-    },
-    "node_modules/undici-types": {
-      "version": "5.26.5",
-      "license": "MIT"
     },
     "node_modules/universalify": {
       "version": "0.1.2",

--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
     "dist/**/*"
   ],
   "engines": {
-    "node": ">=18",
-    "npm": ">=8.6.0"
+    "node": ">=20",
+    "npm": ">=9.6.4"
   },
   "scripts": {
     "build": "npm run build:clean && tsc",
@@ -61,10 +61,10 @@
   "devDependencies": {
     "@biomejs/biome": "^1.9.0",
     "@changesets/cli": "^2.29.8",
-    "@tsconfig/node18": "^18.2.4",
+    "@tsconfig/node20": "^20.1.5",
     "@types/chai": "^4.1.7",
     "@types/mocha": "^10.0.1",
-    "@types/node": "18.19.130",
+    "@types/node": "20.19.0",
     "@types/proxyquire": "^1.3.31",
     "@types/sinon": "^17.0.4",
     "@types/tsscmp": "^1.0.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
-  "extends": "@tsconfig/node18/tsconfig.json",
+  "extends": "@tsconfig/node20/tsconfig.json",
   "compilerOptions": {
     "declaration": true,
     "declarationMap": true,


### PR DESCRIPTION
## Summary

This is a breaking change that drops `Node.js 18` support and raises the minimum required runtime to `Node.js 20`.

### Changes
  - Engine requirements: Updated engines field from `node >=18 / npm >=8.6.0` to `node >=20 / npm >=9.6.4`
  - TypeScript target: Switched from `@tsconfig/node18` to `@tsconfig/node20` across the project and examples
  - Type definitions: Updated `@types/node` from `18.x` to `20.x`
  - CI matrix: Removed `Node.js 18` from both the main CI build and samples workflows (still testing on 20, 22, and 24)
  - Documentation: Updated `AGENTS.md` to reflect the new `tsconfig` base

### Why
`Node.js 18` reached end-of-life on 2025-04-30. Dropping it allows the project to use newer language features, aligns type definitions with the actual supported runtime, and reduces CI surface area.

### Impact to end users

This is a major/breaking release. Users running `@slack/bolt` on `Node.js 18` will need to upgrade to `Node.js 20` or later. The npm engines field will emit a warning (or error with engine-strict) if installed under an unsupported version.


### Requirements <!-- Place an `x` in each `[ ]` -->

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-js/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
