### PR TITLE
fix(types): add context_team_id and context_enterprise_id to EnvelopedEvent (closes #2773)

### DIFF
--- a/.changeset/enveloped-event-context-team-id.md
+++ b/.changeset/enveloped-event-context-team-id.md
@@ -1,0 +1,5 @@
+---
+"@slack/bolt": patch
+---
+
+Add `context_team_id` and `context_enterprise_id` as optional fields on the `EnvelopedEvent` type. Slack's Events API delivers these on the envelope for Slack Connect channels and Enterprise Grid org-wide apps, where `team_id` may refer to a workspace different from the one the bot is installed in. Without the typed fields, downstream code had to reach for `@ts-expect-error` or unsafe casts to route by the correct workspace.

--- a/src/types/events/index.ts
+++ b/src/types/events/index.ts
@@ -81,10 +81,6 @@ export interface EnvelopedEvent<Event = BaseSlackEvent> extends StringIndexed {
   team_id: string;
   enterprise_id?: string;
   context_team_id?: string;
-  /**
-   * Enterprise grid org where the event originated. Companion to `context_team_id`;
-   * present alongside it on Slack Connect / org-wide app payloads.
-   */
   context_enterprise_id?: string;
   api_app_id: string;
   event: Event;

--- a/src/types/events/index.ts
+++ b/src/types/events/index.ts
@@ -80,12 +80,6 @@ export interface EnvelopedEvent<Event = BaseSlackEvent> extends StringIndexed {
   token: string;
   team_id: string;
   enterprise_id?: string;
-  /**
-   * Workspace where the event originated. Sent by Slack on Slack Connect channels and
-   * Enterprise Grid org-wide apps, where `team_id` may refer to a different workspace
-   * than the one the bot is installed in. Prefer this over `team_id` when routing by
-   * workspace. See https://docs.slack.dev/enterprise-grid/org-wide-apps#context-team-id
-   */
   context_team_id?: string;
   /**
    * Enterprise grid org where the event originated. Companion to `context_team_id`;

--- a/src/types/events/index.ts
+++ b/src/types/events/index.ts
@@ -80,6 +80,18 @@ export interface EnvelopedEvent<Event = BaseSlackEvent> extends StringIndexed {
   token: string;
   team_id: string;
   enterprise_id?: string;
+  /**
+   * Workspace where the event originated. Sent by Slack on Slack Connect channels and
+   * Enterprise Grid org-wide apps, where `team_id` may refer to a different workspace
+   * than the one the bot is installed in. Prefer this over `team_id` when routing by
+   * workspace. See https://docs.slack.dev/enterprise-grid/org-wide-apps#context-team-id
+   */
+  context_team_id?: string;
+  /**
+   * Enterprise grid org where the event originated. Companion to `context_team_id`;
+   * present alongside it on Slack Connect / org-wide app payloads.
+   */
+  context_enterprise_id?: string;
   api_app_id: string;
   event: Event;
   type: 'event_callback';

--- a/test/types/event.test-d.ts
+++ b/test/types/event.test-d.ts
@@ -65,5 +65,14 @@ app.event('reaction_removed', async ({ say, event }) => {
   expectType<ReactionRemovedEvent>(event);
 });
 
+// Slack Connect / Enterprise Grid org-wide context fields on the envelope.
+// Both must be optional `string | undefined` — they are absent on classic
+// single-workspace event deliveries and present on cross-workspace ones.
+// Regression coverage for https://github.com/slackapi/bolt-js/issues/2773.
+app.event('message', async ({ body }) => {
+  expectType<string | undefined>(body.context_team_id);
+  expectType<string | undefined>(body.context_enterprise_id);
+});
+
 // TODO: we should not allow providing bogus event names
 // app.event('garbage', async ({ event }) => {});


### PR DESCRIPTION
### Summary

Closes #2773. Adds the two Enterprise Grid / Slack Connect context fields that Slack's Events API delivers on the envelope but the type didn't surface.

In Slack Connect channels and Enterprise Grid org-wide apps, `body.team_id` can identify a workspace different from the one the bot is installed in. Slack solves this by also sending `context_team_id` (and its enterprise counterpart `context_enterprise_id`), which always identify the workspace where the bot is actually running. Reporter (@FreQll) hit this when messages from Slack Connect channels were being routed to the wrong inbox.

Before this PR, accessing those fields on `body` required `@ts-expect-error` or an unsafe cast because the `EnvelopedEvent` interface only declared `team_id` / `enterprise_id`. The `StringIndexed` index signature on the interface meant the access would silently return `any`, defeating type safety.

### What changed

- `src/types/events/index.ts` — added `context_team_id?: string` and `context_enterprise_id?: string` to `EnvelopedEvent`, with JSDoc pointing at the Enterprise Grid docs so the next reader doesn't have to guess when these are sent.
- `test/types/event.test-d.ts` — tsd assertions on `body.context_team_id` / `body.context_enterprise_id` so the fields are exercised as `string | undefined` and can't silently regress into `any` via the `StringIndexed` fallback. The test fails on the unpatched source with \`Parameter type string | undefined is not identical to argument type any\` for both new assertions.

### Notes

- Type-only addition; no runtime change, no behavior change for existing callers.
- Both fields are optional — they're absent on classic single-workspace event deliveries and present on cross-workspace / org-wide ones, per [Slack's docs](https://docs.slack.dev/enterprise-grid/org-wide-apps#context-team-id).
- \`npm test\` (build + Biome + tsd + mocha + coverage) passes locally.

### Requirements

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-js/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).