### PR TITLE
feat: improve error handling

### DIFF
--- a/.changeset/improve-error-handling.md
+++ b/.changeset/improve-error-handling.md
@@ -1,0 +1,5 @@
+---
+"@slack/bolt": minor
+---
+
+Improve error handling by leveraging `@slack/web-api` v8 error classes. Authorization errors are now properly wrapped (preserving the original error's class identity). Default error handlers log richer details for web-api errors (API error codes, rate limit durations, HTTP status codes). Re-export `SlackError`, `WebAPIPlatformError`, `WebAPIRequestError`, `WebAPIHTTPError`, and `WebAPIRateLimitedError` from the package entry point.

--- a/src/App.ts
+++ b/src/App.ts
@@ -1,6 +1,14 @@
 import util from 'node:util';
 import { ConsoleLogger, LogLevel, type Logger } from '@slack/logger';
-import { type FetchFunction, WebClient, type WebClientOptions, addAppMetadata } from '@slack/web-api';
+import {
+  type FetchFunction,
+  WebAPIHTTPError,
+  WebAPIPlatformError,
+  WebAPIRateLimitedError,
+  WebClient,
+  type WebClientOptions,
+  addAppMetadata,
+} from '@slack/web-api';
 import type { Assistant } from './Assistant';
 import {
   CustomFunction,
@@ -20,8 +28,8 @@ import type { SayStreamFn, SetStatusFn } from './context';
 import { type ConversationStore, MemoryStore, conversationContext } from './conversation-store';
 import {
   AppInitializationError,
+  AuthorizationError,
   type CodedError,
-  ErrorCode,
   InvalidCustomPropertyError,
   MultipleListenerError,
   asCodedError,
@@ -918,12 +926,11 @@ export default class App<AppCustomContext extends StringIndexed = StringIndexed>
       try {
         authorizeResult = await this.authorize(source, bodyArg);
       } catch (error) {
-        // biome-ignore lint/suspicious/noExplicitAny: errors can be anything
-        const e = error as any;
+        const e = error instanceof Error ? error : new Error(String(error));
         this.logger.warn('Authorization of incoming event did not succeed. No listeners will be called.');
-        e.code = ErrorCode.AuthorizationError;
+        const authError = new AuthorizationError(`Authorization of incoming event did not succeed. ${e.message}`, e);
         await this.handleError({
-          error: e,
+          error: authError,
           logger: this.logger,
           body: bodyArg,
           context: {
@@ -1351,7 +1358,15 @@ export default class App<AppCustomContext extends StringIndexed = StringIndexed>
 
 function defaultErrorHandler(logger: Logger): ErrorHandler {
   return (error: CodedError) => {
-    logger.error(error);
+    if (error instanceof WebAPIPlatformError) {
+      logger.error(`Slack API error: ${error.data.error}`);
+    } else if (error instanceof WebAPIRateLimitedError) {
+      logger.error(`Rate limited, retry after ${error.retryAfter}s`);
+    } else if (error instanceof WebAPIHTTPError) {
+      logger.error(`HTTP error ${error.statusCode}: ${error.statusMessage}`);
+    } else {
+      logger.error(error);
+    }
 
     return Promise.reject(error);
   };

--- a/src/receivers/HTTPModuleFunctions.ts
+++ b/src/receivers/HTTPModuleFunctions.ts
@@ -2,7 +2,7 @@ import type { IncomingMessage, ServerResponse } from 'node:http';
 import { parse as qsParse } from 'node:querystring';
 import type { Logger } from '@slack/logger';
 import rawBody from 'raw-body';
-import { type CodedError, ErrorCode } from '../errors';
+import { AuthorizationError, type CodedError, HTTPReceiverDeferredRequestError } from '../errors';
 import type { BufferedIncomingMessage } from './BufferedIncomingMessage';
 import { verifySlackRequest } from './verify-request';
 
@@ -166,13 +166,11 @@ export const buildContentResponse = (res: ServerResponse, body: any): void => {
 // Note that it was not possible to make this function async due to the limitation of http module
 export const defaultDispatchErrorHandler = (args: ReceiverDispatchErrorHandlerArgs): void => {
   const { error, logger, request, response } = args;
-  if ('code' in error) {
-    if (error.code === ErrorCode.HTTPReceiverDeferredRequestError) {
-      logger.info(`Unhandled HTTP request (${request.method}) made to ${request.url}`);
-      response.writeHead(404);
-      response.end();
-      return;
-    }
+  if (error instanceof HTTPReceiverDeferredRequestError) {
+    logger.info(`Unhandled HTTP request (${request.method}) made to ${request.url}`);
+    response.writeHead(404);
+    response.end();
+    return;
   }
   logger.error(`An unexpected error occurred during a request (${request.method}) made to ${request.url}`);
   logger.debug(`Error details: ${error}`);
@@ -196,13 +194,11 @@ export const defaultProcessEventErrorHandler = async (args: ReceiverProcessEvent
     return false;
   }
 
-  if ('code' in error) {
-    if (error.code === ErrorCode.AuthorizationError) {
-      // authorize function threw an exception, which means there is no valid installation data
-      response.writeHead(401);
-      response.end();
-      return true;
-    }
+  if (error instanceof AuthorizationError) {
+    // authorize function threw an exception, which means there is no valid installation data
+    response.writeHead(401);
+    response.end();
+    return true;
   }
   logger.error('An unhandled error occurred while Bolt processed an event');
   logger.debug(`Error details: ${error}, storedResponse: ${storedResponse}`);

--- a/src/receivers/SocketModeFunctions.ts
+++ b/src/receivers/SocketModeFunctions.ts
@@ -1,5 +1,5 @@
 import type { Logger } from '@slack/logger';
-import { type CodedError, ErrorCode, isCodedError } from '../errors';
+import { AuthorizationError, type CodedError } from '../errors';
 import type { ReceiverEvent } from '../types';
 
 export async function defaultProcessEventErrorHandler(
@@ -11,7 +11,7 @@ export async function defaultProcessEventErrorHandler(
   // to return more properties to 'slack_event' listeners
   logger.error(`An unhandled error occurred while Bolt processed (type: ${event.body?.type}, error: ${error})`);
   logger.debug(`Error details: ${error}, retry num: ${event.retryNum}, retry reason: ${event.retryReason}`);
-  if (isCodedError(error) && error.code === ErrorCode.AuthorizationError) {
+  if (error instanceof AuthorizationError) {
     // The `authorize` function threw an exception, which means there is no valid installation data.
     // In this case, we can tell the Slack server-side to stop retries.
     return true;

--- a/test/unit/App/middlewares/global.spec.ts
+++ b/test/unit/App/middlewares/global.spec.ts
@@ -103,9 +103,9 @@ describe('App global middleware Processing', () => {
 
     assert(fakeMiddleware.notCalled);
     assert(fakeLogger.warn.called);
-    assert.instanceOf(fakeErrorHandler.firstCall.args[0], Error);
+    assert.instanceOf(fakeErrorHandler.firstCall.args[0], AuthorizationError);
     assert.propertyVal(fakeErrorHandler.firstCall.args[0], 'code', ErrorCode.AuthorizationError);
-    assert.propertyVal(fakeErrorHandler.firstCall.args[0], 'original', dummyAuthorizationError.original);
+    assert.strictEqual(fakeErrorHandler.firstCall.args[0].original, dummyAuthorizationError);
     assert(fakeAck.called);
   });
 


### PR DESCRIPTION
### Summary

These changes aims to improve how bolt handles `web-api` errors by leveraging the new Error classes thrown by the `web-api` packages

### Requirements <!-- Place an `x` in each `[ ]` -->

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-js/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
