### PR TITLE
fix(socket-mode): await client disconnect on shutdown

### DIFF
--- a/.changeset/await-socket-mode-shutdown.md
+++ b/.changeset/await-socket-mode-shutdown.md
@@ -1,0 +1,5 @@
+---
+'@slack/bolt': patch
+---
+
+Await Socket Mode client shutdown before resolving `SocketModeReceiver.stop()`.

--- a/src/receivers/SocketModeReceiver.ts
+++ b/src/receivers/SocketModeReceiver.ts
@@ -260,20 +260,13 @@ export default class SocketModeReceiver implements Receiver {
     return this.client.start();
   }
 
-  public stop(): Promise<void> {
+  public async stop(): Promise<void> {
     if (this.httpServer !== undefined) {
       // This HTTP server is only for the OAuth flow support
       this.httpServer.close((error) => {
         if (error) this.logger.error(`Failed to shutdown the HTTP server for OAuth flow: ${error}`);
       });
     }
-    return new Promise((resolve, reject) => {
-      try {
-        this.client.disconnect();
-        resolve();
-      } catch (error) {
-        reject(error);
-      }
-    });
+    await this.client.disconnect();
   }
 }

--- a/test/unit/receivers/SocketModeReceiver.spec.ts
+++ b/test/unit/receivers/SocketModeReceiver.spec.ts
@@ -649,5 +649,32 @@ describe('SocketModeReceiver', () => {
       await receiver.stop();
       assert(clientStub.disconnect.called);
     });
+
+    it('should wait for SocketModeClient to disconnect', async () => {
+      const clientStub = sinon.createStubInstance(SocketModeClient);
+      let resolveDisconnect = () => {
+        throw new Error('SocketModeClient.disconnect() was not invoked');
+      };
+      clientStub.disconnect.callsFake(
+        () =>
+          new Promise<void>((resolve) => {
+            resolveDisconnect = resolve;
+          }),
+      );
+      const SocketModeReceiver = await importSocketModeReceiver(overrides);
+      const receiver = new SocketModeReceiver({ appToken: 'my-secret', logger: noopLogger });
+      receiver.client = clientStub as unknown as SocketModeClient;
+
+      let stopped = false;
+      const stopPromise = receiver.stop().then(() => {
+        stopped = true;
+      });
+      await Promise.resolve();
+
+      assert.isFalse(stopped);
+      resolveDisconnect();
+      await stopPromise;
+      assert.isTrue(stopped);
+    });
   });
 });


### PR DESCRIPTION
## Problem
`SocketModeReceiver.stop()` calls `SocketModeClient.disconnect()` but resolves immediately instead of awaiting it. Applications can therefore log that shutdown completed while the Socket Mode WebSocket close handshake is still in progress.

## Solution
Await the Socket Mode client's disconnect promise before resolving `SocketModeReceiver.stop()`. This makes `await app.stop()` reflect the actual receiver lifecycle and adds a regression test for the pending disconnect case.

## Validation
- `npx @biomejs/biome check src/receivers/SocketModeReceiver.ts test/unit/receivers/SocketModeReceiver.spec.ts`
- Full build currently blocked by existing strict TypeScript errors in `src/Assistant.ts` and `src/helpers.ts` on the cloned `main` branch.
- Focused Mocha execution is blocked by the existing rewiremock bootstrap error on Node 24.