### PR TITLE
ci: migrate changesets/action release workflow to v2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
     name: Changelog
     runs-on: ubuntu-latest
     outputs:
-      hasChangesets: ${{ steps.changesets.outputs.hasChangesets }}
+      hasChangesets: ${{ steps.changesets.outputs.has-changesets }}
       releaseExists: ${{ steps.published.outputs.exists }}
     permissions:
       contents: write
@@ -36,16 +36,15 @@ jobs:
         id: changesets
         uses: changesets/action@8488615a623b1b9c987934bb89eae8af6a946ac1 # v2.1.1
         with:
-          commit: "chore: release"
-          prDraft: create
-          title: "chore: release"
-          version: npm run version
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "chore: release"
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          pr-draft: create
+          pr-title: "chore: release"
+          version-script: npm run version
 
       - name: Check if publish is needed
         id: published
-        if: steps.changesets.outputs.hasChangesets == 'false'
+        if: steps.changesets.outputs.has-changesets == 'false'
         run: |
           VERSION=$(node -p "require('./package.json').version")
           if gh release view "v${VERSION}" &>/dev/null; then
@@ -95,10 +94,9 @@ jobs:
         id: changesets
         uses: changesets/action@8488615a623b1b9c987934bb89eae8af6a946ac1 # v2.1.1
         with:
-          createGithubReleases: true
-          publish: npm run changeset -- publish
-        env:
-          GITHUB_TOKEN: ${{ steps.credentials.outputs.token }}
+          create-github-releases: true
+          github-token: ${{ steps.credentials.outputs.token }}
+          publish-script: npm run changeset -- publish
 
       - name: Get publication details
         if: steps.changesets.outputs.published == 'true'
@@ -108,7 +106,7 @@ jobs:
           echo "message=$(echo "$PUBLISHED_PACKAGES" | jq -r '.[] | "\(.name)@\(.version)"' | paste -sd ', ' -)" >> "$GITHUB_OUTPUT"
         env:
           GH_TOKEN: ${{ steps.credentials.outputs.token }}
-          PUBLISHED_PACKAGES: ${{ steps.changesets.outputs.publishedPackages }}
+          PUBLISHED_PACKAGES: ${{ steps.changesets.outputs.published-packages }}
 
       - name: Notify Slack
         if: steps.changesets.outputs.published == 'true'


### PR DESCRIPTION
### Summary

`changesets/action` v2 introduced three breaking changes to the release workflow interface:

1. [Renamed the root action inputs](https://github.com/changesets/action/pull/681) to kebab-case (`version` → `version-script`, `commit` → `commit-message`, etc.).
2. [Renamed the outputs](https://github.com/changesets/action/pull/681) (`hasChangesets` → `has-changesets`, `publishedPackages` → `published-packages`).
3. [Now pushes release commits/tags via the GitHub API by default](https://github.com/changesets/action/pull/692), and the token **must** be passed through the `github-token` **input** — the `GITHUB_TOKEN` env var / `actions/checkout` credentials are no longer a substitute.

The action bump only updated the pinned SHA, leaving the workflow on the v1 interface: v2 would silently ignore the inputs (falling back to defaults), resolve the renamed outputs to empty, and lose the token for the API push.

This migrates the workflow to the v2 interface — renamed inputs (alphabetized) + outputs, and the token moved into the `github-token` input. Values unchanged; verified against [`action.yml` at the pinned v2.1.1 SHA](https://github.com/changesets/action/blob/8488615a623b1b9c987934bb89eae8af6a946ac1/action.yml), matching the already-migrated node-slack-sdk release workflow.