### PR TITLE
fix: reject empty signingSecret to prevent involuntary signature bypass

### DIFF
--- a/.changeset/reject-empty-signing-secret.md
+++ b/.changeset/reject-empty-signing-secret.md
@@ -1,0 +1,5 @@
+---
+"@slack/bolt": patch
+---
+
+Reject empty `signingSecret` at initialization to prevent accidental HMAC signature forgery.

--- a/src/App.ts
+++ b/src/App.ts
@@ -1307,7 +1307,7 @@ export default class App<AppCustomContext extends StringIndexed = StringIndexed>
         customRoutes,
       });
     }
-    if (signatureVerification === true && signingSecret === undefined) {
+    if (signatureVerification === true && !signingSecret) {
       // Using default receiver HTTPReceiver, signature verification enabled, missing signingSecret
       throw new AppInitializationError(
         'signingSecret is required to initialize the default receiver. Set signingSecret or use a ' +

--- a/src/receivers/AwsLambdaReceiver.ts
+++ b/src/receivers/AwsLambdaReceiver.ts
@@ -6,6 +6,7 @@ import type App from '../App';
 import { ReceiverMultipleAckError } from '../errors';
 import type { Receiver, ReceiverEvent } from '../types/receiver';
 import type { StringIndexed } from '../types/utilities';
+import { verifySigningSecret } from './verify-signing-secret';
 
 export type AwsEvent = AwsEventV1 | AwsEventV2;
 type AwsEventStringParameters = Record<string, string | undefined>;
@@ -146,6 +147,7 @@ export default class AwsLambdaReceiver implements Receiver {
     invalidRequestSignatureHandler,
     unhandledRequestTimeoutMillis = 3001,
   }: AwsLambdaReceiverOptions) {
+    verifySigningSecret(signingSecret, signatureVerification);
     // Initialize instance variables, substituting defaults for each value
     this.signingSecret = signingSecret;
     this.signatureVerification = signatureVerification;

--- a/src/receivers/ExpressReceiver.ts
+++ b/src/receivers/ExpressReceiver.ts
@@ -194,7 +194,6 @@ export default class ExpressReceiver implements Receiver {
     unhandledRequestHandler = httpFunc.defaultUnhandledRequestHandler,
     unhandledRequestTimeoutMillis = 3001,
   }: ExpressReceiverOptions) {
-    verifySigningSecret(signingSecret, signatureVerification);
     this.app = app !== undefined ? app : express();
 
     if (typeof logger !== 'undefined') {
@@ -204,6 +203,9 @@ export default class ExpressReceiver implements Receiver {
       this.logger.setLevel(logLevel);
     }
 
+    if (typeof signingSecret !== 'function') {
+      verifySigningSecret(signingSecret, signatureVerification);
+    }
     this.signatureVerification = signatureVerification;
     const bodyParser = this.signatureVerification
       ? buildVerificationBodyParserMiddleware(this.logger, signingSecret)

--- a/src/receivers/ExpressReceiver.ts
+++ b/src/receivers/ExpressReceiver.ts
@@ -505,6 +505,12 @@ function verifyRequestSignature(
   signature: string | undefined,
   requestTimestamp: string | undefined,
 ): void {
+  if (!signingSecret) {
+    throw new ReceiverAuthenticityError(
+      'Slack request signing verification failed. signingSecret is empty or undefined.',
+    );
+  }
+
   if (signature === undefined || requestTimestamp === undefined) {
     throw new ReceiverAuthenticityError('Slack request signing verification failed. Some headers are missing.');
   }

--- a/src/receivers/ExpressReceiver.ts
+++ b/src/receivers/ExpressReceiver.ts
@@ -32,6 +32,7 @@ import type { StringIndexed } from '../types/utilities';
 import * as httpFunc from './HTTPModuleFunctions';
 import { HTTPResponseAck } from './HTTPResponseAck';
 import { verifyRedirectOpts } from './verify-redirect-opts';
+import { verifySigningSecret } from './verify-signing-secret';
 
 // Option keys for tls.createServer() and tls.createSecureContext(), exclusive of those for http.createServer()
 const httpsOptionKeys = [
@@ -172,7 +173,7 @@ export default class ExpressReceiver implements Receiver {
   private unhandledRequestTimeoutMillis: number;
 
   public constructor({
-    signingSecret = '',
+    signingSecret,
     logger = undefined,
     logLevel = LogLevel.INFO,
     endpoints = { events: '/slack/events' },
@@ -193,6 +194,7 @@ export default class ExpressReceiver implements Receiver {
     unhandledRequestHandler = httpFunc.defaultUnhandledRequestHandler,
     unhandledRequestTimeoutMillis = 3001,
   }: ExpressReceiverOptions) {
+    verifySigningSecret(signingSecret, signatureVerification);
     this.app = app !== undefined ? app : express();
 
     if (typeof logger !== 'undefined') {

--- a/src/receivers/HTTPReceiver.ts
+++ b/src/receivers/HTTPReceiver.ts
@@ -33,6 +33,7 @@ import * as httpFunc from './HTTPModuleFunctions';
 import { HTTPResponseAck } from './HTTPResponseAck';
 import type { ParamsIncomingMessage } from './ParamsIncomingMessage';
 import { verifyRedirectOpts } from './verify-redirect-opts';
+import { verifySigningSecret } from './verify-signing-secret';
 
 // Option keys for tls.createServer() and tls.createSecureContext(), exclusive of those for http.createServer()
 const httpsOptionKeys = [
@@ -170,7 +171,7 @@ export default class HTTPReceiver implements Receiver {
   private unhandledRequestTimeoutMillis: number;
 
   public constructor({
-    signingSecret = '',
+    signingSecret,
     endpoints = ['/slack/events'],
     port = 3000,
     customRoutes = [],
@@ -191,6 +192,7 @@ export default class HTTPReceiver implements Receiver {
     unhandledRequestHandler = httpFunc.defaultUnhandledRequestHandler,
     unhandledRequestTimeoutMillis = 3001,
   }: HTTPReceiverOptions) {
+    verifySigningSecret(signingSecret, signatureVerification);
     // Initialize instance variables, substituting defaults for each value
     this.signingSecret = signingSecret;
     this.processBeforeResponse = processBeforeResponse;

--- a/src/receivers/verify-request.ts
+++ b/src/receivers/verify-request.ts
@@ -24,6 +24,10 @@ export interface SlackRequestVerificationOptions {
  * If the request is invalid, this method throws an exception with the error details.
  */
 export function verifySlackRequest(options: SlackRequestVerificationOptions): void {
+  if (!options.signingSecret) {
+    throw new Error(`${verifyErrorPrefix}: signingSecret is empty or undefined`);
+  }
+
   const requestTimestampSec = options.headers['x-slack-request-timestamp'];
   const signature = options.headers['x-slack-signature'];
   if (Number.isNaN(requestTimestampSec)) {

--- a/src/receivers/verify-signing-secret.ts
+++ b/src/receivers/verify-signing-secret.ts
@@ -1,6 +1,6 @@
 import { AppInitializationError } from '../errors';
 
-export function verifySigningSecret(signingSecret: unknown, signatureVerification: boolean): void {
+export function verifySigningSecret(signingSecret: string | undefined | null, signatureVerification: boolean): void {
   if (signatureVerification && !signingSecret) {
     throw new AppInitializationError(
       'signingSecret is required when signature verification is enabled. ' +

--- a/src/receivers/verify-signing-secret.ts
+++ b/src/receivers/verify-signing-secret.ts
@@ -1,0 +1,10 @@
+import { AppInitializationError } from '../errors';
+
+export function verifySigningSecret(signingSecret: unknown, signatureVerification: boolean): void {
+  if (signatureVerification && !signingSecret) {
+    throw new AppInitializationError(
+      'signingSecret is required when signature verification is enabled. ' +
+        'You can find your Signing Secret in your Slack App Settings.',
+    );
+  }
+}

--- a/test/unit/App/basic.spec.ts
+++ b/test/unit/App/basic.spec.ts
@@ -32,13 +32,18 @@ describe('App basic features', () => {
     describe('with a custom port value in HTTP Mode', () => {
       it('should accept a port value at the top-level', async () => {
         const MockApp = importApp(overrides);
-        const app = new MockApp({ token: '', signingSecret: '', port: 9999 });
+        const app = new MockApp({ token: '', signingSecret: 'test-signing-secret', port: 9999 });
         // biome-ignore lint/complexity/useLiteralKeys: reaching into private fields
         assert.propertyVal(app['receiver'], 'port', 9999);
       });
       it('should accept a port value under installerOptions', async () => {
         const MockApp = importApp(overrides);
-        const app = new MockApp({ token: '', signingSecret: '', port: 7777, installerOptions: { port: 9999 } });
+        const app = new MockApp({
+          token: '',
+          signingSecret: 'test-signing-secret',
+          port: 7777,
+          installerOptions: { port: 9999 },
+        });
         // biome-ignore lint/complexity/useLiteralKeys: reaching into private fields
         assert.propertyVal(app['receiver'], 'port', 9999);
       });
@@ -91,13 +96,13 @@ describe('App basic features', () => {
     describe('with successful single team authorization results', () => {
       it('should succeed with a token for single team authorization', async () => {
         const MockApp = importApp(overrides);
-        const app = new MockApp({ token: '', signingSecret: '' });
+        const app = new MockApp({ token: '', signingSecret: 'test-signing-secret' });
         // TODO: verify that the fake bot ID and fake bot user ID are retrieved
         assert.instanceOf(app, MockApp);
       });
       it('should pass the given token to app.client', async () => {
         const MockApp = importApp(overrides);
-        const app = new MockApp({ token: 'xoxb-foo-bar', signingSecret: '' });
+        const app = new MockApp({ token: 'xoxb-foo-bar', signingSecret: 'test-signing-secret' });
         assert.isDefined(app.client);
         assert.equal(app.client.token, 'xoxb-foo-bar');
       });
@@ -105,13 +110,13 @@ describe('App basic features', () => {
     it('should succeed with an authorize callback', async () => {
       const authorizeCallback = sinon.fake();
       const MockApp = importApp();
-      new MockApp({ authorize: authorizeCallback, signingSecret: '' });
+      new MockApp({ authorize: authorizeCallback, signingSecret: 'test-signing-secret' });
       assert(authorizeCallback.notCalled, 'Should not call the authorize callback on instantiation');
     });
     it('should fail without a token for single team authorization, authorize callback, nor oauth installer', async () => {
       const MockApp = importApp();
       try {
-        new MockApp({ signingSecret: '' });
+        new MockApp({ signingSecret: 'test-signing-secret' });
         assert.fail();
       } catch (error) {
         assert.propertyVal(error, 'code', ErrorCode.AppInitializationError);
@@ -121,7 +126,7 @@ describe('App basic features', () => {
       const authorizeCallback = sinon.fake();
       const MockApp = importApp();
       try {
-        new MockApp({ token: '', authorize: authorizeCallback, signingSecret: '' });
+        new MockApp({ token: '', authorize: authorizeCallback, signingSecret: 'test-signing-secret' });
         assert.fail();
       } catch (error) {
         assert.propertyVal(error, 'code', ErrorCode.AppInitializationError);
@@ -132,7 +137,13 @@ describe('App basic features', () => {
       const authorizeCallback = sinon.fake();
       const MockApp = importApp();
       try {
-        new MockApp({ token: '', clientId: '', clientSecret: '', stateSecret: '', signingSecret: '' });
+        new MockApp({
+          token: '',
+          clientId: '',
+          clientSecret: '',
+          stateSecret: '',
+          signingSecret: 'test-signing-secret',
+        });
         assert.fail();
       } catch (error) {
         assert.propertyVal(error, 'code', ErrorCode.AppInitializationError);
@@ -148,7 +159,7 @@ describe('App basic features', () => {
           clientId: '',
           clientSecret: '',
           stateSecret: '',
-          signingSecret: '',
+          signingSecret: 'test-signing-secret',
         });
         assert.fail();
       } catch (error) {
@@ -174,11 +185,29 @@ describe('App basic features', () => {
         assert.propertyVal(error, 'code', ErrorCode.AppInitializationError);
       }
     });
+    it('should fail when signingSecret is empty string for the default receiver', async () => {
+      const MockApp = importApp();
+      try {
+        new MockApp({ authorize: noop, signingSecret: '' });
+        assert.fail();
+      } catch (error) {
+        assert.propertyVal(error, 'code', ErrorCode.AppInitializationError);
+      }
+    });
+    it('should fail when signingSecret is null for the default receiver', async () => {
+      const MockApp = importApp();
+      try {
+        new MockApp({ authorize: noop, signingSecret: null as unknown as string });
+        assert.fail();
+      } catch (error) {
+        assert.propertyVal(error, 'code', ErrorCode.AppInitializationError);
+      }
+    });
     it('should fail when both socketMode and a custom receiver are specified', async () => {
       const fakeReceiver = new FakeReceiver();
       const MockApp = importApp();
       try {
-        new MockApp({ token: '', signingSecret: '', socketMode: true, receiver: fakeReceiver });
+        new MockApp({ token: '', signingSecret: 'test-signing-secret', socketMode: true, receiver: fakeReceiver });
         assert.fail();
       } catch (error) {
         assert.propertyVal(error, 'code', ErrorCode.AppInitializationError);
@@ -187,7 +216,7 @@ describe('App basic features', () => {
     it('should succeed when both socketMode and SocketModeReceiver are specified', async () => {
       const MockApp = importApp(overrides);
       const socketModeReceiver = new SocketModeReceiver({ appToken: fakeAppToken });
-      new MockApp({ token: '', signingSecret: '', socketMode: true, receiver: socketModeReceiver });
+      new MockApp({ token: '', signingSecret: 'test-signing-secret', socketMode: true, receiver: socketModeReceiver });
     });
     it('should initialize MemoryStore conversation store by default', async () => {
       const fakeMemoryStore = sinon.fake();
@@ -200,7 +229,7 @@ describe('App basic features', () => {
       );
       const MockApp = importApp(overrides);
 
-      new MockApp({ authorize: noop, signingSecret: '' });
+      new MockApp({ authorize: noop, signingSecret: 'test-signing-secret' });
       assert(fakeMemoryStore.calledWithNew);
       assert(fakeConversationContext.called);
     });
@@ -213,13 +242,13 @@ describe('App basic features', () => {
       );
       it('should initialize without a conversation store when option is false', async () => {
         const MockApp = importApp(overrides);
-        new MockApp({ convoStore: false, authorize: noop, signingSecret: '' });
+        new MockApp({ convoStore: false, authorize: noop, signingSecret: 'test-signing-secret' });
         assert(fakeConversationContext.notCalled);
       });
       it('should initialize the conversation store', async () => {
         const dummyConvoStore = createFakeConversationStore();
         const MockApp = importApp(overrides);
-        const app = new MockApp({ convoStore: dummyConvoStore, authorize: noop, signingSecret: '' });
+        const app = new MockApp({ convoStore: dummyConvoStore, authorize: noop, signingSecret: 'test-signing-secret' });
         assert.instanceOf(app, MockApp);
         assert(fakeConversationContext.firstCall.calledWith(dummyConvoStore));
       });
@@ -228,7 +257,7 @@ describe('App basic features', () => {
       it('should fail when missing installerOptions', async () => {
         const MockApp = importApp();
         try {
-          new MockApp({ token: '', signingSecret: '', redirectUri: 'http://example.com/redirect' }); // eslint-disable-line no-new
+          new MockApp({ token: '', signingSecret: 'test-signing-secret', redirectUri: 'http://example.com/redirect' }); // eslint-disable-line no-new
           assert.fail();
         } catch (error) {
           assert.propertyVal(error, 'code', ErrorCode.AppInitializationError);
@@ -239,7 +268,7 @@ describe('App basic features', () => {
         try {
           new MockApp({
             token: '',
-            signingSecret: '',
+            signingSecret: 'test-signing-secret',
             redirectUri: 'http://example.com/redirect',
             installerOptions: {},
           });
@@ -264,7 +293,7 @@ describe('App basic features', () => {
 
       const MockApp = importApp(overrides);
       const clientOptions = { slackApiUrl: 'proxy.slack.com' };
-      new MockApp({ clientOptions, authorize: noop, signingSecret: '', logLevel: LogLevel.ERROR });
+      new MockApp({ clientOptions, authorize: noop, signingSecret: 'test-signing-secret', logLevel: LogLevel.ERROR });
       assert.ok(fakeConstructor.called);
       const [token, options] = fakeConstructor.lastCall.args;
       assert.strictEqual(token, undefined, 'token should be undefined');

--- a/test/unit/receivers/AwsLambdaReceiver.spec.ts
+++ b/test/unit/receivers/AwsLambdaReceiver.spec.ts
@@ -1,6 +1,7 @@
 import crypto from 'node:crypto';
 import { assert } from 'chai';
 import sinon from 'sinon';
+import { AppInitializationError } from '../../../src/errors';
 import AwsLambdaReceiver from '../../../src/receivers/AwsLambdaReceiver';
 import {
   createDummyAppMentionEventMiddlewareArgs,
@@ -24,6 +25,20 @@ const appOverrides = mergeOverrides(withNoopAppMetadata(), withNoopWebClient(fak
 
 describe('AwsLambdaReceiver', () => {
   const noopLogger = createFakeLogger();
+
+  it('should throw an error if signingSecret is empty string and signature verification enabled', async () => {
+    try {
+      new AwsLambdaReceiver({ signingSecret: '' });
+      assert.fail();
+    } catch (error) {
+      assert.instanceOf(error, AppInitializationError);
+    }
+  });
+
+  it('should succeed with empty signingSecret when signatureVerification is false', async () => {
+    const receiver = new AwsLambdaReceiver({ signingSecret: '', signatureVerification: false });
+    assert.isNotNull(receiver);
+  });
 
   it('should instantiate with default logger', async () => {
     const awsReceiver = new AwsLambdaReceiver({

--- a/test/unit/receivers/ExpressReceiver.spec.ts
+++ b/test/unit/receivers/ExpressReceiver.spec.ts
@@ -17,6 +17,7 @@ import ExpressReceiver, {
   buildBodyParserMiddleware,
   respondToSslCheck,
   respondToUrlVerification,
+  verifySignatureAndParseBody,
   verifySignatureAndParseRawBody,
 } from '../../../src/receivers/ExpressReceiver';
 import * as httpFunc from '../../../src/receivers/HTTPModuleFunctions';
@@ -852,6 +853,20 @@ describe('ExpressReceiver', () => {
       };
       const req = untypedReq as Request;
       await verifySignatureMismatch(req);
+    });
+
+    it('should reject an empty signingSecret at request time', async () => {
+      try {
+        verifySignatureAndParseBody('', body, {
+          'x-slack-signature': signature,
+          'x-slack-request-timestamp': requestTimestamp,
+          'content-type': 'application/x-www-form-urlencoded',
+        });
+        assert.fail('Expected error to be thrown');
+      } catch (e) {
+        assert.instanceOf(e, Error);
+        assert.include((e as Error).message, 'signingSecret is empty or undefined');
+      }
     });
   });
 

--- a/test/unit/receivers/ExpressReceiver.spec.ts
+++ b/test/unit/receivers/ExpressReceiver.spec.ts
@@ -69,6 +69,20 @@ describe('ExpressReceiver', () => {
   });
 
   describe('constructor', () => {
+    it('should throw an error if signingSecret is empty string and signature verification enabled', async () => {
+      try {
+        new ExpressReceiver({ signingSecret: '' });
+        assert.fail();
+      } catch (error) {
+        assert.instanceOf(error, AppInitializationError);
+      }
+    });
+
+    it('should succeed with empty signingSecret when signatureVerification is false', async () => {
+      const receiver = new ExpressReceiver({ signingSecret: '', signatureVerification: false });
+      assert.isNotNull(receiver);
+    });
+
     // NOTE: it would be more informative to test known valid combinations of options, as well as invalid combinations
     it('should accept supported arguments', async () => {
       const receiver = new ExpressReceiver({
@@ -188,7 +202,7 @@ describe('ExpressReceiver', () => {
   describe('#start()', () => {
     it('should start listening for requests using the built-in HTTP server', async () => {
       const ER = importExpressReceiver(overrides);
-      const receiver = new ER({ signingSecret: '' });
+      const receiver = new ER({ signingSecret: 'test-secret' });
       const port = 12345;
 
       const server = await receiver.start(port);
@@ -203,7 +217,7 @@ describe('ExpressReceiver', () => {
         withHttpsCreateServer(fakeCreateServer),
       );
       const ER = importExpressReceiver(overrides);
-      const receiver = new ER({ signingSecret: '' });
+      const receiver = new ER({ signingSecret: 'test-secret' });
       const port = 12345;
       const tlsOptions = { key: '', cert: '' };
 
@@ -220,7 +234,7 @@ describe('ExpressReceiver', () => {
         withHttpsCreateServer(sinon.fake.throws('Should not be used.')),
       );
       const ER = importExpressReceiver(overrides);
-      const receiver = new ER({ signingSecret: '' });
+      const receiver = new ER({ signingSecret: 'test-secret' });
       const port = 12345;
 
       let caughtError: Error | undefined;
@@ -239,7 +253,7 @@ describe('ExpressReceiver', () => {
         withHttpsCreateServer(sinon.fake.throws('Should not be used.')),
       );
       const ER = importExpressReceiver(overrides);
-      const receiver = new ER({ signingSecret: '' });
+      const receiver = new ER({ signingSecret: 'test-secret' });
       const port = 12345;
 
       let caughtError: Error | undefined;
@@ -254,7 +268,7 @@ describe('ExpressReceiver', () => {
     });
     it('should reject with an error when starting and the server was already previously started', async () => {
       const ER = importExpressReceiver(overrides);
-      const receiver = new ER({ signingSecret: '' });
+      const receiver = new ER({ signingSecret: 'test-secret' });
       const port = 12345;
 
       let caughtError: Error | undefined;
@@ -273,7 +287,7 @@ describe('ExpressReceiver', () => {
   describe('#stop()', () => {
     it('should stop listening for requests when a built-in HTTP server is already started', async () => {
       const ER = importExpressReceiver(overrides);
-      const receiver = new ER({ signingSecret: '' });
+      const receiver = new ER({ signingSecret: 'test-secret' });
       const port = 12345;
       await receiver.start(port);
 
@@ -281,7 +295,7 @@ describe('ExpressReceiver', () => {
     });
     it('should reject when a built-in HTTP server is not started', async () => {
       const ER = importExpressReceiver(overrides);
-      const receiver = new ER({ signingSecret: '' });
+      const receiver = new ER({ signingSecret: 'test-secret' });
 
       let caughtError: Error | undefined;
       try {
@@ -304,7 +318,7 @@ describe('ExpressReceiver', () => {
         withHttpsCreateServer(sinon.fake.throws('Should not be used.')),
       );
       const ER = importExpressReceiver(overrides);
-      const receiver = new ER({ signingSecret: '' });
+      const receiver = new ER({ signingSecret: 'test-secret' });
       await receiver.start(12345);
 
       let caughtError: Error | undefined;
@@ -348,7 +362,7 @@ describe('ExpressReceiver', () => {
     });
     it('should not build an HTTP response if processBeforeResponse=false', async () => {
       const ER = importExpressReceiver(overrides);
-      const receiver = new ER({ signingSecret: '' });
+      const receiver = new ER({ signingSecret: 'test-secret' });
       const app = sinon.createStubInstance(App, { processEvent: processStub }) as unknown as App;
       receiver.init(app);
 
@@ -365,7 +379,7 @@ describe('ExpressReceiver', () => {
         return Promise.resolve({});
       });
       const ER = importExpressReceiver(overrides);
-      const receiver = new ER({ signingSecret: '' });
+      const receiver = new ER({ signingSecret: 'test-secret' });
       const app = sinon.createStubInstance(App, { processEvent: processStub }) as unknown as App;
       receiver.init(app);
 
@@ -377,7 +391,7 @@ describe('ExpressReceiver', () => {
     it('should throw and build an HTTP 500 response with no body if processEvent raises an uncoded Error or a coded, non-Authorization Error', async () => {
       processStub.callsFake(() => Promise.reject(new Error('uh oh')));
       const ER = importExpressReceiver(overrides);
-      const receiver = new ER({ signingSecret: '' });
+      const receiver = new ER({ signingSecret: 'test-secret' });
       const app = sinon.createStubInstance(App, { processEvent: processStub }) as unknown as App;
       receiver.init(app);
 
@@ -393,7 +407,7 @@ describe('ExpressReceiver', () => {
     it('should build an HTTP 401 response with no body and call ack() if processEvent raises a coded AuthorizationError', async () => {
       processStub.callsFake(() => Promise.reject(new AuthorizationError('uh oh', new Error())));
       const ER = importExpressReceiver(overrides);
-      const receiver = new ER({ signingSecret: '' });
+      const receiver = new ER({ signingSecret: 'test-secret' });
       const app = sinon.createStubInstance(App, { processEvent: processStub }) as unknown as App;
       receiver.init(app);
 
@@ -412,7 +426,7 @@ describe('ExpressReceiver', () => {
     describe('install path route', () => {
       it('should call into installer.handleInstallPath when HTTP GET request hits the install path', async () => {
         const ER = importExpressReceiver(overrides);
-        const receiver = new ER({ signingSecret: '', clientSecret: '', clientId: '', stateSecret: '' });
+        const receiver = new ER({ signingSecret: 'test-secret', clientSecret: '', clientId: '', stateSecret: '' });
         const handleStub = sinon.stub(receiver.installer as InstallProvider, 'handleInstallPath').resolves();
 
         const req = { body: {}, url: 'http://localhost/slack/install', method: 'GET' } as Request;
@@ -434,7 +448,7 @@ describe('ExpressReceiver', () => {
           callbackOptions,
         };
         const receiver = new ER({
-          signingSecret: '',
+          signingSecret: 'test-secret',
           clientSecret: '',
           clientId: '',
           stateSecret: '',
@@ -459,7 +473,7 @@ describe('ExpressReceiver', () => {
           callbackOptions,
         };
         const receiver = new ER({
-          signingSecret: '',
+          signingSecret: 'test-secret',
           clientSecret: '',
           clientId: '',
           stateSecret: '',
@@ -481,7 +495,7 @@ describe('ExpressReceiver', () => {
   describe('state management for built-in server', () => {
     it('should be able to start after it was stopped', async () => {
       const ER = importExpressReceiver(overrides);
-      const receiver = new ER({ signingSecret: '' });
+      const receiver = new ER({ signingSecret: 'test-secret' });
       const port = 12345;
       await receiver.start(port);
       await receiver.stop();

--- a/test/unit/receivers/HTTPReceiver.spec.ts
+++ b/test/unit/receivers/HTTPReceiver.spec.ts
@@ -116,6 +116,22 @@ describe('HTTPReceiver', () => {
       assert.propertyVal(customPort2, 'port', 9999);
     });
 
+    it('should throw an error if signingSecret is empty string and signature verification enabled', async () => {
+      const HTTPReceiver = importHTTPReceiver(overrides);
+      try {
+        new HTTPReceiver({ signingSecret: '' });
+        assert.fail();
+      } catch (error) {
+        assert.instanceOf(error, AppInitializationError);
+      }
+    });
+
+    it('should succeed with empty signingSecret when signatureVerification is false', async () => {
+      const HTTPReceiver = importHTTPReceiver(overrides);
+      const receiver = new HTTPReceiver({ signingSecret: '', signatureVerification: false });
+      assert.isNotNull(receiver);
+    });
+
     it('should throw an error if redirect uri options supplied invalid or incomplete', async () => {
       const HTTPReceiver = importHTTPReceiver();
       const clientId = 'my-clientId';

--- a/test/unit/receivers/verify-request.spec.ts
+++ b/test/unit/receivers/verify-request.spec.ts
@@ -6,6 +6,20 @@ describe('Request verification', async () => {
   const signingSecret = 'secret';
 
   describe('verifySlackRequest', async () => {
+    it('should throw when signingSecret is empty string', async () => {
+      try {
+        verifySlackRequest({
+          signingSecret: '',
+          headers: { 'x-slack-signature': 'v0=abc', 'x-slack-request-timestamp': Math.floor(Date.now() / 1000) },
+          body: '{}',
+        });
+        assert.fail('Expected error to be thrown');
+      } catch (e) {
+        assert.instanceOf(e, Error);
+        assert.include((e as Error).message, 'signingSecret is empty or undefined');
+      }
+    });
+
     it('should judge a valid request', async () => {
       const timestamp = Math.floor(Date.now() / 1000);
       const rawBody = '{"foo":"bar"}';

--- a/test/unit/receivers/verify-signing-secret.spec.ts
+++ b/test/unit/receivers/verify-signing-secret.spec.ts
@@ -1,0 +1,42 @@
+import { assert } from 'chai';
+import { ErrorCode } from '../../../src/errors';
+import { verifySigningSecret } from '../../../src/receivers/verify-signing-secret';
+
+describe('verifySigningSecret', () => {
+  it('should throw AppInitializationError when signingSecret is empty string and verification enabled', () => {
+    try {
+      verifySigningSecret('', true);
+      assert.fail();
+    } catch (error) {
+      assert.propertyVal(error, 'code', ErrorCode.AppInitializationError);
+    }
+  });
+
+  it('should throw AppInitializationError when signingSecret is null and verification enabled', () => {
+    try {
+      verifySigningSecret(null, true);
+      assert.fail();
+    } catch (error) {
+      assert.propertyVal(error, 'code', ErrorCode.AppInitializationError);
+    }
+  });
+
+  it('should throw AppInitializationError when signingSecret is undefined and verification enabled', () => {
+    try {
+      verifySigningSecret(undefined, true);
+      assert.fail();
+    } catch (error) {
+      assert.propertyVal(error, 'code', ErrorCode.AppInitializationError);
+    }
+  });
+
+  it('should not throw when signingSecret is empty but signatureVerification is false', () => {
+    assert.doesNotThrow(() => verifySigningSecret('', false));
+    assert.doesNotThrow(() => verifySigningSecret(null, false));
+    assert.doesNotThrow(() => verifySigningSecret(undefined, false));
+  });
+
+  it('should not throw when signingSecret is a valid string and verification enabled', () => {
+    assert.doesNotThrow(() => verifySigningSecret('my-signing-secret', true));
+  });
+});


### PR DESCRIPTION
### Summary

- Reject empty `signingSecret` (`''`) at initialization across all receivers and in the request verification layer to prevent accidental verification bypass
- Add a shared `verifySigningSecret()` helper that validates the signing secret is a non-empty string when signature verification is enabled
- Add comprehensive unit tests for the new validation across `App`, `HTTPReceiver`, `ExpressReceiver`, `AwsLambdaReceiver`, `verifyRequest`, and `verifySigningSecret`

## Motivation

Previously, passing an empty string (`''`) as `signingSecret` did not trigger an error, the value is truthy enough to pass `=== undefined` checks but propagates to `createHmac("sha256", "")`, which produces a valid HMAC keyed with an empty secret. This would bypass the request verification without warning the user.


The proper way to disable signature verification is by setting `signatureVerification: false`

## Reproduction

**Server with issue (`app.js`):**

```js
import { App } from '@slack/bolt';

const app = new App({
  signingSecret: '',
  port: 3000,
  authorize: async () => ({ botToken: 'xoxb-fake', botId: 'B000', botUserId: 'U000' }),
});

app.event('app_mention', async ({ event }) => {
  console.log(`Received app_mention from ${event.user}: ${event.text}`);
});

await app.start();
console.log('Vulnerable server listening on :3000');
```

Forged request:
```
TIMESTAMP=$(date +%s) && \
BODY='{"type":"url_verification","challenge":"bypass-confirmed"}' && \
curl -X POST http://localhost:3000/slack/events \
  -H "Content-Type: application/json" \
  -H "x-slack-request-timestamp: $TIMESTAMP" \
  -H "x-slack-signature: v0=$(printf "v0:${TIMESTAMP}:${BODY}" | openssl dgst -sha256 -hmac '' | awk '{print $NF}')" \
  -d "$BODY"
```

With this fix applied, the App constructor now throws an AppInitializationError and receivers throw a ReceiverInitializationError, preventing the server from starting with an empty signing secret.

### Requirements <!-- Place an `x` in each `[ ]` -->

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-js/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
