### PR TITLE
feat: remove references to axios in favor of fetch

### DIFF
--- a/.changeset/use-native-fetch.md
+++ b/.changeset/use-native-fetch.md
@@ -1,0 +1,5 @@
+---
+"@slack/bolt": major
+---
+
+Replace axios with native fetch for response_url calls. Remove `agent` and `clientTls` options from `AppOptions` — use `clientOptions.fetch` to provide a custom fetch implementation for proxy/TLS needs. Add `dispatcher` option to `SocketModeReceiver` for proxy/TLS configuration in socket mode.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,12 +9,11 @@
       "version": "4.7.2",
       "license": "MIT",
       "dependencies": {
-        "@slack/logger": "^4.0.1",
-        "@slack/oauth": "^3.0.5",
-        "@slack/socket-mode": "^2.0.7",
-        "@slack/types": "^2.21.1",
-        "@slack/web-api": "^7.15.2",
-        "axios": "^1.12.0",
+        "@slack/logger": "^5.0.0-rc.1",
+        "@slack/oauth": "^4.0.0-rc.1",
+        "@slack/socket-mode": "^3.0.0-rc.2",
+        "@slack/types": "^3.0.0-rc.1",
+        "@slack/web-api": "^8.0.0-rc.1",
         "express": "^5.0.0",
         "path-to-regexp": "^8.1.0",
         "raw-body": "^3",
@@ -916,81 +915,82 @@
       }
     },
     "node_modules/@slack/logger": {
-      "version": "4.0.1",
+      "version": "5.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@slack/logger/-/logger-5.0.0-rc.1.tgz",
+      "integrity": "sha512-3vO8zNGvk8n8tXpAzhIz1u/fHjhsLxGMhlZqzJEa3FxlXAe2lsY3qn8XBgKYEG2LmGP6ZWWmDq7vAPr2gZe2CQ==",
       "license": "MIT",
       "dependencies": {
-        "@types/node": ">=18"
+        "@types/node": ">=20"
       },
       "engines": {
-        "node": ">= 18",
-        "npm": ">= 8.6.0"
+        "node": ">= 20",
+        "npm": ">=9.6.4"
       }
     },
     "node_modules/@slack/oauth": {
-      "version": "3.0.5",
+      "version": "4.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@slack/oauth/-/oauth-4.0.0-rc.1.tgz",
+      "integrity": "sha512-ciE79zenceNBukfWjSoqxAf335wSRDsl0xU/TdK1i9j/5XtPSx2h23OPjWt6IPOVIypmdGZiwe62iX/p2ulHsQ==",
       "license": "MIT",
       "dependencies": {
-        "@slack/logger": "^4.0.1",
-        "@slack/web-api": "^7.15.0",
+        "@slack/logger": "^5.0.0-rc.1",
+        "@slack/web-api": "^8.0.0-rc.1",
         "@types/jsonwebtoken": "^9",
-        "@types/node": ">=18",
+        "@types/node": ">=20",
         "jsonwebtoken": "^9"
       },
       "engines": {
-        "node": ">=18",
-        "npm": ">=8.6.0"
+        "node": ">=20",
+        "npm": ">=9.6.4"
       }
     },
     "node_modules/@slack/socket-mode": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/@slack/socket-mode/-/socket-mode-2.0.7.tgz",
