### PR TITLE
docs: convert remaining code examples from CommonJS to ESM

### DIFF
--- a/docs/english/concepts/authenticating-oauth.md
+++ b/docs/english/concepts/authenticating-oauth.md
@@ -44,8 +44,8 @@ Here we've provided a default implementation of the `installationStore` with
 developing and testing your app:
 
 ```javascript
-const { App } = require("@slack/bolt");
-const { FileInstallationStore } = require("@slack/oauth");
+import { App } from "@slack/bolt";
+import { FileInstallationStore } from "@slack/oauth";
 const app = new App({
   signingSecret: process.env.SLACK_SIGNING_SECRET,
   clientId: process.env.SLACK_CLIENT_ID,

--- a/docs/english/concepts/custom-routes.md
+++ b/docs/english/concepts/custom-routes.md
@@ -9,7 +9,7 @@ Since `v3.13.0`, the default built-in receivers (`HTTPReceiver` and `SocketModeR
 To determine what port the custom HTTP route will be available on locally, you can specify an `installerOptions.port` property in the `App` constructor. Otherwise, it will default to port `3000`.
 
 ```javascript
-const { App } = require('@slack/bolt');
+import { App } from '@slack/bolt';
 
 // Initialize Bolt app, using the default HTTPReceiver
 const app = new App({
@@ -50,7 +50,7 @@ Adding custom HTTP routes is quite straightforward when using Bolt’s built-in 
 
 
 ```javascript
-const { App, ExpressReceiver } = require('@slack/bolt');
+import { App, ExpressReceiver } from '@slack/bolt';
 
 // Create a Bolt Receiver
 const receiver = new ExpressReceiver({ signingSecret: process.env.SLACK_SIGNING_SECRET });

--- a/docs/english/concepts/deferring-initialization.md
+++ b/docs/english/concepts/deferring-initialization.md
@@ -11,7 +11,7 @@ If you call `start()` before `init()`, Bolt will raise an exception.
 ## Example
 
 ```javascript
-const { App } = require('@slack/bolt');
+import { App } from '@slack/bolt';
 
 // deferInitialization is one of the options you can set in the constructor
 const app = new App({

--- a/docs/english/concepts/error-handling.md
+++ b/docs/english/concepts/error-handling.md
@@ -67,7 +67,7 @@ Starting with version 3.8.0, when passing `extendedErrorHandler: true` to the co
 It is recommended to check whether a property exists on the `context` or `body` objects before accessing its value, as the data available in the `body` object differs from event to event, and because errors can happen at any point in a request's lifecycle (i.e. before a certain property of `context` has been set).
 
 ```javascript
