### PR TITLE
ci: allow Dependabot to update the changesets toolchain

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,8 @@ updates:
       - dependency-name: "@types/node"
       # allow updates for slack official libraries
       - dependency-name: "@slack/*"
+      # allow updates for the changesets release toolchain
+      - dependency-name: "@changesets/*"
     versioning-strategy: increase
     ignore:
       - dependency-name: "@types/node"


### PR DESCRIPTION
### Summary

The root npm Dependabot config (`.github/dependabot.yml`) uses an `allow` list scoped to three names:

```yaml
allow:
  - dependency-name: "typescript"
  - dependency-name: "@types/node"
  - dependency-name: "@slack/*"
```

Because npm updates are `allow`-gated, any npm package outside that list is never proposed for an update — including `@changesets/cli`, which lives in `devDependencies`. That package therefore pins silently and only advances when someone bumps it by hand.

This is easy to miss because the `changesets/action` **GitHub Action** *does* get Dependabot PRs — but those come through the separate `github-actions` ecosystem, which has no `allow` gate. The `@changesets/cli` **npm devDependency** falls under the gated npm ecosystem, so the two halves of the changesets toolchain are governed by different rules.

This PR adds `@changesets/*` to the npm `allow` list so the release toolchain stays current alongside the `@slack/*` packages.

### Change

```diff
       # allow updates for slack official libraries
       - dependency-name: "@slack/*"
+      # allow updates for the changesets release toolchain
+      - dependency-name: "@changesets/*"
```

### Notes

- Config-only change (`.github/dependabot.yml`); no source or published-package change, so no changeset is needed — consistent with recent `.github/**`-only commits.
- Scoped to the **root** npm block. The `examples/**` npm block does not use changesets and is intentionally left unchanged.