-      "integrity": "sha512-qYy07je71WnEHgRwmw12DlAnZLi5HXmdlI2WUzUK2LH/rYXQpP6uEg462S5CwfE8FoCKUdIigHtYnOOfzZH1lQ==",
+      "version": "3.0.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@slack/socket-mode/-/socket-mode-3.0.0-rc.2.tgz",
+      "integrity": "sha512-otuxvm+fRdaUeJHxfQla4iDULbBRiKQrXjagSBFxJkjCpYCOPCdkIorc6LiM/GO9i7RWYRQZKzOj8fNv92PKyg==",
       "license": "MIT",
       "dependencies": {
-        "@slack/logger": "^4.0.1",
-        "@slack/web-api": "^7.15.0",
-        "@types/node": ">=18",
-        "@types/ws": "^8",
-        "eventemitter3": "^5",
-        "ws": "^8"
+        "@slack/logger": "^5.0.0-rc.1",
+        "@slack/web-api": "^8.0.0-rc.1",
+        "@types/node": ">=20",
+        "eventemitter3": "^5"
       },
       "engines": {
-        "node": ">= 18",
-        "npm": ">= 8.6.0"
+        "node": ">=20",
+        "npm": ">=9.6.4"
+      },
+      "peerDependencies": {
+        "undici": "^7.0.0"
       }
     },
     "node_modules/@slack/types": {
-      "version": "2.21.1",
-      "resolved": "https://registry.npmjs.org/@slack/types/-/types-2.21.1.tgz",
-      "integrity": "sha512-I8vmSjNYWsaxuWPx6dz4yeh0h7vRBWbgAMK14LEmblbZ404BtrPbXs6jDPx4cYgGf8msDGF4A9opLZBu21FViQ==",
+      "version": "3.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@slack/types/-/types-3.0.0-rc.1.tgz",
+      "integrity": "sha512-xJZm26o5YK95OdM8BliTE+LijNhMGAwLWWpSpfnrPno4DyLBthNAjC7SG/9Ow2gB7oXCeYadpF/nzlYz7XaATg==",
       "license": "MIT",
       "engines": {
-        "node": ">= 12.13.0",
-        "npm": ">= 6.12.0"
+        "node": ">= 20",
+        "npm": ">=9.6.4"
       }
     },
     "node_modules/@slack/web-api": {
-      "version": "7.15.2",
-      "resolved": "https://registry.npmjs.org/@slack/web-api/-/web-api-7.15.2.tgz",
-      "integrity": "sha512-/m9qVFkiq85Oa/FSQwYIRDa/AO4qNYkDh4sRBK1WqEc2+RyG7w4tbU6rBIwUOcc/TmWOIr24Nraquxg7um5mYw==",
+      "version": "8.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@slack/web-api/-/web-api-8.0.0-rc.1.tgz",
+      "integrity": "sha512-ZFJCYoAq0kC4pUe3V41YUOVvG/mceZ1yCcFMRCkYNu5joEuzkhKQpU4XfD2LnkJenWKwW6mg9J5KbBDMRCxCjg==",
       "license": "MIT",
       "dependencies": {
-        "@slack/logger": "^4.0.1",
-        "@slack/types": "^2.21.0",
-        "@types/node": ">=18",
+        "@slack/logger": "^5.0.0-rc.1",
+        "@slack/types": "^3.0.0-rc.1",
+        "@types/node": ">=20",
         "@types/retry": "0.12.0",
-        "axios": "^1.15.0",
         "eventemitter3": "^5.0.1",
-        "form-data": "^4.0.4",
-        "is-electron": "2.2.2",
-        "is-stream": "^2",
         "p-queue": "^6",
         "p-retry": "^4",
         "retry": "^0.13.1"
       },
       "engines": {
-        "node": ">= 18",
-        "npm": ">= 8.6.0"
+        "node": ">= 20",
+        "npm": ">=9.6.4"
       }
     },
     "node_modules/@tsconfig/node10": {
@@ -1196,13 +1196,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/ws": {
-      "version": "8.18.1",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "node_modules/accepts": {
       "version": "2.0.0",
       "license": "MIT",
@@ -1324,21 +1317,6 @@
       "license": "MIT",
       "engines": {
         "node": "*"
-      }
-    },
-    "node_modules/asynckit": {
-      "version": "0.4.0",
-      "license": "MIT"
-    },
-    "node_modules/axios": {
-      "version": "1.15.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.1.tgz",
-      "integrity": "sha512-WOG+Jj8ZOvR0a3rAn+Tuf1UQJRxw5venr6DgdbJzngJE3qG7X0kL83CZGpdHMxEm+ZK3seAbvFsw4FfOfP9vxg==",
-      "license": "MIT",
-      "dependencies": {
-        "follow-redirects": "^1.15.11",
-        "form-data": "^4.0.5",
-        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/balanced-match": {
@@ -1611,16 +1589,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/combined-stream": {
-      "version": "1.0.8",
-      "license": "MIT",
-      "dependencies": {
-        "delayed-stream": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "dev": true,
@@ -1736,13 +1704,6 @@
       },
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/delayed-stream": {
-      "version": "1.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4.0"
       }
     },
     "node_modules/depd": {
@@ -1866,19 +1827,6 @@
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/es-set-tostringtag": {
-      "version": "2.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "get-intrinsic": "^1.2.6",
-        "has-tostringtag": "^1.0.2",
-        "hasown": "^2.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -2098,24 +2046,6 @@
         "flat": "cli.js"
       }
     },
