### PR TITLE
docs: clarify optional input blocks

### DIFF
--- a/.changeset/optional-input-block-docs.md
+++ b/.changeset/optional-input-block-docs.md
@@ -1,0 +1,5 @@
+---
+"@slack/bolt": patch
+---
+
+Clarify how to make input blocks optional in the Bolt documentation.

--- a/docs/english/concepts/creating-modals.md
+++ b/docs/english/concepts/creating-modals.md
@@ -74,7 +74,7 @@ app.command('/ticket', async ({ ack, body, client, logger }) => {
 
 ### Making input blocks optional
 
-Set `optional: true` on the enclosing `input` block when users should be able to submit the view without providing a value. This setting applies to the element inside the block, including select menus such as `multi_external_select`; the element itself does not need an `optional` field.
+Set `optional: true` on the enclosing `input` block when users should be able to submit the view without providing a value. This setting applies to elements inside the block, including select menus such as `multi_external_select`; the element itself does not need an `optional` field.
 
 ```javascript
 {

--- a/docs/english/concepts/creating-modals.md
+++ b/docs/english/concepts/creating-modals.md
@@ -71,3 +71,22 @@ app.command('/ticket', async ({ ack, body, client, logger }) => {
   }
 });
 ```
+
+### Making input blocks optional
+
+Set `optional: true` on the enclosing `input` block when users should be able to submit the view without providing a value. This setting applies to the element inside the block, including select menus such as `multi_external_select`; the element itself does not need an `optional` field.
+
+```javascript
+{
+  type: 'input',
+  optional: true,
+  label: {
+    type: 'plain_text',
+    text: 'Choose projects'
+  },
+  element: {
+    type: 'multi_external_select',
+    action_id: 'projects'
+  }
+}
+```


### PR DESCRIPTION
### Summary

Fixes #2044 by documenting that `optional: true` belongs on the enclosing `input` block and applies to its child element, including `multi_external_select`.

### Requirements <!-- Place an `x` in each `[ ]` -->

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-js/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).

### Checks

- `npm run build`
- `npm run lint`
- `npm run test:types`
- `git diff --check`
- The full test suite reached 476 passing tests and one unrelated timeout in `conversationContext`; the isolated test passed on rerun.
