### PR TITLE
fix: source events' userId from the authorizations array in buildSource

### DIFF
--- a/.changeset/fix-build-source-user-authorizations.md
+++ b/.changeset/fix-build-source-user-authorizations.md
@@ -1,0 +1,5 @@
+---
+"@slack/bolt": patch
+---
+
+Fix `context.userId` being `undefined` for events whose payload does not carry a user field directly, by sourcing the user ID from the request's `authorizations` array in `buildSource`, matching how `teamId` and `enterpriseId` are already resolved.

--- a/src/App.ts
+++ b/src/App.ts
@@ -1547,7 +1547,21 @@ function buildSource<IsEnterpriseInstall extends boolean>(
   const userId: string | undefined = (() => {
     if (type === IncomingEventType.Event) {
       // NOTE: no type system backed exhaustiveness check within this incoming event type
-      const { event } = body as SlackEventMiddlewareArgs['body'];
+      const bodyAsEvent = body as SlackEventMiddlewareArgs['body'];
+      // The authorizations array names the installing user this event was
+      // delivered for. Event payload fields like `event.user` reference the
+      // user that *triggered* the event, who may never have installed the
+      // app (e.g. the invitee in `member_joined_channel`), which sends
+      // `authorize`/`fetchInstallation` looking up the wrong installation.
+      // Mirrors the teamId/enterpriseId extraction above. See #2271.
+      if (
+        Array.isArray(bodyAsEvent.authorizations) &&
+        bodyAsEvent.authorizations[0] !== undefined &&
+        bodyAsEvent.authorizations[0].user_id !== null
+      ) {
+        return bodyAsEvent.authorizations[0].user_id;
+      }
+      const { event } = bodyAsEvent;
       if ('user' in event) {
         if (typeof event.user === 'string') {
           return event.user;

--- a/test/unit/App/build-source.spec.ts
+++ b/test/unit/App/build-source.spec.ts
@@ -1,0 +1,95 @@
+import assert from 'node:assert';
+import sinon, { type SinonSpy } from 'sinon';
+import type App from '../../../src/App';
+import {
+  createDummyAppMentionEventMiddlewareArgs,
+  createFakeLogger,
+  FakeReceiver,
+  importApp,
+  mergeOverrides,
+  noopMiddleware,
+  type Override,
+  withConversationContext,
+  withMemoryStore,
+  withNoopAppMetadata,
+  withNoopWebClient,
+} from '../helpers';
+
+function buildOverrides(secondOverrides: Override[]): Override {
+  return mergeOverrides(
+    withNoopAppMetadata(),
+    withNoopWebClient(),
+    ...secondOverrides,
+    withMemoryStore(sinon.fake()),
+    withConversationContext(sinon.fake.returns(noopMiddleware)),
+  );
+}
+
+describe('App authorize source (buildSource)', () => {
+  let fakeReceiver: FakeReceiver;
+  let fakeHandler: SinonSpy;
+  let fakeAck: SinonSpy;
+  let fakeAuthorize: SinonSpy;
+  let MockApp: Awaited<ReturnType<typeof importApp>>;
+  let app: App;
+
+  beforeEach(async () => {
+    fakeReceiver = new FakeReceiver();
+    fakeHandler = sinon.fake();
+    fakeAck = sinon.fake();
+    fakeAuthorize = sinon.fake.resolves({ botToken: '', botId: '' });
+    MockApp = importApp(buildOverrides([]));
+    app = new MockApp({
+      logger: createFakeLogger(),
+      receiver: fakeReceiver,
+      authorize: fakeAuthorize,
+    });
+  });
+
+  it('should prefer the authorizations array user over the event user for events', async () => {
+    // The event `user` is whoever triggered the event (e.g. the invitee in
+    // `member_joined_channel`) and may never have installed the app; the
+    // authorizations array names the installing user the event was
+    // delivered for. authorize/fetchInstallation must be keyed on the
+    // latter. See #2271.
+    app.event('app_mention', fakeHandler);
+    await fakeReceiver.sendEvent({
+      ...createDummyAppMentionEventMiddlewareArgs(undefined, {
+        authorizations: [
+          {
+            enterprise_id: null,
+            team_id: 'T1234',
+            user_id: 'U-installer',
+            is_bot: false,
+            is_enterprise_install: false,
+          },
+        ],
+      }),
+      ack: fakeAck,
+    });
+    sinon.assert.calledOnce(fakeAuthorize);
+    const source = fakeAuthorize.getCall(0).args[0];
+    assert.strictEqual(source.userId, 'U-installer');
+  });
+
+  it('should fall back to the event user when no authorizations array is present', async () => {
+    app.event('app_mention', fakeHandler);
+    const args = createDummyAppMentionEventMiddlewareArgs({
+      event: {
+        type: 'app_mention',
+        text: 'hi',
+        user: 'U-event-user',
+        channel: 'C1234',
+        ts: '1234.56',
+        event_ts: '1234.56',
+      },
+    });
+    await fakeReceiver.sendEvent({
+      ...args,
+      ack: fakeAck,
+    });
+    sinon.assert.calledOnce(fakeAuthorize);
+    const source = fakeAuthorize.getCall(0).args[0];
+    assert.strictEqual(source.userId, 'U-event-user');
+  });
+});


### PR DESCRIPTION
### Summary

Fixes #2271 — the bug @filmaj confirmed there: for event payloads, `buildSource` extracts `userId` from event fields (`event.user`, `channel.creator`, `subteam.created_by`). Those name whoever **triggered** the event — e.g. the invitee in `member_joined_channel` — who may never have installed the app. `authorize()` / `fetchInstallation()` then look up an installation keyed on the wrong user, which breaks apps with multiple user-token installations per team: the installation store cannot know which installation the event was actually delivered for.

The envelope's `authorizations` array names the installing user the event was delivered for, and `buildSource` **already prefers it for `teamId` and `enterpriseId`** (the asymmetry called out in the issue) — `userId` was the odd one out. This PR applies the same pattern: prefer `authorizations[0].user_id`, falling back to the existing event-field extraction when the array is absent (URL-verification and other non-enveloped shapes are unaffected).

Behavior notes:
- Single-workspace/bot-token apps are unaffected in practice: for them `authorizations[0].user_id` is the installing user, which is what a single-install `authorize` keys on (team/enterprise), and the built-in authorize ignores `userId` entirely.
- The fallback preserves today's behavior byte-for-byte when `authorizations` is missing.

Tests: new `test/unit/App/build-source.spec.ts` covers both paths — authorizations present (installer id wins over `event.user`) and absent (`event.user` fallback unchanged). Full run: 479 passing; `npm run build`, `npm run lint` (biome), and `npm run test:types` (tsd) all clean.

### Requirements <!-- Place an `x` in each `[ ]` -->

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-js/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