-    "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/RubenVerborgh"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=4.0"
-      },
-      "peerDependenciesMeta": {
-        "debug": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/foreground-child": {
       "version": "3.3.1",
       "dev": true,
@@ -2129,37 +2059,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/form-data": {
-      "version": "4.0.5",
-      "license": "MIT",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/form-data/node_modules/mime-db": {
-      "version": "1.52.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/form-data/node_modules/mime-types": {
-      "version": "2.1.35",
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "1.52.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
       }
     },
     "node_modules/forwarded": {
@@ -2351,19 +2250,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/has-tostringtag": {
-      "version": "1.0.2",
-      "license": "MIT",
-      "dependencies": {
-        "has-symbols": "^1.0.3"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/hasown": {
       "version": "2.0.2",
       "license": "MIT",
@@ -2520,10 +2406,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/is-electron": {
-      "version": "2.2.2",
-      "license": "MIT"
-    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "dev": true,
@@ -2578,16 +2460,6 @@
     "node_modules/is-promise": {
       "version": "4.0.0",
       "license": "MIT"
-    },
-    "node_modules/is-stream": {
-      "version": "2.0.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "node_modules/is-subdir": {
       "version": "1.2.0",
@@ -3497,13 +3369,6 @@
       },
       "engines": {
         "node": ">= 0.10"
-      }
-    },
-    "node_modules/proxy-from-env": {
-      "version": "2.1.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/proxyquire": {
@@ -4573,6 +4438,16 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/undici": {
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
+      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
     "node_modules/universalify": {
       "version": "0.1.2",
       "dev": true,
@@ -4686,25 +4561,6 @@
     "node_modules/wrappy": {
       "version": "1.0.2",
       "license": "ISC"
-    },
-    "node_modules/ws": {
-      "version": "8.20.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/package.json
+++ b/package.json
@@ -47,12 +47,11 @@
     "url": "https://github.com/slackapi/bolt-js/issues"
   },
   "dependencies": {
-    "@slack/logger": "^4.0.1",
-    "@slack/oauth": "^3.0.5",
-    "@slack/socket-mode": "^2.0.7",
-    "@slack/types": "^2.21.1",
-    "@slack/web-api": "^7.15.2",
-    "axios": "^1.12.0",
+    "@slack/logger": "^5.0.0-rc.1",
+    "@slack/oauth": "^4.0.0-rc.1",
+    "@slack/socket-mode": "^3.0.0-rc.2",
+    "@slack/types": "^3.0.0-rc.1",
+    "@slack/web-api": "^8.0.0-rc.1",
     "express": "^5.0.0",
     "path-to-regexp": "^8.1.0",
     "raw-body": "^3",

--- a/src/App.ts
+++ b/src/App.ts
@@ -1,9 +1,6 @@
-import type { Agent } from 'node:http';
-import type { SecureContextOptions } from 'node:tls';
 import util from 'node:util';
 import { ConsoleLogger, LogLevel, type Logger } from '@slack/logger';
-import { WebClient, type WebClientOptions, addAppMetadata } from '@slack/web-api';
-import axios, { type AxiosInstance } from 'axios';
+import { type FetchFunction, WebClient, type WebClientOptions, addAppMetadata } from '@slack/web-api';
 import type { Assistant } from './Assistant';
 import {
   CustomFunction,
@@ -126,8 +123,6 @@ export interface AppOptions {
   installationStore?: HTTPReceiverOptions['installationStore']; // default MemoryInstallationStore
   scopes?: HTTPReceiverOptions['scopes'];
   installerOptions?: HTTPReceiverOptions['installerOptions'];
-  agent?: Agent;
-  clientTls?: Pick<SecureContextOptions, 'pfx' | 'key' | 'passphrase' | 'cert' | 'ca'>;
   convoStore?: ConversationStore | false;
   token?: AuthorizeResult['botToken']; // either token or authorize
   appToken?: string; // TODO should this be included in AuthorizeResult
@@ -254,7 +249,7 @@ export default class App<AppCustomContext extends StringIndexed = StringIndexed>
 
   private errorHandler: AnyErrorHandler;
 
-  private axios: AxiosInstance;
+  private fetchFn: FetchFunction;
 
   private installerOptions: HTTPReceiverOptions['installerOptions'];
 
@@ -286,8 +281,6 @@ export default class App<AppCustomContext extends StringIndexed = StringIndexed>
     endpoints = undefined,
     port = undefined,
     customRoutes = undefined,
-    agent = undefined,
-    clientTls = undefined,
     receiver = undefined,
     convoStore = undefined,
     token = undefined,
@@ -351,12 +344,6 @@ export default class App<AppCustomContext extends StringIndexed = StringIndexed>
 
     /* ------------------------ Set client options ------------------------*/
     this.clientOptions = clientOptions !== undefined ? clientOptions : {};
-    if (agent !== undefined && this.clientOptions.agent === undefined) {
-      this.clientOptions.agent = agent;
-    }
-    if (clientTls !== undefined && this.clientOptions.tls === undefined) {
-      this.clientOptions.tls = clientTls;
-    }
     if (logLevel !== undefined && logger === undefined) {
       // only logLevel is passed
       this.clientOptions.logLevel = logLevel;
@@ -368,16 +355,7 @@ export default class App<AppCustomContext extends StringIndexed = StringIndexed>
     // Since v3.4, it can have the passed token in the case of single workspace installation.
     this.client = new WebClient(token, this.clientOptions);
 
-    this.axios = axios.create({
-      httpAgent: agent,
-      httpsAgent: agent,
-      // disabling axios' automatic proxy support:
-      // axios would read from env vars to configure a proxy automatically, but it doesn't support TLS destinations.
-      // for compatibility with https://api.slack.com, and for a larger set of possible proxies (SOCKS or other
-      // protocols), users of this package should use the `agent` option to configure a proxy.
-      proxy: false,
-      ...clientTls,
-    });
+    this.fetchFn = this.clientOptions.fetch ?? globalThis.fetch;
 
     this.middleware = [];
     this.listeners = [];
@@ -1147,10 +1125,10 @@ export default class App<AppCustomContext extends StringIndexed = StringIndexed>
 
     // Set respond() utility
     if (body.response_url) {
-      listenerArgs.respond = createRespond(this.axios, body.response_url);
+      listenerArgs.respond = createRespond(this.fetchFn, body.response_url);
     } else if (typeof body.response_urls !== 'undefined' && body.response_urls.length > 0) {
       // This can exist only when view_submission payloads - response_url_enabled: true
-      listenerArgs.respond = createRespond(this.axios, body.response_urls[0].response_url);
+      listenerArgs.respond = createRespond(this.fetchFn, body.response_urls[0].response_url);
     }
 
     // Set ack() utility

--- a/src/context/create-respond.ts
+++ b/src/context/create-respond.ts
@@ -1,12 +1,13 @@
-import type { AxiosInstance, AxiosResponse } from 'axios';
-import type { RespondArguments } from '../types';
+import type { FetchFunction } from '@slack/web-api';
+import type { RespondArguments, RespondFn } from '../types';
 
-export function createRespond(
-  axiosInstance: AxiosInstance,
-  responseUrl: string,
-): (response: string | RespondArguments) => Promise<AxiosResponse> {
+export function createRespond(fetchFn: FetchFunction, responseUrl: string): RespondFn {
   return async (message: string | RespondArguments) => {
     const normalizedArgs: RespondArguments = typeof message === 'string' ? { text: message } : message;
-    return axiosInstance.post(responseUrl, normalizedArgs);
+    return fetchFn(responseUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(normalizedArgs),
+    });
   };
 }

--- a/src/receivers/SocketModeReceiver.ts
+++ b/src/receivers/SocketModeReceiver.ts
@@ -9,6 +9,7 @@ import {
   type InstallURLOptions,
 } from '@slack/oauth';
 import { SocketModeClient } from '@slack/socket-mode';
+import type { SocketModeOptions } from '@slack/socket-mode';
 import type { AppsConnectionsOpenResponse } from '@slack/web-api';
 import type { ParamsDictionary } from 'express-serve-static-core';
 import { match } from 'path-to-regexp';
@@ -38,6 +39,7 @@ export interface SocketModeReceiverOptions {
   scopes?: InstallURLOptions['scopes'];
   installerOptions?: InstallerOptions;
   appToken: string; // App Level Token
+  dispatcher?: SocketModeOptions['dispatcher'];
   customRoutes?: CustomRoute[];
   clientPingTimeout?: number;
   serverPingTimeout?: number;
@@ -98,6 +100,7 @@ export default class SocketModeReceiver implements Receiver {
 
   public constructor({
     appToken,
+    dispatcher,
     logger = undefined,
     logLevel = LogLevel.INFO,
     clientPingTimeout = undefined,
@@ -117,6 +120,7 @@ export default class SocketModeReceiver implements Receiver {
   }: SocketModeReceiverOptions) {
     this.client = new SocketModeClient({
       appToken,
+      dispatcher,
       logLevel,
       logger,
       clientPingTimeout,

--- a/test/types/App.test-d.ts
+++ b/test/types/App.test-d.ts
@@ -1,4 +1,3 @@
-import { Agent } from 'node:http';
 import { ConsoleLogger, LogLevel } from '@slack/logger';
 import type { Installation, InstallationQuery } from '@slack/oauth';
 import { expectAssignable, expectError, expectType } from 'tsd';
@@ -50,7 +49,6 @@ expectAssignable<App>(
 expectAssignable<App>(
   new App({
     clientOptions: {
-      agent: new Agent(),
       allowAbsoluteUrls: false,
       logger: new ConsoleLogger(),
       retryConfig: {

--- a/test/unit/App/middlewares/arguments.spec.ts
+++ b/test/unit/App/middlewares/arguments.spec.ts
@@ -19,7 +19,6 @@ import {
   mergeOverrides,
   noop,
   noopMiddleware,
-  withAxiosPost,
   withChatStream,
   withConversationContext,
   withMemoryStore,
@@ -59,8 +58,7 @@ describe('App middleware and listener arguments', () => {
 
   describe('authorize', () => {
     it('should extract valid enterprise_id in a shared channel #935', async () => {
-      const fakeAxiosPost = sinon.fake.resolves({});
-      overrides = buildOverrides([withNoopWebClient(), withAxiosPost(fakeAxiosPost)]);
+      overrides = buildOverrides([withNoopWebClient()]);
       const MockApp = importApp(overrides);
       const fakeHandler = sinon.fake();
 
@@ -96,8 +94,7 @@ describe('App middleware and listener arguments', () => {
       sinon.assert.calledOnce(fakeHandler);
     });
     it('should be skipped for tokens_revoked events #674', async () => {
-      const fakeAxiosPost = sinon.fake.resolves({});
-      overrides = buildOverrides([withNoopWebClient(), withAxiosPost(fakeAxiosPost)]);
+      overrides = buildOverrides([withNoopWebClient()]);
       const MockApp = importApp(overrides);
       const fakeAuthorize = sinon.fake.resolves({});
       const fakeHandler = sinon.fake();
@@ -137,8 +134,7 @@ describe('App middleware and listener arguments', () => {
       sinon.assert.calledOnce(fakeHandler);
     });
     it('should be skipped for app_uninstalled events #674', async () => {
-      const fakeAxiosPost = sinon.fake.resolves({});
-      overrides = buildOverrides([withNoopWebClient(), withAxiosPost(fakeAxiosPost)]);
+      overrides = buildOverrides([withNoopWebClient()]);
       const MockApp = importApp(overrides);
       const fakeAuthorize = sinon.fake.resolves({});
       const fakeHandler = sinon.fake();
@@ -180,11 +176,15 @@ describe('App middleware and listener arguments', () => {
       const responseText = 'response';
       const response_url = 'https://fake.slack/response_url';
       const action_id = 'block_action_id';
-      const fakeAxiosPost = sinon.fake.resolves({});
-      overrides = buildOverrides([withNoopWebClient(), withAxiosPost(fakeAxiosPost)]);
+      const fakeFetch = sinon.fake.resolves(new Response(null, { status: 200 }));
+      overrides = buildOverrides([withNoopWebClient()]);
       const MockApp = importApp(overrides);
 
-      const app = new MockApp({ receiver: fakeReceiver, authorize: sinon.fake.resolves(dummyAuthorizationResult) });
+      const app = new MockApp({
+        receiver: fakeReceiver,
+        authorize: sinon.fake.resolves(dummyAuthorizationResult),
+        clientOptions: { fetch: fakeFetch },
+      });
       app.action(action_id, async ({ respond }) => {
         await respond(responseText);
       });
@@ -207,19 +207,24 @@ describe('App middleware and listener arguments', () => {
       );
 
       sinon.assert.notCalled(fakeErrorHandler);
-      // Assert that each call to fakeAxiosPost had the right arguments
-      sinon.assert.calledOnceWithExactly(fakeAxiosPost, response_url, { text: responseText });
+      sinon.assert.calledOnce(fakeFetch);
+      assert.equal(fakeFetch.firstCall.args[0], response_url);
+      assert.deepEqual(JSON.parse(fakeFetch.firstCall.args[1].body), { text: responseText });
     });
 
     it('should respond with a response object', async () => {
       const responseObject = { text: 'response' };
       const response_url = 'https://fake.slack/response_url';
       const action_id = 'block_action_id';
-      const fakeAxiosPost = sinon.fake.resolves({});
-      overrides = buildOverrides([withNoopWebClient(), withAxiosPost(fakeAxiosPost)]);
+      const fakeFetch = sinon.fake.resolves(new Response(null, { status: 200 }));
+      overrides = buildOverrides([withNoopWebClient()]);
       const MockApp = importApp(overrides);
 
-      const app = new MockApp({ receiver: fakeReceiver, authorize: sinon.fake.resolves(dummyAuthorizationResult) });
+      const app = new MockApp({
+        receiver: fakeReceiver,
+        authorize: sinon.fake.resolves(dummyAuthorizationResult),
+        clientOptions: { fetch: fakeFetch },
+      });
       app.action(action_id, async ({ respond }) => {
         await respond(responseObject);
       });
@@ -241,17 +246,22 @@ describe('App middleware and listener arguments', () => {
         ),
       );
 
-      // Assert that each call to fakeAxiosPost had the right arguments
-      sinon.assert.calledOnceWithExactly(fakeAxiosPost, response_url, responseObject);
+      sinon.assert.calledOnce(fakeFetch);
+      assert.equal(fakeFetch.firstCall.args[0], response_url);
+      assert.deepEqual(JSON.parse(fakeFetch.firstCall.args[1].body), responseObject);
     });
     it('should be able to use respond for view_submission payloads', async () => {
       const responseObject = { text: 'response' };
       const responseUrl = 'https://fake.slack/response_url';
-      const fakeAxiosPost = sinon.fake.resolves({});
-      overrides = buildOverrides([withNoopWebClient(), withAxiosPost(fakeAxiosPost)]);
+      const fakeFetch = sinon.fake.resolves(new Response(null, { status: 200 }));
+      overrides = buildOverrides([withNoopWebClient()]);
       const MockApp = importApp(overrides);
 
-      const app = new MockApp({ receiver: fakeReceiver, authorize: sinon.fake.resolves(dummyAuthorizationResult) });
+      const app = new MockApp({
+        receiver: fakeReceiver,
+        authorize: sinon.fake.resolves(dummyAuthorizationResult),
+        clientOptions: { fetch: fakeFetch },
+      });
       app.view('view-id', async ({ respond }) => {
         await respond(responseObject);
       });
@@ -276,8 +286,9 @@ describe('App middleware and listener arguments', () => {
         ),
       );
 
-      // Assert that each call to fakeAxiosPost had the right arguments
-      sinon.assert.calledOnceWithExactly(fakeAxiosPost, responseUrl, responseObject);
+      sinon.assert.calledOnce(fakeFetch);
+      assert.equal(fakeFetch.firstCall.args[0], responseUrl);
+      assert.deepEqual(JSON.parse(fakeFetch.firstCall.args[1].body), responseObject);
     });
   });
 
@@ -891,8 +902,7 @@ describe('App middleware and listener arguments', () => {
 
   describe('context', () => {
     it('should be able to use the app_installed_team_id when provided by the payload', async () => {
-      const fakeAxiosPost = sinon.fake.resolves({});
-      overrides = buildOverrides([withNoopWebClient(), withAxiosPost(fakeAxiosPost)]);
+      overrides = buildOverrides([withNoopWebClient()]);
       const MockApp = importApp(overrides);
       const callback_id = 'view-id';
       const app_installed_team_id = 'T-installed-workspace';
@@ -921,8 +931,7 @@ describe('App middleware and listener arguments', () => {
     });
 
     it('should have function executed event details from a custom step payload', async () => {
-      const fakeAxiosPost = sinon.fake.resolves({});
-      overrides = buildOverrides([withNoopWebClient(), withAxiosPost(fakeAxiosPost)]);
+      overrides = buildOverrides([withNoopWebClient()]);
       const MockApp = importApp(overrides);
       const callbackId = 'reverse_string';
       const functionBotAccessToken = 'xwfp-example';
@@ -963,8 +972,7 @@ describe('App middleware and listener arguments', () => {
     });
 
     it('should have function executed event details from a block actions payload', async () => {
-      const fakeAxiosPost = sinon.fake.resolves({});
-      overrides = buildOverrides([withNoopWebClient(), withAxiosPost(fakeAxiosPost)]);
+      overrides = buildOverrides([withNoopWebClient()]);
       const MockApp = importApp(overrides);
       const callbackId = 'reverse_string_button';
       const functionBotAccessToken = 'xwfp-example';

--- a/test/unit/context/create-respond.spec.ts
+++ b/test/unit/context/create-respond.spec.ts
@@ -1,39 +1,42 @@
-import type { AxiosInstance } from 'axios';
+import type { FetchFunction } from '@slack/web-api';
 import { assert } from 'chai';
 import sinon from 'sinon';
 import { createRespond } from '../../../src/context';
 
 describe('createRespond', () => {
   it('should post to the response URL with text when given a string', async () => {
-    const axiosInstance = { post: sinon.stub().resolves({ status: 200 }) };
-    const respond = createRespond(axiosInstance as unknown as AxiosInstance, 'https://hooks.slack.com/response/123');
+    const fakeFetch = sinon.fake.resolves(new Response(null, { status: 200 }));
+    const respond = createRespond(fakeFetch as unknown as FetchFunction, 'https://hooks.slack.com/response/123');
 
     await respond('hello');
 
-    assert(axiosInstance.post.calledOnce);
-    assert.equal(axiosInstance.post.firstCall.args[0], 'https://hooks.slack.com/response/123');
-    assert.deepEqual(axiosInstance.post.firstCall.args[1], { text: 'hello' });
+    assert(fakeFetch.calledOnce);
+    assert.equal(fakeFetch.firstCall.args[0], 'https://hooks.slack.com/response/123');
+    assert.equal(fakeFetch.firstCall.args[1].method, 'POST');
+    assert.deepEqual(JSON.parse(fakeFetch.firstCall.args[1].body), { text: 'hello' });
   });
 
   it('should post to the response URL with the full message object', async () => {
     const url = 'https://hooks.slack.com/response/123';
-    const axiosInstance = { post: sinon.stub().resolves({ status: 200 }) };
-    const respond = createRespond(axiosInstance as unknown as AxiosInstance, url);
+    const fakeFetch = sinon.fake.resolves(new Response(null, { status: 200 }));
+    const respond = createRespond(fakeFetch as unknown as FetchFunction, url);
 
     const message = { text: 'hello', replace_original: true };
     await respond(message);
 
-    assert(axiosInstance.post.calledOnceWithExactly(url, message));
+    assert(fakeFetch.calledOnce);
+    assert.equal(fakeFetch.firstCall.args[0], url);
+    assert.deepEqual(JSON.parse(fakeFetch.firstCall.args[1].body), message);
   });
 
   it('should use the correct response URL', async () => {
     const url = 'https://hooks.slack.com/response/456';
-    const axiosInstance = { post: sinon.stub().resolves({ status: 200 }) };
-    const respond = createRespond(axiosInstance as unknown as AxiosInstance, url);
+    const fakeFetch = sinon.fake.resolves(new Response(null, { status: 200 }));
+    const respond = createRespond(fakeFetch as unknown as FetchFunction, url);
 
     await respond('test');
 
-    assert(axiosInstance.post.calledOnce);
-    assert.equal(axiosInstance.post.firstCall.args[0], url);
+    assert(fakeFetch.calledOnce);
+    assert.equal(fakeFetch.firstCall.args[0], url);
   });
 });

--- a/test/unit/helpers/app.ts
+++ b/test/unit/helpers/app.ts
@@ -131,16 +131,6 @@ export function withSetStatus(spy: SinonSpy): Override {
   };
 }
 
-export function withAxiosPost(spy: SinonSpy): Override {
-  return {
-    axios: {
-      create: () => ({
-        post: spy,
-      }),
-    },
-  };
-}
-
 export function withSuccessfulBotUserFetchingWebClient(botId: string, botUserId: string): Override {
   return {
     '@slack/web-api': {


### PR DESCRIPTION
## Summary

These changes remove `axios` dependency from `@slack/bolt` and upgrades all `@slack/*` dependencies to their next major versions. The `respond()` utility now uses the native Fetch API, and proxy/TLS configuration is unified through the `fetch` and `dispatcher` options introduced upstream.

### Breaking Changes

- **`agent` option removed from `AppOptions`**: Use `clientOptions.fetch` with an [undici](https://undici.nodejs.org/) dispatcher instead.
- **`clientTls` option removed from `AppOptions`**: Use `clientOptions.fetch` with an undici `Agent` configured with TLS options instead.
- **`axios` dependency removed**: The internal `AxiosInstance` used for `response_url` calls has been replaced with native `fetch`. If you were relying on axios interceptors or proxy behavior, use `clientOptions.fetch` instead.
- **Upgraded `@slack/*` dependencies:**
  - `@slack/web-api` `^7` → `^8`
  - `@slack/socket-mode` `^2` → `^3`
  - `@slack/oauth` `^3` → `^4`
  - `@slack/logger` `^4` → `^5`
  - `@slack/types` `^2` → `^3`

### New: `dispatcher` option on `SocketModeReceiver`

The `SocketModeReceiver` now accepts a `dispatcher` option, which is passed directly to `@slack/socket-mode`. This handles both WebSocket connections **and** HTTP API calls in a single configuration point.

### Migration Guide

#### No proxy/TLS needed (most users)

No changes required beyond updating the package version. The SDK uses `globalThis.fetch` by default.

#### Proxy configuration

**Option A — Environment variable (recommended, zero code changes):**

```bash
NODE_USE_ENV_PROXY=1 HTTPS_PROXY=http://corporate.proxy:8080 node app.js
```
Option B — Programmatic (call once at startup):
```js
import http from 'node:http';
http.setGlobalProxyFromEnv();
```
Option C — Per-client undici dispatcher:
```js
import { App } from '@slack/bolt';
import { ProxyAgent } from 'undici';

const dispatcher = new ProxyAgent('http://corporate.proxy:8080');

// HTTP receiver (proxy for respond() and Web API calls)
const app = new App({
  token: process.env.SLACK_BOT_TOKEN,
  signingSecret: process.env.SLACK_SIGNING_SECRET,
  clientOptions: {
    fetch: (url, init) => fetch(url, { ...init, dispatcher }),
  },
});
```

#### Socket Mode with dispatcher

The dispatcher handles both WebSocket and HTTP traffic for the socket mode client:
```js
import { App, SocketModeReceiver } from '@slack/bolt';
import { ProxyAgent } from 'undici';

const dispatcher = new ProxyAgent('http://corporate.proxy:8080');

const app = new App({
  token: process.env.SLACK_BOT_TOKEN,
  appToken: process.env.SLACK_APP_TOKEN,
  // dispatcher is passed through to @slack/socket-mode
  receiver: new SocketModeReceiver({
    appToken: process.env.SLACK_APP_TOKEN,
    dispatcher,
  }),
  // dispatcher is passed through to Bolt WebClient
  clientOptions: {
    fetch: (url, init) => fetch(url, { ...init, dispatcher }),
  },
});
```

#### Custom TLS
```js
import { App } from '@slack/bolt';
import { fetch, Agent } from 'undici';
import fs from 'node:fs';

const dispatcher = new Agent({
  connect: {
    cert: fs.readFileSync('/path/to/client-cert.pem'),
    key: fs.readFileSync('/path/to/client-key.pem'),
    ca: fs.readFileSync('/path/to/ca-cert.pem'),
  },
});

const app = new App({
  token: process.env.SLACK_BOT_TOKEN,
  signingSecret: process.env.SLACK_SIGNING_SECRET,
  clientOptions: {
    fetch: (url, init) => fetch(url, { ...init, dispatcher }),
  },
});
```

#### respond() return type changed

`respond()` now returns `Promise<Response>` (native Fetch Response) instead of `Promise<AxiosResponse>`.

### Requirements <!-- Place an `x` in each `[ ]` -->

- [ ] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-js/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [ ] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
