### PR TITLE
chore: block @types/node@26 for @dependabot and revert examples to @types/node@24

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,6 +23,7 @@ updates:
           - "23.x"
           - "24.x"
           - "25.x"
+          - "26.x"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
@@ -50,3 +51,4 @@ updates:
       - dependency-name: "@types/node"
         versions:
           - "25.x"
+          - "26.x"

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -24,6 +24,7 @@ jobs:
           - 20.x
           - 22.x
           - 24.x
+          - 26.x
     permissions:
       contents: read
     steps:

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -24,7 +24,6 @@ jobs:
           - 20.x
           - 22.x
           - 24.x
-          - 26.x
     permissions:
       contents: read
     steps:

--- a/examples/custom-receiver/package-lock.json
+++ b/examples/custom-receiver/package-lock.json
@@ -20,7 +20,7 @@
       "devDependencies": {
         "@tsconfig/node18": "^18.2.6",
         "@types/koa": "^3.0.3",
-        "@types/node": "^26",
+        "@types/node": "^24",
         "ts-node": "^10",
         "typescript": "6.0.3"
       }
@@ -484,12 +484,12 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "26.0.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.0.0.tgz",
-      "integrity": "sha512-vf2YFi1iY9lHGwNJMs01biZFbKJkrZR1T6/MlzjhJLPdntOHLhTrDSnSVcdtvjihi4VQNlrFRIxLsDBlQpAipA==",
+      "version": "24.13.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.2.tgz",
+      "integrity": "sha512-fRa09kZTgu8o71KFcDjUFuc7F+dEbZYZmkI0mg5YBTRs0yMKjYHsq/c0urDKeDb+D5qVgXOdFcuu+DZPKOITwA==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~8.3.0"
+        "undici-types": "~7.18.0"
       }
     },
     "node_modules/@types/qs": {
@@ -2460,9 +2460,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
-      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "license": "MIT"
     },
     "node_modules/unpipe": {

--- a/examples/custom-receiver/package.json
+++ b/examples/custom-receiver/package.json
@@ -22,7 +22,7 @@
   "devDependencies": {
     "@tsconfig/node18": "^18.2.6",
     "@types/koa": "^3.0.3",
-    "@types/node": "^26",
+    "@types/node": "^24",
     "ts-node": "^10",
     "typescript": "6.0.3"
   }

--- a/examples/getting-started-typescript/package.json
+++ b/examples/getting-started-typescript/package.json
@@ -15,7 +15,7 @@
   },
   "devDependencies": {
     "@tsconfig/node18": "^18.2.6",
-    "@types/node": "^26",
+    "@types/node": "^24",
     "ts-node": "^10",
     "typescript": "6.0.3"
   }


### PR DESCRIPTION
### Summary

This pull request caps `@types/node` for Bolt for JavaScript and rolls the bundled examples back to v24.

- Extends the `@types/node` Dependabot ignore rules to also block `26.x` (framework stays on the v18 line; examples on v24).
- Reverts #2983 and #2986, which had bumped `@types/node` to v26 in `examples/custom-receiver` and `examples/getting-started-typescript`; both return to the v24 line.

The Node 26 CI matrix addition was split out into #2990 so it can land independently.

### Requirements <!-- Place an `x` in each `[ ]` -->

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-js/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