-const { App } = require('@slack/bolt');
+import { App } from '@slack/bolt';
 
 const app = new App({
   signingSecret: process.env.SLACK_SIGNING_SECRET,

--- a/docs/english/concepts/logging.md
+++ b/docs/english/concepts/logging.md
@@ -4,7 +4,7 @@ By default, Bolt for JavaScript will log information from your app to the consol
 
 ```javascript
 // Import LogLevel from the package
-const { App, LogLevel } = require('@slack/bolt');
+import { App, LogLevel } from '@slack/bolt';
 
 // Log level is one of the options you can set in the constructor
 const app = new App({
@@ -60,8 +60,8 @@ If you want to send logs to somewhere besides the console or want more control o
 A very simple custom logger might ignore the name and level, and write all messages to a file.
 
 ```javascript
-const { App } = require('@slack/bolt');
-const { createWriteStream } = require('fs');
+import { App } from '@slack/bolt';
+import { createWriteStream } from 'fs';
 const logWritable = createWriteStream('/var/my_log_file'); // Not shown: close this stream
 
 const app = new App({

--- a/docs/english/concepts/message-listening.md
+++ b/docs/english/concepts/message-listening.md
@@ -38,7 +38,7 @@ You can filter on subtypes of events by using the built-in `subtype()` middlewar
 
 ```javascript
 // Import subtype from the package
-const { App, subtype } = require('@slack/bolt');
+import { App, subtype } from '@slack/bolt';
 
 // Matches all message changes from users
 app.message(subtype('message_changed'), ({ event, logger }) => {

--- a/docs/english/concepts/receiver.md
+++ b/docs/english/concepts/receiver.md
@@ -30,7 +30,7 @@ Use the `customPropertiesExtractor` option to extract custom properties from inc
 This is particularly useful for extracting HTTP headers that you want to propagate to other services, for example, if you need to propagate a header for distributed tracing.
 
 ```javascript
-const { App, HTTPReceiver } = require('@slack/bolt');
+import { App, HTTPReceiver } from '@slack/bolt';
 
 const app = new App({
   token: process.env.SLACK_BOT_TOKEN,

--- a/docs/english/concepts/socket-mode.md
+++ b/docs/english/concepts/socket-mode.md
@@ -5,7 +5,7 @@
 To use the `SocketModeReceiver`, just pass in `socketMode:true` and `appToken:YOUR_APP_TOKEN` when initializing `App`. You can get your App Level Token in your app configuration under the **Basic Information** section.
 
 ```javascript
-const { App } = require('@slack/bolt');
+import { App } from '@slack/bolt';
 
 const app = new App({
   token: process.env.BOT_TOKEN,
@@ -24,7 +24,7 @@ const app = new App({
 You can define a custom `SocketModeReceiver` by importing it from `@slack/bolt`.
 
 ```javascript
-const { App, SocketModeReceiver } = require('@slack/bolt');
+import { App, SocketModeReceiver } from '@slack/bolt';
 
 const socketModeReceiver = new SocketModeReceiver({
   appToken: process.env.APP_TOKEN,

--- a/docs/english/concepts/token-rotation.md
+++ b/docs/english/concepts/token-rotation.md
@@ -11,7 +11,7 @@ Bolt for JavaScript will rotate tokens automatically in response to incoming eve
 To rotate tokens on a separate schedule, consider implementing the `InstallProvider` from the [`@slack/oauth`](/tools/node-slack-sdk/oauth) package for use of the provided `authorize` method:
 
 ```js
-const { InstallProvider } = require("@slack/oauth");
+import { InstallProvider } from "@slack/oauth";
 
 const installer = new InstallProvider({
   clientId: process.env.SLACK_CLIENT_ID,

--- a/docs/english/deployments/aws-lambda.md
+++ b/docs/english/deployments/aws-lambda.md
@@ -118,7 +118,7 @@ Next, we'll customize your Bolt app's [`receiver`](/tools/bolt-js/concepts/recei
 Update the [source code that imports your modules](https://github.com/slack-samples/bolt-js-getting-started-app/blob/4c29a21438b40f0cbca71ece0d39b356dfcf88d5/app.js#L1) in `app.js` to require Bolt's AwsLambdaReceiver:
 
 ```javascript
-const { App, AwsLambdaReceiver } = require('@slack/bolt');
+import { App, AwsLambdaReceiver } from '@slack/bolt';
 ```
 
 :::warning
@@ -155,7 +155,7 @@ Finally, at the bottom of your app, update the [source code that starts the HTTP
 
 ```javascript
 // Handle the Lambda function event
-module.exports.handler = async (event, context, callback) => {
+export const handler = async (event, context, callback) => {
     const handler = await awsLambdaReceiver.start();
     return handler(event, context, callback);
 }

--- a/docs/english/tutorials/code-assistant.md
+++ b/docs/english/tutorials/code-assistant.md
@@ -168,9 +168,9 @@ HUGGINGFACE_API_KEY=hf_exampletoken
 Delete the template contents in the `app.js` file and replace it with this:
 
 ````js title="app.js"
-const { App, LogLevel, Assistant } = require("@slack/bolt");
-const { config } = require("dotenv");
-const { InferenceClient } = require("@huggingface/inference");
+import { App, LogLevel, Assistant } from "@slack/bolt";
+import { config } from "dotenv";
+import { InferenceClient } from "@huggingface/inference";
 
 config();
 

--- a/docs/japanese/concepts/authenticating-oauth.md
+++ b/docs/japanese/concepts/authenticating-oauth.md
@@ -12,8 +12,8 @@ OAuth を有効にするために、以下を提供する必要があります�
 開発・テストの際に利用することを想定して `installationStore` オプションのデフォルト実装である `FileInstallationStore` を提供しています。
 
 ```javascript
-const { App } = require('@slack/bolt');
-const { FileInstallationStore } = require('@slack/oauth');
+import { App } from '@slack/bolt';
+import { FileInstallationStore } from '@slack/oauth';
 const app = new App({
   signingSecret: process.env.SLACK_SIGNING_SECRET,
   clientId: process.env.SLACK_CLIENT_ID,

--- a/docs/japanese/concepts/custom-routes.md
+++ b/docs/japanese/concepts/custom-routes.md
@@ -9,7 +9,7 @@
 カスタムの HTTP ルートがローカル環境でどのポートからアクセスできるかを指定するために `App` コンストラクターに `installerOptions.port` というプロパティを渡すことができます。指定しない場合は、デフォルトの `3000` ポートとなります。
 
 ```javascript
-const { App } = require('@slack/bolt');
+import { App } from '@slack/bolt';
 
 // デフォルトの HTTPReceiver を使って Bolt アプリを初期化します
 const app = new App({
@@ -49,7 +49,7 @@ const app = new App({
 Bolt の組み込みの `ExpressReceiver` を使っているなら、カスタムの HTTP ルートを追加するのはとても簡単です。`v2.1.0` から `ExpressReceiver` には `router` というプロパティが追加されています。これは、さらにルートを追加できるように `App` 内部で保持している Express の [Router](http://expressjs.com/en/4x/api.html#router) を public にしたものです。
 
 ```javascript
-const { App, ExpressReceiver } = require('@slack/bolt');
+import { App, ExpressReceiver } from '@slack/bolt';
 
 // Bolt の Receiver を明に生成
 const receiver = new ExpressReceiver({ signingSecret: process.env.SLACK_SIGNING_SECRET });

--- a/docs/japanese/concepts/deferring-initialization.md
+++ b/docs/japanese/concepts/deferring-initialization.md
@@ -5,7 +5,7 @@ Bolt は `deferInitialization` というオプションを使うことで、ア�
 _注意: `init()` メソッドを呼び出す前に `start()` メソッドを呼び出した場合、 Bolt は例外を発生させます。_
 
 ```javascript
-const { App } = require('@slack/bolt');
+import { App } from '@slack/bolt';
 
 // deferInitialization はコンストラクターで指定できるオプション
 const app = new App({

--- a/docs/japanese/concepts/error-handling.md
+++ b/docs/japanese/concepts/error-handling.md
@@ -60,7 +60,7 @@ app.error(async (error) => {
 
 
 ```javascript
-const { App } = require('@slack/bolt');
+import { App } from '@slack/bolt';
 
 const app = new App({
   signingSecret: process.env.SLACK_SIGNING_SECRET,

--- a/docs/japanese/concepts/logging.md
+++ b/docs/japanese/concepts/logging.md
@@ -4,7 +4,7 @@ Bolt はデフォルトの設定では、標準出力のコンソールにログ
 
 ```javascript
 // パッケージから LogLevel をインポート
-const { App, LogLevel } = require('@slack/bolt');
+import { App, LogLevel } from '@slack/bolt';
 
 // オプションとして、コンストラクタで Log level を設定可能
 const app = new App({
@@ -31,8 +31,8 @@ const app = new App({
 非常に単純なカスタム logger では、名前やレベルが無視され、すべてのメッセージがファイルに書き込まれることがあります。
 
 ```javascript
-const { App } = require('@slack/bolt');
-const { createWriteStream } = require('fs');
+import { App } from '@slack/bolt';
+import { createWriteStream } from 'fs';
 const logWritable = createWriteStream('/var/my_log_file');
 
 const app = new App({

--- a/docs/japanese/concepts/message-listening.md
+++ b/docs/japanese/concepts/message-listening.md
@@ -38,7 +38,7 @@ app.message(/^(hi|hello|hey).*/, async ({ context, say }) => {
 
 ```javascript
 // パッケージから subtype をインポート
-const { App, subtype } = require('@slack/bolt');
+import { App, subtype } from '@slack/bolt';
 
 // user からのメッセージの編集と一致
 app.message(subtype('message_changed'), ({ event, logger }) => {

--- a/docs/japanese/concepts/socket-mode.md
+++ b/docs/japanese/concepts/socket-mode.md
@@ -5,7 +5,7 @@
 `SocketModeReceiver` を使う方法は `App` インスタンスの初期化時にコンストラクターに `socketMode: true` と `appToken: YOUR_APP_TOKEN` を渡すだけです。App Level Token は、アプリ管理画面の **Basic Information** セクションから取得できます。
 
 ```javascript
-const { App } = require('@slack/bolt');
+import { App } from '@slack/bolt';
 
 const app = new App({
   token: process.env.BOT_TOKEN,
@@ -24,7 +24,7 @@ const app = new App({
 以下のように `@slack/bolt` から `SocketModeReceiver` を import して、カスタムされたインスタンスとして定義することができます。
 
 ```javascript
-const { App, SocketModeReceiver } = require('@slack/bolt');
+import { App, SocketModeReceiver } from '@slack/bolt';
 
 const socketModeReceiver = new SocketModeReceiver({
   appToken: process.env.APP_TOKEN,

--- a/docs/japanese/deployments/aws-lambda.md
+++ b/docs/japanese/deployments/aws-lambda.md
@@ -122,7 +122,7 @@ const app = new App({
 `app.js` のソースコードの中で[モジュールのインポートを行う部分](https://github.com/slackapi/bolt-js-getting-started-app/blob/main/app.js#L1)を編集し、Bolt の `AwsLambdaReceiver` モジュールを require します。
 
 ```javascript
-const { App, AwsLambdaReceiver } = require('@slack/bolt');
+import { App, AwsLambdaReceiver } from '@slack/bolt';
 ```
 
 :::tip 
@@ -158,7 +158,7 @@ const app = new App({
 
 ```javascript
 // Lambda 関数のイベントを処理します
-module.exports.handler = async (event, context, callback) => {
+export const handler = async (event, context, callback) => {
   const handler = await awsLambdaReceiver.start();
   return handler(event, context, callback);
 }


### PR DESCRIPTION
### Summary

Fixes #2923. Converts the remaining CommonJS code examples to ESM, covering exactly the in-scope checklist from that issue — 11 English pages (concepts: authenticating-oauth, custom-routes, deferring-initialization, error-handling, logging, message-listening, receiver, socket-mode, token-rotation; deployments: aws-lambda; tutorials: code-assistant) and 8 Japanese counterparts.

Conversions applied:

- `const { X } = require('pkg')` → `import { X } from 'pkg'`
- `const X = require('pkg')` → `import X from 'pkg'`
- `module.exports.handler = async (…)` → `export const handler = async (…)` (AWS Lambda deployment docs, both languages — the case specifically called out in the issue notes)

The deprecated `legacy/steps-from-apps.md` pages are untouched, per the issue's "Out of scope" section. No prose changes — code fences only.

Verified: zero `require(`/`module.exports` remaining across the in-scope files, and `npm run lint` (biome checks `docs/`) passes.

### Requirements <!-- Place an `x` in each `[ ]` -->

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/bolt-js/blob/main/.github/contributing.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
