### PR TITLE
docs: fix non-existent import in v4 migration guide and undefined variables in JA OAuth snippets

### DIFF
--- a/docs/english/migration/migration-v4.md
+++ b/docs/english/migration/migration-v4.md
@@ -85,7 +85,7 @@ import { SocketModeFunctions } from '@slack/bolt';
 SocketModeFunctions.defaultProcessEventErrorHandler
 
 // now:
-import { defaultProcessEventHandler } from '@slack/bolt';
+import { defaultProcessEventErrorHandler } from '@slack/bolt';
 ```
 
 ## 🏭 Built-in middleware changes {#built-in-middleware-changes}

--- a/docs/japanese/concepts/authenticating-oauth.md
+++ b/docs/japanese/concepts/authenticating-oauth.md
@@ -154,11 +154,11 @@ const app = new App({
       // 実際のデータベースから削除するために、ここのコードを変更
       if (installQuery.isEnterpriseInstall && installQuery.enterpriseId !== undefined) {
         // OrG 全体へのインストール情報の削除
-        return await myDB.delete(installQuery.enterpriseId);
+        return await database.delete(installQuery.enterpriseId);
       }
       if (installQuery.teamId !== undefined) {
         // 単独のワークスペースへのインストール情報の削除
-        return await myDB.delete(installQuery.teamId);
+        return await database.delete(installQuery.teamId);
       }
       throw new Error('Failed to delete installation');
     },
@@ -215,7 +215,7 @@ const app = new App({
           // URL の state パラメーターとして使用するランダムな文字列を生成
           const randomState = randomStringGenerator();
           // その値をキャッシュ、データベースに保存
-          await myDB.set(randomState, installUrlOptions);
+          await database.set(randomState, installUrlOptions);
           // データベースに保存されたものを利用可能な値として返却
           return randomState;
         },
@@ -224,7 +224,7 @@ const app = new App({
         // `installUrlOptions` オブジェクトを応答
         verifyStateParam: async (date, state) => {
           // state をキーに、データベースから保存された installOptions を取得
-          const installUrlOptions = await myDB.get(randomState);
+          const installUrlOptions = await database.get(state);
           return installUrlOptions;
         }
       },


### PR DESCRIPTION
Two commits:

1. **`docs/english/migration/migration-v4.md`** — the "after" snippet imports `defaultProcessEventHandler`, which `@slack/bolt` does not export; the named export (`src/index.ts`) is `defaultProcessEventErrorHandler`, as the surrounding prose and the "before" snippet already say. The import as written fails to compile.
2. **`docs/japanese/concepts/authenticating-oauth.md`** — the snippets call `myDB.delete/set/get`, but the store these snippets declare and use everywhere else is `database` (matching the English guide), so the code throws `ReferenceError` if run; additionally `verifyStateParam` read `randomState`, which is scoped to the sibling `generateStateParam` callback — the correct key is its own `state` parameter (the English counterpart uses `database.get(state)`).

**Verification:** `npm test` passes locally on Node 22 (build + biome check over `docs src test examples` + tsd + mocha: **477 passing**; macOS arm64).

Prepared with AI assistance (Claude); the export was grep-verified against `src/index.ts` and the variable scoping checked against the English guide.