### PR TITLE
Clarify HTTP event delivery setup

### DIFF
--- a/.changeset/http-event-delivery-docs.md
+++ b/.changeset/http-event-delivery-docs.md
@@ -1,0 +1,5 @@
+---
+"@slack/bolt": patch
+---
+
+Clarify HTTP event delivery setup in the Bolt documentation.

--- a/docs/english/getting-started.md
+++ b/docs/english/getting-started.md
@@ -11,6 +11,8 @@ When complete, you'll have a local environment configured with a customized [app
 
 In search of the complete guide to building an app from scratch? Check out the [building an app](/tools/bolt-js/creating-an-app) guide.
 
+If your app will receive events over HTTP instead of Socket Mode, start with the [HTTP setup section](/tools/bolt-js/creating-an-app#preparing-receive-events) in that guide.
+
 :::
 
 #### Prerequisites


### PR DESCRIPTION
The Quickstart now links directly to the HTTP event delivery setup section in the full Bolt for JavaScript guide.

This makes the HTTP path easier to find for developers who are not using Socket Mode.

Checks:
- `npm run build`
- `npm run lint`
- `npm run test:types`
- Focused conversation-context unit test
- `git diff --check`

The full unit suite passed 476 tests but had one unrelated timeout in the conversation-store test.

Closes #2083
