### PR TITLE
feat(custom-routes): expose query params on request object

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -68,6 +68,7 @@ export {
   RequestVerificationOptions,
 } from './receivers/HTTPModuleFunctions';
 export type { HTTPReceiverOptions } from './receivers/HTTPReceiver';
+export type { ParamsIncomingMessage, QueryDictionary } from './receivers/ParamsIncomingMessage';
 export { HTTPResponseAck } from './receivers/HTTPResponseAck';
 export {
   defaultProcessEventErrorHandler,

--- a/src/receivers/HTTPReceiver.ts
+++ b/src/receivers/HTTPReceiver.ts
@@ -31,7 +31,7 @@ import type { BufferedIncomingMessage } from './BufferedIncomingMessage';
 import { buildReceiverRoutes, type CustomRoute, type ReceiverRoutes } from './custom-routes';
 import * as httpFunc from './HTTPModuleFunctions';
 import { HTTPResponseAck } from './HTTPResponseAck';
-import type { ParamsIncomingMessage } from './ParamsIncomingMessage';
+import type { ParamsIncomingMessage, QueryDictionary } from './ParamsIncomingMessage';
 import { verifyRedirectOpts } from './verify-redirect-opts';
 
 // Option keys for tls.createServer() and tls.createSecureContext(), exclusive of those for http.createServer()
@@ -413,7 +413,9 @@ export default class HTTPReceiver implements Receiver {
       const pathMatch = matchRegex(path);
       if (pathMatch && this.routes[route][method] !== undefined) {
         const params = pathMatch.params as ParamsDictionary;
-        const message: ParamsIncomingMessage = Object.assign(req, { params });
+        const parsedUrl = new URL(req.url as string, 'http://localhost');
+        const query = parseSearchParams(parsedUrl.searchParams);
+        const message: ParamsIncomingMessage = Object.assign(req, { params, query });
         return this.routes[route][method](message, res);
       }
     }
@@ -566,4 +568,13 @@ export default class HTTPReceiver implements Receiver {
       installer.handleCallback(req, res, installCallbackOptions).catch(errorHandler);
     }
   }
+}
+
+function parseSearchParams(searchParams: URLSearchParams): QueryDictionary {
+  const query: QueryDictionary = {};
+  for (const key of searchParams.keys()) {
+    const values = searchParams.getAll(key);
+    query[key] = values.length === 1 ? values[0] : values;
+  }
+  return query;
 }

--- a/src/receivers/ParamsIncomingMessage.ts
+++ b/src/receivers/ParamsIncomingMessage.ts
@@ -1,6 +1,8 @@
 import type { IncomingMessage } from 'node:http';
 import type { ParamsDictionary } from 'express-serve-static-core';
 
+export type QueryDictionary = Record<string, string | string[] | undefined>;
+
 export interface ParamsIncomingMessage extends IncomingMessage {
   /**
    * **Only valid for requests with path parameters.**
@@ -10,4 +12,11 @@ export interface ParamsIncomingMessage extends IncomingMessage {
    * then `request.params` will be `{ id: '123' }`.
    */
   params?: ParamsDictionary;
+
+  /**
+   * The query parameters of the request. For example, if the request URL is
+   * `/greetings?name=you&tags=a&tags=b`, then `request.query` will be
+   * `{ name: 'you', tags: ['a', 'b'] }`.
+   */
+  query?: QueryDictionary;
 }

--- a/src/receivers/SocketModeReceiver.ts
+++ b/src/receivers/SocketModeReceiver.ts
@@ -17,7 +17,7 @@ import type { CodedError } from '../errors';
 import type { Receiver, ReceiverEvent } from '../types';
 import type { StringIndexed } from '../types/utilities';
 import { buildReceiverRoutes, type ReceiverRoutes } from './custom-routes';
-import type { ParamsIncomingMessage } from './ParamsIncomingMessage';
+import type { ParamsIncomingMessage, QueryDictionary } from './ParamsIncomingMessage';
 import {
   defaultProcessEventErrorHandler,
   type SocketModeReceiverProcessEventErrorHandlerArgs,
@@ -209,7 +209,8 @@ export default class SocketModeReceiver implements Receiver {
         if (customRoutes.length && req.url) {
           // NOTE: the domain and scheme are irrelevant here.
           // The URL object is only used to safely obtain the path to match
-          const { pathname: path } = new URL(req.url as string, 'http://localhost');
+          const parsedUrl = new URL(req.url as string, 'http://localhost');
+          const { pathname: path } = parsedUrl;
           const routes = Object.keys(this.routes);
           for (let i = 0; i < routes.length; i += 1) {
             const route = routes[i];
@@ -217,7 +218,8 @@ export default class SocketModeReceiver implements Receiver {
             const pathMatch = matchRegex(path);
             if (pathMatch && this.routes[route][method] !== undefined) {
               const params = pathMatch.params as ParamsDictionary;
-              const message: ParamsIncomingMessage = Object.assign(req, { params });
+              const query = parseSearchParams(parsedUrl.searchParams);
+              const message: ParamsIncomingMessage = Object.assign(req, { params, query });
               this.routes[route][method](message, res);
               return;
             }
@@ -290,4 +292,13 @@ export default class SocketModeReceiver implements Receiver {
       }
     });
   }
+}
+
+function parseSearchParams(searchParams: URLSearchParams): QueryDictionary {
+  const query: QueryDictionary = {};
+  for (const key of searchParams.keys()) {
+    const values = searchParams.getAll(key);
+    query[key] = values.length === 1 ? values[0] : values;
+  }
+  return query;
 }


### PR DESCRIPTION
## Summary

Exposes query parameters to custom route handlers via req.query, similar to how Express.js handles them. When a request like /greetings?name=you comes in, the handler can access req.query.name directly.

## Changes

- Added QueryDictionary type to ParamsIncomingMessage.ts
- Added query property to ParamsIncomingMessage interface
- Updated HTTPReceiver to parse query params and attach to request
- Updated SocketModeReceiver to do the same
- Exported QueryDictionary and ParamsIncomingMessage from index.ts

## Example

```js
customRoutes: [
  {
    path: '/greetings',
    method: ['GET'],
    handler: (req, res) => {
      res.writeHead(200);
      res.end(+""+Hello +""+${req.query?.name || 'World'}!);
    },
  },
]
```

Requesting /greetings?name=you returns "Hello you!"

For repeated keys like /test?tags=a&tags=b, req.query.tags becomes ['a', 'b'].

Fixes #2100