### PR TITLE
fix(receivers): allow null for AwsEventV1.multiValueQueryStringParameters

### DIFF
--- a/.changeset/fix-aws-event-v1-null-multi-value-params.md
+++ b/.changeset/fix-aws-event-v1-null-multi-value-params.md
@@ -1,0 +1,5 @@
+---
+"@slack/bolt": patch
+---
+
+Fix `AwsEventV1.multiValueQueryStringParameters` to allow `null`, matching the actual AWS API Gateway payload and the `@types/aws-lambda` `APIGatewayProxyEvent` type. This resolves the type error when passing an `APIGatewayProxyEvent` directly to the handler returned by `AwsLambdaReceiver`.

--- a/src/receivers/AwsLambdaReceiver.ts
+++ b/src/receivers/AwsLambdaReceiver.ts
@@ -24,7 +24,7 @@ export interface AwsEventV1 {
   // v1-only properties:
   httpMethod: string;
   multiValueHeaders: AwsEventMultiValueStringParameters;
-  multiValueQueryStringParameters: AwsEventMultiValueStringParameters;
+  multiValueQueryStringParameters: AwsEventMultiValueStringParameters | null;
   path: string;
   resource: string;
 }

--- a/test/types/aws-lambda-receiver.test-d.ts
+++ b/test/types/aws-lambda-receiver.test-d.ts
@@ -1,0 +1,18 @@
+import { expectAssignable } from 'tsd';
+import type { AwsEventV1 } from '../../src/receivers/AwsLambdaReceiver';
+
+// multiValueQueryStringParameters can be null (as AWS sends when no multi-value params exist)
+expectAssignable<AwsEventV1>({
+  body: null,
+  headers: {},
+  isBase64Encoded: false,
+  pathParameters: null,
+  queryStringParameters: null,
+  requestContext: {},
+  stageVariables: null,
+  httpMethod: 'POST',
+  multiValueHeaders: {},
+  multiValueQueryStringParameters: null,
+  path: '/slack/events',
+  resource: '/slack/events',
+});


### PR DESCRIPTION
AWS API Gateway sends `null` for `multiValueQueryStringParameters` when no multi-value query params are present. This matches `@types/aws-lambda`'s `APIGatewayProxyEvent` and fixes the type error when passing that type directly to the handler returned by `AwsLambdaReceiver`.

Fixes #2939

### Summary

`AwsEventV1.multiValueQueryStringParameters` was typed as non-nullable (`Record<string, string[] | undefined>`), but AWS actually sends `null` for this field when there are no multi-value query string parameters. This caused a type incompatibility when passing an `APIGatewayProxyEvent` (from `@types/aws-lambda`) directly to the handler returned by `AwsLambdaReceiver.start()` or `toHandler()`, requiring an unnecessary `as AwsEventV1` cast.

This PR changes the type to `AwsEventMultiValueStringParameters | null` to match reality and the official AWS types. A tsd type test is also added to prevent regression.

### Requirements
- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt js/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
